### PR TITLE
feat(podium): F0 migrations & scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,24 @@
+# Grays Internal portal — environment template (placeholders only, NO real secrets).
+# Copy to .env for local dev. Vercel holds the real values per-scope; set the
+# Podium/CRM vars in the PREVIEW scope only until they are ready for Production.
+
+# --- Database (Neon) ---
+# Local dev + migrations: point at the Neon DEV/PREVIEW branch, never production.
+DATABASE_URL=
+
+# --- Auth ---
+JWT_SECRET=
+
+# --- Feature flags (Podium→CRM Phase 1) ---
+FEATURE_MYOB=false          # quote/payment seam stubs stay off until the MYOB phase
+PODIUM_MOCK=true            # mock-first until live Podium credentials are wired
+
+# --- Podium API (execution-plan §5; leave blank until the app is approved) ---
+PODIUM_CLIENT_ID=
+PODIUM_CLIENT_SECRET=
+PODIUM_REDIRECT_URI=        # https://<portal>/api/podium/oauth/callback — must EXACTLY match the registered URI
+PODIUM_WEBHOOK_SECRET=      # HMAC-SHA256 key for webhook signature verification
+PODIUM_API_VERSION=         # PIN a dated version, e.g. 2021-04-01 (omitting = latest = breaking changes)
+PODIUM_LOCATION_UID=        # Grays location UID (webhook subscription + message send)
+PODIUM_ORG_UID=             # Grays organization UID (optional; org-level webhook)
+PODIUM_OAUTH_SCOPES=read_messages write_messages read_contacts write_contacts read_users read_reviews write_reviews read_locations read_organizations

--- a/db/README.md
+++ b/db/README.md
@@ -1,0 +1,38 @@
+# Database migrations
+
+Plain-SQL, forward + rollback migrations for the Grays Internal portal, run by a
+tiny Node runner (`db/migrate.js`, pg + ESM — same style as `lib/db.js`).
+
+## Layout
+
+```
+db/
+  migrate.js                    runner (up / status / down)
+  migrations/
+    0001_podium.sql             forward migration
+    0001_podium_down.sql        paired rollback
+```
+
+Each forward migration is **additive and idempotent** (`IF NOT EXISTS`, `DO`-guarded
+`CREATE TYPE`) and ships with a paired `_down.sql`. Applied versions are tracked in a
+`schema_migrations` table, so re-running is a safe no-op.
+
+## Running
+
+Set `DATABASE_URL` to the **Neon dev/preview branch** — never the production/default
+branch. The runner reads it from the environment (a local `.env` works via dotenv).
+
+```bash
+npm run migrate           # apply all pending migrations
+npm run migrate:status    # show applied vs pending
+npm run migrate:down 0001_podium   # roll back one migration
+```
+
+## Conventions
+
+- Number migrations `NNNN_<slug>.sql`; add a matching `NNNN_<slug>_down.sql`.
+- Additive only; never drop/alter existing columns destructively in a forward file.
+- New Podium API routes live under `api/podium/` (and `api/leads.js`), not the
+  `api/[...path].js` catch-all.
+- No chat message bodies are ever stored (P1): `integration_sync_log.payload` holds
+  envelope metadata only.

--- a/db/migrate.js
+++ b/db/migrate.js
@@ -1,0 +1,134 @@
+#!/usr/bin/env node
+/**
+ * Tiny forward/rollback SQL migration runner for the Grays Internal portal.
+ *
+ * Usage:
+ *   node db/migrate.js up            # apply all pending *.sql (excluding *_down.sql)
+ *   node db/migrate.js status        # list applied vs pending
+ *   node db/migrate.js down <ver>    # run <ver>_down.sql and un-record it (e.g. 0001_podium)
+ *
+ * Reads DATABASE_URL from the environment (dotenv-friendly via a local .env).
+ * IMPORTANT: point DATABASE_URL at the Neon dev/preview branch — NEVER the
+ * production/default branch. Each migration runs inside a transaction and its
+ * version is recorded in schema_migrations, so re-runs are safe no-ops.
+ *
+ * Matches the repo's pg + ESM style (see lib/db.js).
+ */
+import 'dotenv/config';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { Pool } from 'pg';
+
+const MIGRATIONS_DIR = join(dirname(fileURLToPath(import.meta.url)), 'migrations');
+
+const versionOf = (file) => file.replace(/\.sql$/, '');
+
+function migrationFiles() {
+  return readdirSync(MIGRATIONS_DIR)
+    .filter((f) => f.endsWith('.sql') && !f.endsWith('_down.sql'))
+    .sort();
+}
+
+async function ensureTable(client) {
+  await client.query(`
+    CREATE TABLE IF NOT EXISTS schema_migrations (
+      version    TEXT PRIMARY KEY,
+      applied_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )`);
+}
+
+async function appliedVersions(client) {
+  const { rows } = await client.query('SELECT version FROM schema_migrations');
+  return new Set(rows.map((r) => r.version));
+}
+
+async function runInTx(client, sql, after) {
+  await client.query('BEGIN');
+  try {
+    await client.query(sql);
+    if (after) await after();
+    await client.query('COMMIT');
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  }
+}
+
+async function up(pool) {
+  const client = await pool.connect();
+  try {
+    await ensureTable(client);
+    const done = await appliedVersions(client);
+    const pending = migrationFiles().filter((f) => !done.has(versionOf(f)));
+    if (pending.length === 0) {
+      console.log('Nothing to apply — schema up to date.');
+      return;
+    }
+    for (const file of pending) {
+      const version = versionOf(file);
+      const sql = readFileSync(join(MIGRATIONS_DIR, file), 'utf8');
+      console.log(`Applying ${file} ...`);
+      await runInTx(client, sql, () =>
+        client.query('INSERT INTO schema_migrations(version) VALUES ($1)', [version])
+      );
+      console.log(`  ✓ ${version}`);
+    }
+  } finally {
+    client.release();
+  }
+}
+
+async function down(pool, version) {
+  if (!version) throw new Error('Usage: node db/migrate.js down <version>   e.g. 0001_podium');
+  const sql = readFileSync(join(MIGRATIONS_DIR, `${version}_down.sql`), 'utf8');
+  const client = await pool.connect();
+  try {
+    await ensureTable(client);
+    console.log(`Rolling back ${version}_down.sql ...`);
+    await runInTx(client, sql, () =>
+      client.query('DELETE FROM schema_migrations WHERE version = $1', [version])
+    );
+    console.log(`  ✓ rolled back ${version}`);
+  } finally {
+    client.release();
+  }
+}
+
+async function status(pool) {
+  const client = await pool.connect();
+  try {
+    await ensureTable(client);
+    const done = await appliedVersions(client);
+    for (const file of migrationFiles()) {
+      const version = versionOf(file);
+      console.log(`${done.has(version) ? '[applied]' : '[pending]'} ${version}`);
+    }
+  } finally {
+    client.release();
+  }
+}
+
+async function main() {
+  if (!process.env.DATABASE_URL) {
+    console.error('DATABASE_URL is not set. Point it at the Neon dev/preview branch, never production.');
+    process.exit(1);
+  }
+  const pool = new Pool({
+    connectionString: process.env.DATABASE_URL,
+    ssl: { rejectUnauthorized: false },
+  });
+  const [cmd, arg] = process.argv.slice(2);
+  try {
+    if (cmd === 'down') await down(pool, arg);
+    else if (cmd === 'status') await status(pool);
+    else await up(pool); // default: `up`
+  } catch (err) {
+    console.error('Migration failed:', err.message);
+    process.exitCode = 1;
+  } finally {
+    await pool.end();
+  }
+}
+
+main();

--- a/db/migrations/0001_podium.sql
+++ b/db/migrations/0001_podium.sql
@@ -1,0 +1,132 @@
+-- 0001_podium.sql — Podium→CRM Phase 1 data model (execution-plan §4)
+--
+-- ADDITIVE + IDEMPOTENT ONLY. Safe to run more than once. No existing column is
+-- dropped or altered destructively. Paired rollback: 0001_podium_down.sql.
+-- Apply ONLY to the Neon dev/preview branch — never the production/default branch.
+--
+-- Constraints honoured:
+--   P1  no chat message bodies are ever stored (see integration_sync_log.payload note)
+--   P10 single-user-multi-role RBAC (user_roles) kept alongside legacy users.access
+--   P11 new roles: sales + logistics
+
+-- =====================================================================
+-- §4.0  Multi-role RBAC (P10/P11) — additive, backward-compatible
+-- users.access stays the PRIMARY role; user_roles holds the full set.
+-- =====================================================================
+CREATE TABLE IF NOT EXISTS user_roles (
+  user_id    VARCHAR(2) NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+  role       VARCHAR(20) NOT NULL,   -- superadmin | staff | technician | workshop | sales | logistics
+  granted_by VARCHAR(2) REFERENCES users(id),
+  granted_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (user_id, role)
+);
+CREATE INDEX IF NOT EXISTS idx_user_roles_role ON user_roles(role);
+
+-- Backfill: every current user's single access value becomes their first role.
+INSERT INTO user_roles (user_id, role)
+SELECT id, access FROM users
+WHERE access IS NOT NULL
+ON CONFLICT DO NOTHING;
+
+-- =====================================================================
+-- §4.1  Bridges & per-rep mapping
+-- =====================================================================
+ALTER TABLE customers ADD COLUMN IF NOT EXISTS podium_contact_id VARCHAR;
+ALTER TABLE customers ADD COLUMN IF NOT EXISTS myob_uid          VARCHAR;   -- reserved (future)
+ALTER TABLE customers ADD COLUMN IF NOT EXISTS woo_customer_id   INTEGER;   -- reserved (future)
+CREATE INDEX IF NOT EXISTS idx_customers_podium      ON customers(podium_contact_id);
+CREATE INDEX IF NOT EXISTS idx_customers_email_lower ON customers(LOWER(email));
+
+-- Map each portal salesperson to their Podium member/user (drives native assignment)
+ALTER TABLE users ADD COLUMN IF NOT EXISTS podium_user_id VARCHAR;          -- Podium member UID
+
+-- =====================================================================
+-- §4.2  Per-user OAuth token store
+-- NULL user_id row = the location/webhook registration (scope_level='location').
+-- =====================================================================
+CREATE TABLE IF NOT EXISTS podium_oauth (
+  id             SERIAL PRIMARY KEY,
+  user_id        VARCHAR(2) REFERENCES users(id),
+  scope_level    VARCHAR(12) NOT NULL DEFAULT 'user',  -- 'user' | 'location'
+  org_uid        VARCHAR,
+  location_uid   VARCHAR,
+  podium_user_id VARCHAR,
+  access_token   TEXT NOT NULL,
+  refresh_token  TEXT NOT NULL,
+  scopes         TEXT,
+  expires_at     TIMESTAMPTZ NOT NULL,
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_podium_oauth_user
+  ON podium_oauth(user_id) WHERE user_id IS NOT NULL;
+
+-- =====================================================================
+-- §4.3  Leads / opportunities (mirrors the canonical funnel, §1c)
+-- CREATE TYPE has no IF NOT EXISTS; guard each with a DO block so re-runs are no-ops.
+-- =====================================================================
+DO $$ BEGIN
+  CREATE TYPE lead_stage AS ENUM ('New','Contacted','Quoted','Payment Received','Won','Lost');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+DO $$ BEGIN
+  CREATE TYPE payment_type AS ENUM ('none','deposit_50','paid_full','exception');
+EXCEPTION WHEN duplicate_object THEN NULL; END $$;
+
+CREATE TABLE IF NOT EXISTS leads (
+  lead_id                SERIAL PRIMARY KEY,
+  source                 VARCHAR(20)  NOT NULL DEFAULT 'podium',
+  source_channel         VARCHAR(20),                  -- sms|email|facebook|google|instagram|webchat
+  customer_id            INTEGER REFERENCES customers(id),
+  podium_contact_id      VARCHAR,
+  podium_conversation_id VARCHAR,
+  stage                  lead_stage   NOT NULL DEFAULT 'New',
+  assigned_to            VARCHAR(2)   REFERENCES users(id),   -- == Podium assignee (synced)
+  value_est              NUMERIC(12,2),
+  product_interest       TEXT,
+  -- quote / payment (steps 3-4); auto-filled by MYOB later, manual for now
+  quote_invoice_id       VARCHAR,                      -- MYOB invoice number -> becomes workorder.invoice_id
+  order_total            NUMERIC(12,2),
+  payment                payment_type NOT NULL DEFAULT 'none',
+  payment_note           TEXT,                         -- reason when 'exception' (waived/partial deposit, etc.)
+  paid_at                TIMESTAMPTZ,
+  workorder_created_by   VARCHAR(2) REFERENCES users(id),  -- logistics person who created the workorder
+  paid_confirmed_by      VARCHAR(2) REFERENCES users(id),  -- logistics person who confirmed MYOB payment
+  lost_reason            TEXT,
+  last_contact_at        TIMESTAMPTZ,
+  next_followup_at       TIMESTAMPTZ,
+  converted_workorder_id INTEGER REFERENCES workorder(workorder_id),
+  notes                  TEXT,
+  created_at             TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  updated_at             TIMESTAMPTZ  NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_leads_stage    ON leads(stage);
+CREATE INDEX IF NOT EXISTS idx_leads_assigned ON leads(assigned_to);
+CREATE INDEX IF NOT EXISTS idx_leads_contact  ON leads(podium_contact_id);
+
+-- Append-only stage history (mirrors workorder_logs)
+CREATE TABLE IF NOT EXISTS lead_stage_log (
+  id         SERIAL PRIMARY KEY,
+  lead_id    INTEGER NOT NULL REFERENCES leads(lead_id) ON DELETE CASCADE,
+  from_stage lead_stage,
+  to_stage   lead_stage NOT NULL,
+  user_id    VARCHAR(2),
+  notes_log  TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- =====================================================================
+-- §4.4  Integration audit / idempotency (ENVELOPE ONLY — no chat bodies, P1)
+-- =====================================================================
+CREATE TABLE IF NOT EXISTS integration_sync_log (
+  id           SERIAL PRIMARY KEY,
+  source       VARCHAR(20) NOT NULL,            -- podium|myob|woocommerce
+  direction    VARCHAR(10) NOT NULL,            -- inbound|outbound
+  event_type   VARCHAR(60) NOT NULL,
+  reference_id VARCHAR,                          -- Podium event id (dedupe key)
+  status       VARCHAR(20) NOT NULL DEFAULT 'received',
+  payload      JSONB,                            -- MINIMAL envelope: ids, channel, assignee, ts. NEVER message text (P1).
+  error        TEXT,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE UNIQUE INDEX IF NOT EXISTS uq_sync_ref
+  ON integration_sync_log(source, reference_id) WHERE reference_id IS NOT NULL;

--- a/db/migrations/0001_podium_down.sql
+++ b/db/migrations/0001_podium_down.sql
@@ -1,0 +1,29 @@
+-- 0001_podium_down.sql — reverse of 0001_podium.sql
+--
+-- Drops ONLY the objects 0001_podium.sql created. Idempotent (IF EXISTS).
+-- Dependents are dropped before their dependencies. Dropping a table also drops
+-- its own indexes, so per-table indexes are not listed separately below.
+-- Run ONLY on the Neon dev/preview branch — never the production/default branch.
+
+-- §4.4  audit / idempotency
+DROP TABLE IF EXISTS integration_sync_log;   -- also drops uq_sync_ref
+
+-- §4.3  leads / opportunities (drop children -> parent -> types)
+DROP TABLE IF EXISTS lead_stage_log;
+DROP TABLE IF EXISTS leads;                   -- also drops idx_leads_*
+DROP TYPE  IF EXISTS payment_type;
+DROP TYPE  IF EXISTS lead_stage;
+
+-- §4.2  per-user OAuth token store
+DROP TABLE IF EXISTS podium_oauth;            -- also drops uq_podium_oauth_user
+
+-- §4.1  bridges & per-rep mapping (columns/indexes added to pre-existing tables)
+ALTER TABLE users     DROP COLUMN IF EXISTS podium_user_id;
+DROP INDEX IF EXISTS idx_customers_email_lower;
+DROP INDEX IF EXISTS idx_customers_podium;
+ALTER TABLE customers DROP COLUMN IF EXISTS woo_customer_id;
+ALTER TABLE customers DROP COLUMN IF EXISTS myob_uid;
+ALTER TABLE customers DROP COLUMN IF EXISTS podium_contact_id;
+
+-- §4.0  multi-role RBAC
+DROP TABLE IF EXISTS user_roles;              -- also drops idx_user_roles_role

--- a/package.json
+++ b/package.json
@@ -25,7 +25,10 @@
     "start": "react-scripts start",
     "build": "react-scripts build",
     "test": "react-scripts test",
-    "eject": "react-scripts eject"
+    "eject": "react-scripts eject",
+    "migrate": "node db/migrate.js up",
+    "migrate:status": "node db/migrate.js status",
+    "migrate:down": "node db/migrate.js down"
   },
   "eslintConfig": {
     "extends": [


### PR DESCRIPTION
## Summary
F0 — Migrations & scaffolding for the Podium→CRM Phase 1 (execution-plan.md §4). Adds the additive/idempotent data model plus a tiny SQL migration runner. **No app/runtime behaviour changes** — the CRA build is unaffected.

## Scope
- `db/migrations/0001_podium.sql` — forward migration: `user_roles` (P10/P11 multi-role RBAC + backfill from `users.access`), `customers`/`users` bridge columns + indexes, `podium_oauth` token store, `leads` + `lead_stage_log` (+ `lead_stage`/`payment_type` enums), `integration_sync_log` (envelope only — no chat bodies, P1)
- `db/migrations/0001_podium_down.sql` — paired rollback (drops only what 0001 created, dependents first)
- `db/migrate.js` — pg + ESM runner: `up` / `status` / `down <ver>`, transactional, tracked in `schema_migrations`
- `db/README.md`, `.env.example` (placeholders only), `migrate*` npm scripts

## Migration note
Applied to the Neon **dev** branch `dev` (`br-late-boat-aeutfn5t`, forked from the default `production` branch) and verified: 6 tables, 3 customer cols, 1 users col, 2 enums, 8 indexes; 18/18 users backfilled into `user_roles`. **No prod DB changes.** Down script authored; verify on a throwaway branch via `npm run migrate:down 0001_podium`.

## Test steps
1. `git checkout feat/podium-f0-migrations && npm ci && npm run build` → Compiled successfully
2. Point `DATABASE_URL` at the Neon **dev** branch → `npm run migrate:status` → `[applied] 0001_podium`
3. On a fresh dev branch: `npm run migrate` twice → second run prints "Nothing to apply" (idempotent)
4. `npm run migrate:down 0001_podium` on a throwaway branch → objects removed, pre-existing tables intact

## Reviewer checklist
- [ ] DDL matches execution-plan §4; additive + reversible; no prod impact
- [ ] `user_roles` backfill correct; `users.access` retained as primary role
- [ ] Runner safe (transactional, idempotent, refuses without `DATABASE_URL`)
- [ ] No secrets committed; no chat-body column anywhere (P1)

Full report: Notion → "Daily Build Report — 3 Jul 2026 — F0 Migrations & scaffolding"

🤖 Generated with [Claude Code](https://claude.com/claude-code)
