### PR TITLE
F0b — Single-user-multi-role RBAC foundation (P10/P11)

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -2,6 +2,7 @@
 import { compare, hash } from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import { getClientWithTimezone } from '../lib/db.js';
+import { getRolesForUser, syncUserRoles, sanitizeRoles, primaryRole } from '../lib/rbac.js';
 
 /** Robust path segmentation that works on Vercel + Next.js local */
 function segs(req) {
@@ -322,7 +323,11 @@ async function handleAuth(req, res, action) {
       const ok = await compare(password, user.password);
       if (!ok) return res.status(401).json({ error: 'Invalid credentials' });
 
-      const token = jwt.sign({ id: user.id, email: user.email }, process.env.JWT_SECRET, {
+      // F0b: load the full multi-role set (falls back to [access] if user_roles
+      // is absent). Carry it in the JWT so the server can authorize on it later.
+      const roles = await getRolesForUser(client, user.id, user.access);
+
+      const token = jwt.sign({ id: user.id, email: user.email, roles }, process.env.JWT_SECRET, {
         expiresIn: '1h',
       });
 
@@ -337,7 +342,8 @@ async function handleAuth(req, res, action) {
         id: user.id,
         name: user.name,
         email: user.email,
-        access: user.access,
+        access: user.access, // primary role, unchanged (backward-compat)
+        roles,               // F0b: full role set
       });
     }
 
@@ -348,12 +354,20 @@ async function handleAuth(req, res, action) {
       const existing = await client.query('SELECT 1 FROM users WHERE email = $1', [email]);
       if (existing.rows.length) return res.status(409).json({ error: 'Email is already registered' });
 
+      // F0b: role set from the multi-select (falls back to a single `access` value
+      // or 'staff'). users.access mirrors the primary (highest-precedence) role.
+      let roles = sanitizeRoles(req.body.roles);
+      if (!roles.length && req.body.access) roles = sanitizeRoles([req.body.access]);
+      if (!roles.length) roles = ['staff'];
+      const primary = primaryRole(roles);
+
       const hashed = await hash(password, 10);
       await client.query(
-        'INSERT INTO users (id, name, email, password) VALUES ($1,$2,$3,$4)',
-        [id, name, email, hashed]
+        'INSERT INTO users (id, name, email, password, access) VALUES ($1,$2,$3,$4,$5)',
+        [id, name, email, hashed, primary]
       );
-      return res.status(200).json({ message: 'User registered successfully' });
+      await syncUserRoles(client, id, roles, null); // granted_by unknown (no acting-admin identity here)
+      return res.status(200).json({ message: 'User registered successfully', roles });
     }
 
     if (action === 'change-password') {
@@ -391,25 +405,50 @@ async function handleUsers(req, res) {
     const { method, body } = req;
 
     if (method === 'GET') {
-        const access = (req.query?.access || '').toString();
-        if (access) {
-            const r = await client.query('SELECT * FROM users WHERE access = $1', [access]);
-            return res.status(200).json(r.rows);
-        }
-        const r = await client.query('SELECT * FROM users');
+      const access = (req.query?.access || '').toString();
+      // F0b: return each user's full role set alongside the legacy columns.
+      // Falls back to [access] if user_roles is absent (undefined_table).
+      try {
+        const params = [];
+        let where = '';
+        if (access) { params.push(access); where = 'WHERE u.access = $1'; }
+        const r = await client.query(
+          `SELECT u.*,
+                  COALESCE(array_agg(ur.role) FILTER (WHERE ur.role IS NOT NULL),
+                           ARRAY[]::text[]) AS roles
+             FROM users u
+             LEFT JOIN user_roles ur ON ur.user_id = u.id
+             ${where}
+             GROUP BY u.id
+             ORDER BY u.id`,
+          params
+        );
         return res.status(200).json(r.rows);
+      } catch (err) {
+        if (err?.code !== '42P01') throw err; // only fall back when user_roles is missing
+        const r = access
+          ? await client.query('SELECT * FROM users WHERE access = $1', [access])
+          : await client.query('SELECT * FROM users');
+        return res.status(200).json(r.rows.map((u) => ({ ...u, roles: u.access ? [u.access] : [] })));
+      }
     }
 
     if (method === 'PUT') {
       const { id, name, email, password, access } = body;
       if (!id) return res.status(400).json({ error: 'User ID is required' });
+      // F0b: role set from the multi-select; users.access mirrors the primary role.
+      let roles = sanitizeRoles(body.roles);
+      if (!roles.length && access) roles = sanitizeRoles([access]);
+      if (!roles.length) roles = ['staff'];
+      const primary = primaryRole(roles);
       await client.query(
         `UPDATE users
            SET name=$1, email=$2, password=$3, access=$4
          WHERE id=$5`,
-        [name, email, password, access || 'staff', id]
+        [name, email, password, primary, id]
       );
-      return res.status(200).json({ message: 'User updated successfully' });
+      await syncUserRoles(client, id, roles, null);
+      return res.status(200).json({ message: 'User updated successfully', roles });
     }
 
     if (method === 'DELETE') {

--- a/lib/rbac.js
+++ b/lib/rbac.js
@@ -1,0 +1,108 @@
+// lib/rbac.js — Single-user-multi-role RBAC foundation (P10/P11, feature F0b)
+//
+// Roles live in the additive `user_roles` table (migration 0001_podium.sql, §4.0).
+// `users.access` stays the PRIMARY role for backward-compat; `user_roles` holds the
+// full set (including that primary). Two rules:
+//   1. Authorize on the SERVER. The role set is carried in the login JWT and read
+//      back via getAuthUser() — never trust a client-supplied role list alone.
+//   2. Fall back to the legacy single `access` value if `user_roles` is missing,
+//      so a DB that hasn't run the F0 migration yet (e.g. Production before release)
+//      keeps working.
+
+import jwt from 'jsonwebtoken';
+
+// Known roles. Existing (from users.access): superadmin, admin, staff, technician,
+// workshop. New (P11): sales, logistics. Order here is the primary-role precedence
+// (highest privilege first) used to mirror a multi-role set back into users.access.
+export const ROLES = ['superadmin', 'admin', 'logistics', 'sales', 'staff', 'technician', 'workshop'];
+
+/** Derive the primary (highest-precedence) role from a set. Falls back to 'staff'. */
+export function primaryRole(roles) {
+  const set = new Set((roles || []).map((r) => String(r).toLowerCase()));
+  for (const r of ROLES) if (set.has(r)) return r;
+  // A role we don't know about — keep it rather than lose the caller's intent.
+  return (roles && roles[0]) || 'staff';
+}
+
+/** Normalise a requested role list to known roles, lower-cased and de-duped. */
+export function sanitizeRoles(roles) {
+  const known = new Set(ROLES);
+  const out = [];
+  for (const r of roles || []) {
+    const v = String(r).toLowerCase().trim();
+    if (known.has(v) && !out.includes(v)) out.push(v);
+  }
+  return out;
+}
+
+/**
+ * Load a user's full role set from user_roles, with a defensive fallback to the
+ * legacy single `access` value when the table is absent (42P01) or empty. Always
+ * returns a non-empty array when an access value exists.
+ */
+export async function getRolesForUser(client, userId, fallbackAccess) {
+  try {
+    const r = await client.query('SELECT role FROM user_roles WHERE user_id = $1', [userId]);
+    const roles = r.rows.map((x) => x.role);
+    if (roles.length) return roles;
+  } catch (err) {
+    if (err?.code !== '42P01') console.error('getRolesForUser error:', err); // 42P01 = undefined_table
+  }
+  return fallbackAccess ? [fallbackAccess] : [];
+}
+
+/**
+ * Replace a user's role set with `roles` (idempotent, transactional). Swallows a
+ * missing-table error (42P01) so it's safe on a DB that hasn't run the F0 migration
+ * yet. Returns true if applied, false if user_roles is absent.
+ */
+export async function syncUserRoles(client, userId, roles, grantedBy) {
+  const set = sanitizeRoles(roles);
+  try {
+    await client.query('BEGIN');
+    await client.query('DELETE FROM user_roles WHERE user_id = $1', [userId]);
+    for (const role of set) {
+      await client.query(
+        `INSERT INTO user_roles (user_id, role, granted_by)
+         VALUES ($1,$2,$3) ON CONFLICT (user_id, role) DO NOTHING`,
+        [userId, role, grantedBy || null]
+      );
+    }
+    await client.query('COMMIT');
+    return true;
+  } catch (err) {
+    try { await client.query('ROLLBACK'); } catch (_) {}
+    if (err?.code === '42P01') return false; // user_roles not migrated on this DB yet
+    throw err;
+  }
+}
+
+/** Pure check: does this role set include `role`? Case-insensitive. */
+export function hasRole(roles, role) {
+  if (!roles) return false;
+  const want = String(role).toLowerCase();
+  return roles.some((r) => String(r).toLowerCase() === want);
+}
+
+/** Pure check: does this role set include ANY of `wanted`? */
+export function hasAnyRole(roles, wanted) {
+  return (wanted || []).some((w) => hasRole(roles, w));
+}
+
+/**
+ * Server-authoritative auth context from the request's login JWT. Returns
+ * { id, email, roles } or null. Use this — not a client header — to gate protected
+ * routes in later features (F9). The role set is signed at login, so it can't be
+ * forged by the client.
+ */
+export function getAuthUser(req) {
+  try {
+    const h = req.headers?.authorization || '';
+    const token = h.startsWith('Bearer ') ? h.slice(7) : null;
+    if (!token || !process.env.JWT_SECRET) return null;
+    const p = jwt.verify(token, process.env.JWT_SECRET);
+    return { id: p.id, email: p.email, roles: Array.isArray(p.roles) ? p.roles : [] };
+  } catch {
+    return null;
+  }
+}

--- a/src/pages/register.js
+++ b/src/pages/register.js
@@ -4,6 +4,28 @@ import BackButton from '../components/backbutton';
 import HomeButton from '../components/homebutton';
 import toast from 'react-hot-toast';
 
+// F0b: single-user-multi-role. Keep in sync with lib/rbac.js ROLES (precedence order).
+// users.access mirrors the primary (highest-precedence) role server-side.
+const ROLES = ['superadmin', 'admin', 'logistics', 'sales', 'staff', 'technician', 'workshop'];
+
+function RoleCheckboxes({ selected, onToggle }) {
+  const set = new Set(selected || []);
+  return (
+    <div className="flex flex-wrap gap-x-4 gap-y-1">
+      {ROLES.map((role) => (
+        <label key={role} className="inline-flex items-center gap-1 text-sm">
+          <input
+            type="checkbox"
+            checked={set.has(role)}
+            onChange={() => onToggle(role)}
+          />
+          {role}
+        </label>
+      ))}
+    </div>
+  );
+}
+
 export default function Register() {
   const [activeTab, setActiveTab] = useState('register');
   const [form, setForm] = useState({
@@ -12,6 +34,7 @@ export default function Register() {
     email: '',
     password: '',
     confirmPassword: '',
+    roles: ['staff'],
   });
   const [users, setUsers] = useState([]);
   const [loadingUsers, setLoadingUsers] = useState(false);
@@ -34,10 +57,22 @@ export default function Register() {
   const handleChange = (e) =>
     setForm({ ...form, [e.target.name]: e.target.value });
 
+  const toggleFormRole = (role) =>
+    setForm((f) => {
+      const set = new Set(f.roles);
+      if (set.has(role)) set.delete(role);
+      else set.add(role);
+      return { ...f, roles: ROLES.filter((r) => set.has(r)) };
+    });
+
   const handleSubmit = async (e) => {
     e.preventDefault();
     if (form.password !== form.confirmPassword) {
       toast.error('Passwords do not match');
+      return;
+    }
+    if (!form.roles.length) {
+      toast.error('Select at least one role');
       return;
     }
 
@@ -62,6 +97,7 @@ export default function Register() {
           email: '',
           password: '',
           confirmPassword: '',
+          roles: ['staff'],
         });
       } else {
         toast.error(data.error || 'Registration failed');
@@ -78,7 +114,12 @@ export default function Register() {
       const res = await fetch('/api/users');
       if (!res.ok) throw new Error('Failed to fetch users');
       const data = await res.json();
-      setUsers(Array.isArray(data) ? data : []);
+      // Ensure every row has a roles array (falls back to [access]).
+      const normalised = (Array.isArray(data) ? data : []).map((u) => ({
+        ...u,
+        roles: Array.isArray(u.roles) && u.roles.length ? u.roles : u.access ? [u.access] : [],
+      }));
+      setUsers(normalised);
     } catch {
       toast.error('Failed to fetch users');
       setUsers([]);
@@ -87,7 +128,22 @@ export default function Register() {
     }
   };
 
+  const toggleUserRole = (userId, role) =>
+    setUsers((prev) =>
+      prev.map((u) => {
+        if (u.id !== userId) return u;
+        const set = new Set(u.roles || []);
+        if (set.has(role)) set.delete(role);
+        else set.add(role);
+        return { ...u, roles: ROLES.filter((r) => set.has(r)) };
+      })
+    );
+
   const handleUpdate = async (row) => {
+    if (!row.roles?.length) {
+      toast.error('Select at least one role');
+      return;
+    }
     const updateToast = toast.loading('Updating user...');
     try {
       const res = await fetch('/api/users', {
@@ -113,8 +169,6 @@ export default function Register() {
   useEffect(() => {
     if (activeTab === 'update') fetchUsers();
   }, [activeTab]);
-
-  const accessLevels = ['superadmin', 'admin', 'staff', 'technician'];
 
   return (
     <>
@@ -154,6 +208,13 @@ export default function Register() {
                   required
                 />
               ))}
+              <div className="mb-4">
+                <p className="text-sm font-semibold mb-1">Roles</p>
+                <RoleCheckboxes selected={form.roles} onToggle={toggleFormRole} />
+                <p className="text-xs text-gray-500 mt-1">
+                  The highest-privilege role becomes the user's primary access level.
+                </p>
+              </div>
               <button
                 type="submit"
                 className="w-full bg-blue-500 text-white py-2 rounded hover:bg-blue-600"
@@ -178,7 +239,7 @@ export default function Register() {
                         <th className="border px-4 py-2">ID</th>
                         <th className="border px-4 py-2">Name</th>
                         <th className="border px-4 py-2">Email</th>
-                        <th className="border px-4 py-2">Access Level</th>
+                        <th className="border px-4 py-2">Roles</th>
                         <th className="border px-4 py-2">Action</th>
                       </tr>
                     </thead>
@@ -207,19 +268,10 @@ export default function Register() {
                             />
                           </td>
                           <td className="border px-4 py-2">
-                            <select
-                              className="w-full px-2 py-1 border rounded"
-                              value={u.access}
-                              onChange={(e) =>
-                                setUsers(users.map((x) => (x.id === u.id ? { ...x, access: e.target.value } : x)))
-                              }
-                            >
-                              {accessLevels.map((level) => (
-                                <option key={level} value={level}>
-                                  {level}
-                                </option>
-                              ))}
-                            </select>
+                            <RoleCheckboxes
+                              selected={u.roles}
+                              onToggle={(role) => toggleUserRole(u.id, role)}
+                            />
                           </td>
                           <td className="border px-4 py-2 text-center">
                             <button


### PR DESCRIPTION
## Summary
Moves RBAC from one `users.access` value per user to a **set of roles** (P10), and introduces the **`sales`** and **`logistics`** roles (P11) — without breaking existing single-role code. Application-layer only: the `user_roles` table + backfill (execution-plan §4.0) already shipped in migration `0001` (F0, PR #39, merged), so **there is no new migration in this PR**.

## Scope (acceptance criteria)
- [x] An existing user logs in unchanged — their old `access` is now also their primary role, and login additionally returns `roles[]`.
- [x] A user granted e.g. `{superadmin, sales}` passes both a superadmin gate and a sales gate (`hasAnyRole`).
- [x] Removing a role revokes it on next auth (roles are re-read at login and re-signed into the JWT).
- [x] Backward-compatible + reversible (no schema change here; §4.0 migration from F0 is reversible via its `_down.sql`).

## Changes
- **`lib/rbac.js`** (new): `getRolesForUser` (defensive `42P01` fallback to `[access]`), `syncUserRoles` (transactional, idempotent), `hasRole`/`hasAnyRole`, `primaryRole` precedence, `sanitizeRoles`, `getAuthUser` (verifies the login JWT — server-authoritative, for gating future F1+/F9 routes).
- **`api/[...path].js`**: login loads the role set, signs it into the JWT, and returns `roles[]` alongside the unchanged `access`; `register` and `users` PUT accept a role set, mirror the **primary** (highest-precedence) role into `users.access`, and sync `user_roles`; `users` GET returns each user's `roles[]` (falls back to `[access]` if `user_roles` is absent).
- **`src/pages/register.js`**: role multi-select (checkboxes) on both the Register form and the Update Users table, replacing the single access dropdown.

## Feature flags / mocking
- `PODIUM_MOCK=true`, `FEATURE_MYOB=false` — unchanged; not exercised by F0b (no Podium/MYOB calls here).

## How to test
1. Open the Preview (URL added as a comment once the build is READY).
2. Log in as a **superadmin** → response now includes `roles` (e.g. `["superadmin"]`); existing UI still reads `access` and behaves identically.
3. Go to **/register → Update Users**: each user shows role checkboxes. Tick `sales` + `logistics` on a user and Save.
4. Reload → the new roles persist; that user's primary `access` reflects the highest-precedence role selected.
5. **Register** a new user with a couple of roles → created with those roles and the mirrored primary access.
6. (P1) No chat/message tables are touched by this feature.

## Migration
- **None in this PR.** The §4.0 `user_roles` DDL + backfill shipped in `db/migrations/0001_podium.sql` (F0), already applied to the Neon **dev** branch and reversible via `0001_podium_down.sql`.
- _No prod DB changes._

## Reviewer checklist
- [x] Login returns `roles[]`; existing `access`-based behaviour unchanged
- [x] Multi-select writes/reads `user_roles`; primary mirrored into `users.access`
- [x] Server-side authorization path (`getAuthUser`) verifies the JWT, not a client header
- [x] No secrets; no chat bodies persisted; no prod impact
- [x] Approve & merge, or leave feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)