### PR TITLE
F1 (increment 1): Podium service module + typed mock (mock-first)

### DIFF
--- a/lib/podium.js
+++ b/lib/podium.js
@@ -1,0 +1,432 @@
+// lib/podium.js — Per-user Podium API v4 service module (feature F1).
+//
+// One place for every Podium call the portal makes. Built AGAINST the verified
+// reference in execution-plan.md §15 and mock-first per Golden Rule 6: while
+// PODIUM_MOCK=true (no live developer credentials yet) every request is served by
+// lib/podium.mock.js, so Previews work without secrets or network. Swapping to
+// live is a config change (set PODIUM_MOCK=false + the PODIUM_* creds) — no code
+// change here.
+//
+// Design (execution-plan.md F1, step 4):
+//   • Per-user OAuth (P4): each `sales` rep links their own account; calls run on
+//     that rep's token. `tokenForUser(userId)` reads podium_oauth and auto-refreshes
+//     within ~5 min of the 10h expiry or on a 401.
+//   • `request()` adds the Bearer token + the PINNED dated version header (omitting
+//     it defaults to Podium's latest = breaking changes, §15.1) and retries on
+//     429/5xx with backoff.
+//   • Cursor pagination helper (§15.5): `{ data, metadata:{ nextCursor } }`.
+//   • Helpers map 1:1 to the §15.4 endpoints used by F1b/F2/F3/F8.
+//
+// P1 GUARD: this module returns live message data to callers but performs NO
+// database writes of message content. Callers must never persist `data.body`
+// (Podium is the system of record). The only DB this module touches is the
+// podium_oauth token store.
+
+import { getClientWithTimezone } from './db.js';
+import * as mock from './podium.mock.js';
+
+// ---- Constants -------------------------------------------------------------
+
+export const API_BASE = 'https://api.podium.com/v4';
+export const OAUTH_AUTHORIZE_URL = 'https://api.podium.com/oauth/authorize';
+export const OAUTH_TOKEN_URL = 'https://api.podium.com/oauth/token';
+
+// Least-privilege scopes this integration needs (§15.3). No `webhooks` scope
+// exists — a webhook for an event type needs that event's own scope.
+export const DEFAULT_SCOPES = [
+  'read_messages', 'write_messages',
+  'read_contacts', 'write_contacts',
+  'read_users',
+  'read_reviews', 'write_reviews',
+  'read_locations', 'read_organizations',
+];
+
+// Podium's dated API-version request header. VERIFY the exact header name against
+// docs.podium.com when wiring live creds; the value comes from PODIUM_API_VERSION
+// and MUST be pinned (§15.1). Kept in one place so the live swap is trivial.
+const VERSION_HEADER = 'Podium-Version';
+
+// Refresh a token this long before its hard 10h expiry.
+const REFRESH_SKEW_MS = 5 * 60 * 1000;
+// Retry policy for transient upstream failures.
+const MAX_RETRIES = 3;
+const RETRY_BASE_MS = 300;
+
+// ---- Pure config helpers (env read at call-time, so tests can flip flags) ---
+
+export function isMock() {
+  const v = String(process.env.PODIUM_MOCK ?? '').toLowerCase();
+  // Default to mock unless explicitly disabled OR client creds are present.
+  if (v === 'true' || v === '1') return true;
+  if (v === 'false' || v === '0') return false;
+  return !process.env.PODIUM_CLIENT_ID; // no creds ⇒ mock
+}
+
+export function apiVersion() {
+  return process.env.PODIUM_API_VERSION || '';
+}
+
+export function scopes() {
+  const fromEnv = (process.env.PODIUM_OAUTH_SCOPES || '').trim();
+  return fromEnv ? fromEnv.split(/\s+/) : DEFAULT_SCOPES.slice();
+}
+
+export function redirectUri() {
+  return process.env.PODIUM_REDIRECT_URI || '';
+}
+
+/** Is a token (expiry as ms epoch or ISO/Date) due for refresh? */
+export function needsRefresh(expiresAt, now = Date.now(), skewMs = REFRESH_SKEW_MS) {
+  if (expiresAt == null) return true;
+  const exp = expiresAt instanceof Date ? expiresAt.getTime()
+    : typeof expiresAt === 'number' ? expiresAt
+      : Date.parse(expiresAt);
+  if (!Number.isFinite(exp)) return true;
+  return now >= exp - skewMs;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+// ---- OAuth 2 (per-user) ----------------------------------------------------
+
+/**
+ * Build the browser authorize URL (§15.2). `state` carries the portal user id so
+ * the callback can key the token to the right rep. Scopes are space-separated and
+ * %20-encoded by URLSearchParams.
+ */
+export function buildAuthorizeUrl(userId, opts = {}) {
+  // Build the query by hand: scopes must be %20-encoded (§15.2), but
+  // URLSearchParams emits `+` for spaces. encodeURIComponent gives %20.
+  const params = {
+    client_id: process.env.PODIUM_CLIENT_ID || '',
+    redirect_uri: opts.redirectUri || redirectUri(),
+    scope: (opts.scopes || scopes()).join(' '),
+    response_type: 'code',
+    state: opts.state || String(userId ?? ''),
+  };
+  const qs = Object.entries(params)
+    .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(v)}`)
+    .join('&');
+  return `${OAUTH_AUTHORIZE_URL}?${qs}`;
+}
+
+/** Exchange an authorization code for tokens (§15.2). Mock-first. */
+export async function exchangeCode(code, opts = {}) {
+  if (isMock()) return mock.oauthExchange(code);
+  return postToken({
+    grant_type: 'authorization_code',
+    code,
+    redirect_uri: opts.redirectUri || redirectUri(),
+    client_id: process.env.PODIUM_CLIENT_ID,
+    client_secret: process.env.PODIUM_CLIENT_SECRET,
+  });
+}
+
+/** Refresh an access token (§15.2). Mock-first. */
+export async function refreshAccessToken(refreshToken) {
+  if (isMock()) return mock.oauthRefresh(refreshToken);
+  return postToken({
+    grant_type: 'refresh_token',
+    refresh_token: refreshToken,
+    client_id: process.env.PODIUM_CLIENT_ID,
+    client_secret: process.env.PODIUM_CLIENT_SECRET,
+  });
+}
+
+async function postToken(bodyObj) {
+  const resp = await fetch(OAUTH_TOKEN_URL, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+    body: JSON.stringify(bodyObj),
+  });
+  const text = await resp.text();
+  if (!resp.ok) {
+    const err = new Error(`Podium OAuth ${resp.status}: ${text.slice(0, 300)}`);
+    err.status = resp.status;
+    throw err;
+  }
+  return text ? JSON.parse(text) : {};
+}
+
+// ---- Token store (podium_oauth) --------------------------------------------
+// Only DB the service touches. A NULL user_id row is the location/webhook
+// registration (scope_level='location', §4.2). Uses the repo pg + timezone helper.
+
+async function withClient(injected, fn) {
+  if (injected) return fn(injected);
+  const client = await getClientWithTimezone();
+  try {
+    return await fn(client);
+  } finally {
+    client.release();
+  }
+}
+
+/** Read the stored token row for a rep (or null). */
+export async function getStoredToken(userId, opts = {}) {
+  return withClient(opts.client, async (client) => {
+    const r = await client.query(
+      `SELECT id, user_id, access_token, refresh_token, scopes, expires_at,
+              podium_user_id, org_uid, location_uid, scope_level
+         FROM podium_oauth
+        WHERE user_id = $1
+        LIMIT 1`,
+      [userId]
+    );
+    return r.rowCount ? r.rows[0] : null;
+  });
+}
+
+/**
+ * Upsert a rep's token set (from exchange or refresh). `expiresInSeconds`
+ * defaults to the 10h Podium TTL. Keyed by user_id (uq_podium_oauth_user).
+ */
+export async function saveUserToken(userId, tokenSet, meta = {}, opts = {}) {
+  const expiresInSeconds = Number(tokenSet.expires_in) || 10 * 60 * 60;
+  const expiresAt = new Date(Date.now() + expiresInSeconds * 1000);
+  const scopeStr = Array.isArray(tokenSet.scope) ? tokenSet.scope.join(' ')
+    : (tokenSet.scope || meta.scopes || scopes().join(' '));
+  return withClient(opts.client, async (client) => {
+    const r = await client.query(
+      `INSERT INTO podium_oauth
+         (user_id, scope_level, org_uid, location_uid, podium_user_id,
+          access_token, refresh_token, scopes, expires_at, updated_at)
+       VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9, NOW())
+       ON CONFLICT (user_id) WHERE user_id IS NOT NULL
+       DO UPDATE SET access_token = EXCLUDED.access_token,
+                     refresh_token = EXCLUDED.refresh_token,
+                     scopes        = EXCLUDED.scopes,
+                     expires_at    = EXCLUDED.expires_at,
+                     podium_user_id = COALESCE(EXCLUDED.podium_user_id, podium_oauth.podium_user_id),
+                     updated_at    = NOW()
+       RETURNING id`,
+      [
+        userId,
+        meta.scopeLevel || 'user',
+        meta.orgUid || null,
+        meta.locationUid || null,
+        tokenSet.podium_user_id || meta.podiumUserId || null,
+        tokenSet.access_token,
+        tokenSet.refresh_token,
+        scopeStr,
+        expiresAt,
+      ]
+    );
+    return r.rows[0]?.id ?? null;
+  });
+}
+
+/**
+ * Return a valid access token for a rep, refreshing + persisting if it's within
+ * the skew of its 10h expiry. In mock mode returns a synthetic token (no DB).
+ * Throws PodiumNotConnectedError if the rep has never linked their account.
+ */
+export async function tokenForUser(userId, opts = {}) {
+  if (isMock()) return `mock_at_${userId}`;
+  return withClient(opts.client, async (client) => {
+    const row = await getStoredToken(userId, { client });
+    if (!row) {
+      const err = new Error(`Podium account not connected for user ${userId}`);
+      err.code = 'PODIUM_NOT_CONNECTED';
+      throw err;
+    }
+    if (!needsRefresh(row.expires_at)) return row.access_token;
+    const refreshed = await refreshAccessToken(row.refresh_token);
+    await saveUserToken(userId, refreshed, { scopeLevel: row.scope_level }, { client });
+    return refreshed.access_token;
+  });
+}
+
+// ---- Core request wrapper --------------------------------------------------
+
+function buildUrl(path, query) {
+  const clean = String(path).replace(/^\//, '');
+  const url = new URL(`${API_BASE}/${clean.replace(/^v4\//, '')}`);
+  for (const [k, v] of Object.entries(query || {})) {
+    if (v !== undefined && v !== null && v !== '') url.searchParams.set(k, v);
+  }
+  return url.toString();
+}
+
+function isRetryable(status) {
+  return status === 429 || status === 500 || status === 502 || status === 503 || status === 504;
+}
+
+/**
+ * Make an authenticated Podium request AS `userId`. Mock-first (no token/DB in
+ * mock mode). Adds the pinned version header, retries transient failures with
+ * backoff, and refreshes once on a 401.
+ */
+export async function request(userId, method, path, opts = {}) {
+  if (isMock()) return mock.handle(method, path, opts);
+
+  const doFetch = async (token) => {
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      Accept: 'application/json',
+      [VERSION_HEADER]: apiVersion(),
+    };
+    const init = { method: String(method || 'GET').toUpperCase(), headers };
+    if (opts.body !== undefined) {
+      headers['Content-Type'] = 'application/json';
+      init.body = JSON.stringify(opts.body);
+    }
+    return fetch(buildUrl(path, opts.query), init);
+  };
+
+  let token = await tokenForUser(userId, { client: opts.client });
+  let attempt = 0;
+  let refreshedOn401 = false;
+
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    let resp;
+    try {
+      resp = await doFetch(token);
+    } catch (netErr) {
+      if (attempt < MAX_RETRIES) {
+        await sleep(RETRY_BASE_MS * 2 ** attempt);
+        attempt += 1;
+        continue;
+      }
+      throw netErr;
+    }
+
+    // One forced refresh + retry on 401 (token may have been revoked upstream).
+    if (resp.status === 401 && !refreshedOn401 && !opts.client) {
+      refreshedOn401 = true;
+      const row = await getStoredToken(userId);
+      if (row) {
+        const refreshed = await refreshAccessToken(row.refresh_token);
+        await saveUserToken(userId, refreshed, { scopeLevel: row.scope_level });
+        token = refreshed.access_token;
+        continue;
+      }
+    }
+
+    if (isRetryable(resp.status) && attempt < MAX_RETRIES) {
+      const retryAfter = Number(resp.headers.get('retry-after'));
+      const wait = Number.isFinite(retryAfter) && retryAfter > 0
+        ? retryAfter * 1000
+        : RETRY_BASE_MS * 2 ** attempt;
+      await sleep(wait);
+      attempt += 1;
+      continue;
+    }
+
+    const text = await resp.text();
+    if (!resp.ok) {
+      const err = new Error(`Podium ${init_method(method)} ${path} → ${resp.status}: ${text.slice(0, 300)}`);
+      err.status = resp.status;
+      throw err;
+    }
+    return text ? JSON.parse(text) : {};
+  }
+}
+
+function init_method(m) {
+  return String(m || 'GET').toUpperCase();
+}
+
+/**
+ * Walk a cursor-paginated list endpoint (§15.5), returning the concatenated
+ * `data`. `max` caps total items pulled (safety against runaway pagination).
+ */
+export async function paginate(userId, path, opts = {}) {
+  const limit = Math.min(Math.max(Number(opts.limit) || 100, 1), 100);
+  const max = Number(opts.max) || 1000;
+  const out = [];
+  let cursor = opts.cursor || undefined;
+  do {
+    const query = { ...(opts.query || {}), limit };
+    if (cursor) query.cursor = cursor;
+    const res = await request(userId, 'GET', path, { query, client: opts.client });
+    const batch = Array.isArray(res?.data) ? res.data : [];
+    out.push(...batch);
+    cursor = res?.metadata?.nextCursor || null;
+  } while (cursor && out.length < max);
+  return out.slice(0, max);
+}
+
+// ---- Endpoint helpers (§15.4) ----------------------------------------------
+
+/** GET /v4/conversations (cursor+limit). `scope:'mine'` filters by the rep. */
+export function listConversations(userId, opts = {}) {
+  const query = { ...(opts.query || {}) };
+  if (opts.limit) query.limit = opts.limit;
+  if (opts.cursor) query.cursor = opts.cursor;
+  if (opts.assigneeUid) query.assigneeUid = opts.assigneeUid;
+  return request(userId, 'GET', 'conversations', { query, client: opts.client });
+}
+
+/** GET /v4/conversations/{uid} */
+export function getConversation(userId, conversationUid, opts = {}) {
+  return request(userId, 'GET', `conversations/${conversationUid}`, { client: opts.client });
+}
+
+/** GET /v4/conversations/{uid}/messages (cursor+limit). Bodies are live-only (P1). */
+export function listMessages(userId, conversationUid, opts = {}) {
+  const query = {};
+  if (opts.limit) query.limit = opts.limit;
+  if (opts.cursor) query.cursor = opts.cursor;
+  return request(userId, 'GET', `conversations/${conversationUid}/messages`, { query, client: opts.client });
+}
+
+/** POST /v4/messages — send AS the logged-in rep. */
+export function sendMessage(userId, { conversationUid, body, channel, to, type = 'text', locationUid } = {}) {
+  const payload = {
+    conversationUid,
+    body,
+    type,
+    locationUid: locationUid || process.env.PODIUM_LOCATION_UID || undefined,
+  };
+  if (channel) payload.channel = channel;
+  if (to) payload.to = to;
+  return request(userId, 'POST', 'messages', { body: payload });
+}
+
+/** GET /v4/conversations/{uid}/assignees */
+export function getAssignee(userId, conversationUid, opts = {}) {
+  return request(userId, 'GET', `conversations/${conversationUid}/assignees`, { client: opts.client });
+}
+
+/** PUT /v4/conversations/{uid}/assignees — drives native assignment (F1b). */
+export function assignConversation(userId, conversationUid, assigneeUid) {
+  return request(userId, 'PUT', `conversations/${conversationUid}/assignees`, {
+    body: { userUid: assigneeUid },
+  });
+}
+
+/** GET /v4/users (+ pagination via paginate()) or GET /v4/users/{uid}. */
+export function getUsers(userId, opts = {}) {
+  if (opts.uid) return request(userId, 'GET', `users/${opts.uid}`, { client: opts.client });
+  return request(userId, 'GET', 'users', {
+    query: { ...(opts.limit ? { limit: opts.limit } : {}), ...(opts.cursor ? { cursor: opts.cursor } : {}) },
+    client: opts.client,
+  });
+}
+
+/** GET /v4/contacts/{uid} */
+export function getContact(userId, contactUid, opts = {}) {
+  return request(userId, 'GET', `contacts/${contactUid}`, { client: opts.client });
+}
+
+/** POST /v4/reviews/invites (F8c). */
+export function requestReview(userId, { contactUid, locationUid, channel } = {}) {
+  return request(userId, 'POST', 'reviews/invites', {
+    body: {
+      contactUid,
+      channel,
+      locationUid: locationUid || process.env.PODIUM_LOCATION_UID || undefined,
+    },
+  });
+}
+
+export default {
+  isMock, apiVersion, scopes, redirectUri, needsRefresh,
+  buildAuthorizeUrl, exchangeCode, refreshAccessToken,
+  getStoredToken, saveUserToken, tokenForUser,
+  request, paginate,
+  listConversations, getConversation, listMessages, sendMessage,
+  getAssignee, assignConversation, getUsers, getContact, requestReview,
+};

--- a/lib/podium.mock.js
+++ b/lib/podium.mock.js
@@ -1,0 +1,284 @@
+// lib/podium.mock.js — typed, in-memory Podium API v4 mock (F1, mock-first).
+//
+// Until live Podium developer credentials are wired into Vercel (PODIUM_MOCK=true,
+// Golden Rule 6), `lib/podium.js` routes every call through this module so the
+// Preview stays reviewable without network or secrets. Responses are shaped to
+// match the VERIFIED Podium v4 reference in execution-plan.md §15 — cursor
+// pagination envelope `{ data, metadata:{ nextCursor, previousCursor } }`, stable
+// opaque `uid`s, `conversation.channel.{type,identifier}`, `assignedUser.uid`, and
+// the (deprecated-but-present) `contact` hint on message events.
+//
+// NOTE ON P1: this mock returns `data.body` on messages purely so the future inbox
+// UI has something to render live. The service and its callers must NEVER persist
+// message bodies (execution-plan P1) — Podium is the system of record.
+
+// ---- Fixtures -------------------------------------------------------------
+
+// Reps / members (Podium "users"). Their `uid` maps to users.podium_user_id.
+const USERS = [
+  { uid: 'pod_usr_amELia', name: 'Amelia Reid', email: 'amelia@graysfitness.com.au', role: 'member' },
+  { uid: 'pod_usr_bENjin', name: 'Ben Jindra', email: 'ben@graysfitness.com.au', role: 'member' },
+  { uid: 'pod_usr_owNER1', name: 'Grays Owner', email: 'owner@graysfitness.com.au', role: 'owner' },
+];
+
+// Contacts (customers on the Podium side). uid maps to customers.podium_contact_id.
+const CONTACTS = [
+  { uid: 'pod_con_maRIA1', name: 'Maria Papadopoulos', phoneNumber: '+61400111222', email: 'maria@example.com', channels: ['phone', 'facebook'] },
+  { uid: 'pod_con_toMH20', name: 'Tom Harris', phoneNumber: '+61400333444', email: 'tom.h@example.com', channels: ['phone'] },
+  { uid: 'pod_con_liNDA3', name: 'Linda Nguyen', phoneNumber: '+61400555666', email: null, channels: ['instagram'] },
+  { uid: 'pod_con_jaKE44', name: 'Jake Wilson', phoneNumber: '+61400777888', email: 'jakew@example.com', channels: ['google'] },
+];
+
+const LOCATION_UID = () => process.env.PODIUM_LOCATION_UID || 'pod_loc_GRAYSHQ';
+const ORG_UID = () => process.env.PODIUM_ORG_UID || 'pod_org_GRAYS';
+
+// Conversations — one per contact, spread across channels + assignees.
+const CONVERSATIONS = [
+  {
+    uid: 'pod_cnv_00001',
+    channel: { type: 'phone', identifier: '+61400111222' },
+    contact: { uid: 'pod_con_maRIA1' }, // deprecated hint (see §15.6) — resolve via Contacts API
+    assignedUser: { uid: 'pod_usr_amELia' },
+    location: { uid: LOCATION_UID(), organizationUid: ORG_UID() },
+    lastMessageAt: '2026-07-03T09:15:00+10:00',
+  },
+  {
+    uid: 'pod_cnv_00002',
+    channel: { type: 'facebook', identifier: 'fb:graysfitness' },
+    contact: { uid: 'pod_con_maRIA1' },
+    assignedUser: { uid: 'pod_usr_bENjin' },
+    location: { uid: LOCATION_UID(), organizationUid: ORG_UID() },
+    lastMessageAt: '2026-07-02T16:40:00+10:00',
+  },
+  {
+    uid: 'pod_cnv_00003',
+    channel: { type: 'phone', identifier: '+61400333444' },
+    contact: { uid: 'pod_con_toMH20' },
+    assignedUser: null, // unassigned — auto-created lead would be unassigned (P12)
+    location: { uid: LOCATION_UID(), organizationUid: ORG_UID() },
+    lastMessageAt: '2026-07-03T08:02:00+10:00',
+  },
+  {
+    uid: 'pod_cnv_00004',
+    channel: { type: 'instagram', identifier: 'ig:graysfitness' },
+    contact: { uid: 'pod_con_liNDA3' },
+    assignedUser: { uid: 'pod_usr_amELia' },
+    location: { uid: LOCATION_UID(), organizationUid: ORG_UID() },
+    lastMessageAt: '2026-07-01T11:20:00+10:00',
+  },
+  {
+    uid: 'pod_cnv_00005',
+    channel: { type: 'google', identifier: 'gbm:graysfitness' },
+    contact: { uid: 'pod_con_jaKE44' },
+    assignedUser: { uid: 'pod_usr_bENjin' },
+    location: { uid: LOCATION_UID(), organizationUid: ORG_UID() },
+    lastMessageAt: '2026-07-03T07:45:00+10:00',
+  },
+];
+
+// Messages keyed by conversation uid (oldest → newest). `body` present (see P1 note).
+const MESSAGES = {
+  pod_cnv_00001: [
+    { uid: 'pod_msg_0001a', direction: 'inbound', channel: 'phone', body: 'Hi, is the 20kg adjustable dumbbell set back in stock?', createdAt: '2026-07-03T09:10:00+10:00' },
+    { uid: 'pod_msg_0001b', direction: 'outbound', channel: 'phone', body: 'Hi Maria! Yes, we just restocked — want me to hold a set for you?', createdAt: '2026-07-03T09:12:00+10:00' },
+    { uid: 'pod_msg_0001c', direction: 'inbound', channel: 'phone', body: 'Yes please, and can you do delivery to Brunswick?', createdAt: '2026-07-03T09:15:00+10:00' },
+  ],
+  pod_cnv_00002: [
+    { uid: 'pod_msg_0002a', direction: 'inbound', channel: 'facebook', body: 'Do you price match on the rowing machine?', createdAt: '2026-07-02T16:38:00+10:00' },
+    { uid: 'pod_msg_0002b', direction: 'outbound', channel: 'facebook', body: 'We can usually get close — send me the competitor link?', createdAt: '2026-07-02T16:40:00+10:00' },
+  ],
+  pod_cnv_00003: [
+    { uid: 'pod_msg_0003a', direction: 'inbound', channel: 'phone', body: 'What are your warehouse pickup hours on Saturday?', createdAt: '2026-07-03T08:02:00+10:00' },
+  ],
+  pod_cnv_00004: [
+    { uid: 'pod_msg_0004a', direction: 'inbound', channel: 'instagram', body: 'Love the new squat racks 😍 do they come assembled?', createdAt: '2026-07-01T11:18:00+10:00' },
+    { uid: 'pod_msg_0004b', direction: 'outbound', channel: 'instagram', body: 'Thank you! They ship flat-packed but assembly is straightforward.', createdAt: '2026-07-01T11:20:00+10:00' },
+  ],
+  pod_cnv_00005: [
+    { uid: 'pod_msg_0005a', direction: 'inbound', channel: 'google', body: 'Can I get a quote for a full home gym setup?', createdAt: '2026-07-03T07:45:00+10:00' },
+  ],
+};
+
+// ---- Cursor pagination -----------------------------------------------------
+// Opaque cursor = base64("offset:<n>"). Mirrors §15.5 (limit 1–100, default 10).
+
+function encodeCursor(offset) {
+  return Buffer.from(`offset:${offset}`, 'utf8').toString('base64');
+}
+function decodeCursor(cursor) {
+  if (!cursor) return 0;
+  try {
+    const s = Buffer.from(String(cursor), 'base64').toString('utf8');
+    const m = s.match(/^offset:(\d+)$/);
+    return m ? parseInt(m[1], 10) : 0;
+  } catch {
+    return 0;
+  }
+}
+
+function paginateList(items, query = {}) {
+  const rawLimit = parseInt(query.limit, 10);
+  const limit = Number.isFinite(rawLimit) ? Math.min(Math.max(rawLimit, 1), 100) : 10;
+  const offset = decodeCursor(query.cursor);
+  const page = items.slice(offset, offset + limit);
+  const nextOffset = offset + limit;
+  const nextCursor = nextOffset < items.length ? encodeCursor(nextOffset) : null;
+  const previousCursor = offset > 0 ? encodeCursor(Math.max(offset - limit, 0)) : null;
+  return { data: page, metadata: { nextCursor, previousCursor } };
+}
+
+// ---- OAuth mock ------------------------------------------------------------
+
+const TEN_HOURS_SECONDS = 10 * 60 * 60;
+
+/** Synthetic token set matching the real `{ access_token, refresh_token }` shape. */
+export function oauthExchange(code) {
+  return {
+    access_token: `mock_at_${code || 'code'}_${'x'.repeat(6)}`,
+    refresh_token: `mock_rt_${code || 'code'}`,
+    expires_in: TEN_HOURS_SECONDS, // access token lives 10h (§15.2)
+    token_type: 'bearer',
+    // resolved rep identity the callback uses to set users.podium_user_id
+    podium_user_id: USERS[0].uid,
+  };
+}
+
+/** Refresh returns a fresh access token; refresh token may rotate. */
+export function oauthRefresh(refreshToken) {
+  return {
+    access_token: `mock_at_refreshed_${'x'.repeat(6)}`,
+    refresh_token: refreshToken || 'mock_rt_rotated',
+    expires_in: TEN_HOURS_SECONDS,
+    token_type: 'bearer',
+  };
+}
+
+// ---- Request router --------------------------------------------------------
+// `lib/podium.js` calls handle() in mock mode. Path is the part after /v4/.
+
+function stripV4(path) {
+  return String(path || '').replace(/^\/?v4\//, '').replace(/^\//, '');
+}
+
+/**
+ * Route a mock request. Returns a plain object shaped like the live API.
+ * @param {string} method  GET|POST|PUT|PATCH|DELETE
+ * @param {string} path    e.g. 'conversations' or 'conversations/pod_cnv_00001/messages'
+ * @param {{query?:object, body?:object}} opts
+ */
+export function handle(method, path, opts = {}) {
+  const m = String(method || 'GET').toUpperCase();
+  const p = stripV4(path);
+  const query = opts.query || {};
+  const body = opts.body || {};
+  const segs = p.split('/').filter(Boolean);
+
+  // GET /users  ·  GET /users/{uid}
+  if (segs[0] === 'users') {
+    if (segs[1]) {
+      const u = USERS.find((x) => x.uid === segs[1]);
+      if (!u) return notFound('user', segs[1]);
+      return u;
+    }
+    return paginateList(USERS, query);
+  }
+
+  // GET /contacts  ·  GET /contacts/{uid}
+  if (segs[0] === 'contacts') {
+    if (segs[1]) {
+      const c = CONTACTS.find((x) => x.uid === segs[1]);
+      if (!c) return notFound('contact', segs[1]);
+      return c;
+    }
+    return paginateList(CONTACTS, query);
+  }
+
+  // conversations ...
+  if (segs[0] === 'conversations') {
+    // GET /conversations
+    if (!segs[1]) {
+      let items = CONVERSATIONS;
+      if (query.assigneeUid) items = items.filter((c) => c.assignedUser?.uid === query.assigneeUid);
+      return paginateList(items, query);
+    }
+    const convUid = segs[1];
+    const conv = CONVERSATIONS.find((c) => c.uid === convUid);
+    // GET /conversations/{uid}/messages
+    if (segs[2] === 'messages') {
+      if (!conv) return notFound('conversation', convUid);
+      return paginateList(MESSAGES[convUid] || [], query);
+    }
+    // GET|PUT /conversations/{uid}/assignees
+    if (segs[2] === 'assignees') {
+      if (!conv) return notFound('conversation', convUid);
+      if (m === 'PUT') {
+        const assigneeUid = body.userUid || body.assigneeUid || body.uid || null;
+        return { conversationUid: convUid, assignedUser: assigneeUid ? { uid: assigneeUid } : null };
+      }
+      return { conversationUid: convUid, assignedUser: conv.assignedUser || null };
+    }
+    // GET|PATCH /conversations/{uid}
+    if (!conv) return notFound('conversation', convUid);
+    if (m === 'PATCH') return { ...conv, ...body };
+    return conv;
+  }
+
+  // POST /messages (send)
+  if (segs[0] === 'messages' && m === 'POST') {
+    return {
+      uid: `pod_msg_sent_${Date.now().toString(36)}`,
+      conversationUid: body.conversationUid || null,
+      channel: body.channel || 'phone',
+      direction: 'outbound',
+      status: 'sent',
+      locationUid: body.locationUid || LOCATION_UID(),
+      createdAt: nowIso(),
+    };
+  }
+
+  // POST /reviews/invites
+  if (segs[0] === 'reviews' && segs[1] === 'invites' && m === 'POST') {
+    return {
+      uid: `pod_rev_inv_${Date.now().toString(36)}`,
+      status: 'sent',
+      locationUid: body.locationUid || LOCATION_UID(),
+      contactUid: body.contactUid || null,
+      createdAt: nowIso(),
+    };
+  }
+
+  // GET /reviews
+  if (segs[0] === 'reviews' && !segs[1]) {
+    return paginateList([], query);
+  }
+
+  // GET /locations · GET /organizations/{uid}
+  if (segs[0] === 'locations') return paginateList([{ uid: LOCATION_UID(), name: 'Grays Fitness HQ', organizationUid: ORG_UID() }], query);
+  if (segs[0] === 'organizations') return { uid: ORG_UID(), name: 'Grays Fitness' };
+
+  // Webhooks CRUD (F2 will use these) — minimal echo so setup code is testable.
+  if (segs[0] === 'webhooks') {
+    if (m === 'POST') return { uid: `pod_wh_${Date.now().toString(36)}`, url: body.url, eventTypes: body.eventTypes || body.eventType, status: 'active' };
+    if (m === 'GET') return paginateList([], query);
+    if (m === 'DELETE') return { uid: segs[1] || null, deleted: true };
+    if (m === 'PATCH') return { uid: segs[1] || null, ...body };
+  }
+
+  return notFound('route', `${m} /${p}`);
+}
+
+function notFound(kind, id) {
+  const err = new Error(`Podium mock: ${kind} not found: ${id}`);
+  err.status = 404;
+  err.podiumMock = true;
+  throw err;
+}
+
+function nowIso() {
+  // Podium timestamps are ISO 8601; exact value is irrelevant for the mock.
+  return new Date(0).toISOString();
+}
+
+// Exported for tests / later increments.
+export const fixtures = { USERS, CONTACTS, CONVERSATIONS, MESSAGES };
+export const _internal = { encodeCursor, decodeCursor, paginateList };

--- a/scripts/podium-smoke.mjs
+++ b/scripts/podium-smoke.mjs
@@ -1,0 +1,94 @@
+// scripts/podium-smoke.mjs — offline smoke test for the Podium service (F1).
+//
+// Exercises lib/podium.js end-to-end against lib/podium.mock.js. NO network, NO
+// database, NO secrets — it forces PODIUM_MOCK=true, so request() short-circuits
+// to the in-memory mock and never touches podium_oauth. Reviewers can run:
+//
+//   node scripts/podium-smoke.mjs
+//
+// Exit 0 = all checks passed; non-zero = a check threw.
+
+process.env.PODIUM_MOCK = 'true';
+// Give the version pin + scopes deterministic values for the assertions below.
+process.env.PODIUM_API_VERSION = process.env.PODIUM_API_VERSION || '2021-04-01';
+process.env.PODIUM_CLIENT_ID = process.env.PODIUM_CLIENT_ID || 'mock_client';
+process.env.PODIUM_REDIRECT_URI = 'https://portal.example/api/podium/oauth/callback';
+
+const podium = await import('../lib/podium.js');
+
+let passed = 0;
+function check(name, cond, detail) {
+  if (!cond) throw new Error(`FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  passed += 1;
+  console.log(`  ✓ ${name}`);
+}
+
+const REP = 'AM'; // portal 2-char user id
+
+console.log('Podium service smoke (PODIUM_MOCK=true)\n');
+
+// 1. mock/config helpers
+check('isMock() true under PODIUM_MOCK', podium.isMock() === true);
+check('apiVersion() pinned', podium.apiVersion() === '2021-04-01');
+check('scopes() = least-privilege set', podium.scopes().includes('read_messages') && !podium.scopes().includes('webhooks'));
+
+// 2. needsRefresh (pure token math)
+check('needsRefresh: far-future token is fresh', podium.needsRefresh(Date.now() + 60 * 60 * 1000) === false);
+check('needsRefresh: expired token needs refresh', podium.needsRefresh(Date.now() - 1000) === true);
+check('needsRefresh: within 5min skew needs refresh', podium.needsRefresh(Date.now() + 60 * 1000) === true);
+check('needsRefresh: null needs refresh', podium.needsRefresh(null) === true);
+
+// 3. authorize URL
+const url = podium.buildAuthorizeUrl(REP);
+check('authorize URL hits /oauth/authorize', url.startsWith('https://api.podium.com/oauth/authorize?'));
+check('authorize URL carries state=userId', url.includes('state=AM'));
+check('authorize URL space-encodes scopes', url.includes('read_messages') && url.includes('%20'));
+check('authorize URL includes redirect_uri', url.includes(encodeURIComponent('https://portal.example/api/podium/oauth/callback')));
+
+// 4. OAuth exchange + refresh (mock)
+const tok = await podium.exchangeCode('auth-code-123');
+check('exchangeCode returns access+refresh', !!tok.access_token && !!tok.refresh_token);
+check('exchangeCode TTL is 10h', tok.expires_in === 10 * 60 * 60);
+const refreshed = await podium.refreshAccessToken(tok.refresh_token);
+check('refreshAccessToken returns a new access token', refreshed.access_token && refreshed.access_token !== tok.access_token);
+
+// 5. tokenForUser in mock mode does NOT hit the DB
+const mockTok = await podium.tokenForUser(REP);
+check('tokenForUser returns synthetic token in mock', mockTok === `mock_at_${REP}`);
+
+// 6. list conversations + cursor pagination
+const page1 = await podium.listConversations(REP, { limit: 2 });
+check('listConversations page1 has 2 items', page1.data.length === 2, `got ${page1.data.length}`);
+check('listConversations page1 has nextCursor', !!page1.metadata.nextCursor);
+const page2 = await podium.listConversations(REP, { limit: 2, cursor: page1.metadata.nextCursor });
+check('listConversations page2 is a different page', page2.data[0].uid !== page1.data[0].uid);
+
+const allConvos = await podium.paginate(REP, 'conversations', { limit: 2 });
+check('paginate() walks every conversation', allConvos.length === 5, `got ${allConvos.length}`);
+
+// 7. "My conversations" filter (drives F1b/F3 default view)
+const mine = await podium.listConversations(REP, { assigneeUid: 'pod_usr_amELia' });
+check('assignee filter returns only Amelia’s convos', mine.data.length === 2 && mine.data.every((c) => c.assignedUser?.uid === 'pod_usr_amELia'));
+
+// 8. messages (live-only; never persisted — P1)
+const msgs = await podium.listMessages(REP, 'pod_cnv_00001');
+check('listMessages returns the thread', msgs.data.length === 3);
+check('messages carry a body for live render only', typeof msgs.data[0].body === 'string');
+
+// 9. send message
+const sent = await podium.sendMessage(REP, { conversationUid: 'pod_cnv_00001', body: 'On its way!' });
+check('sendMessage returns sent status', sent.status === 'sent' && sent.direction === 'outbound');
+
+// 10. assignment (F1b)
+const assigned = await podium.assignConversation(REP, 'pod_cnv_00003', 'pod_usr_amELia');
+check('assignConversation sets the assignee', assigned.assignedUser?.uid === 'pod_usr_amELia');
+
+// 11. users + contact + review invite
+const users = await podium.getUsers(REP);
+check('getUsers lists members', users.data.length === 3);
+const contact = await podium.getContact(REP, 'pod_con_maRIA1');
+check('getContact resolves the contact', contact.name === 'Maria Papadopoulos');
+const invite = await podium.requestReview(REP, { contactUid: 'pod_con_maRIA1' });
+check('requestReview sends an invite', invite.status === 'sent');
+
+console.log(`\nAll ${passed} checks passed ✅`);


### PR DESCRIPTION
## F1 — Per-user Podium OAuth + service module · increment 1 of a Large feature

The backbone service the rest of the Podium phase (F1b, F2, F3, F8) imports. Built **mock-first** behind `PODIUM_MOCK=true` (Golden Rule 6) so this Preview works with no live Podium credentials. Coded against the verified API reference in `execution-plan.md` §15.

### What's in this increment
- **`lib/podium.js`** — per-user OAuth (`buildAuthorizeUrl`, `exchangeCode`, `refreshAccessToken`; 10h token TTL), `podium_oauth` token store (`getStoredToken`/`saveUserToken`/`tokenForUser`) with proactive auto-refresh inside a 5-min skew and a one-shot 401-refresh retry, a `request()` wrapper (Bearer + **pinned** `PODIUM_API_VERSION` header + 429/5xx backoff), a cursor-pagination helper, and the §15.4 endpoint helpers: `listConversations`, `getConversation`, `listMessages`, `sendMessage`, `getAssignee`, `assignConversation`, `getUsers`, `getContact`, `requestReview`.
- **`lib/podium.mock.js`** — typed in-memory fixtures shaped exactly like the live v4 responses (cursor envelope `{data, metadata:{nextCursor}}`, `conversation.channel.{type,identifier}`, `assignedUser.uid`, the deprecated `contact` hint) + OAuth mock. `request()` routes here while `PODIUM_MOCK=true`.
- **`scripts/podium-smoke.mjs`** — offline smoke (no network / DB / secrets): `node scripts/podium-smoke.mjs` → **27 checks pass**.

### Not in this increment (deferred, tracked in MEMORY.md)
- OAuth HTTP endpoints (`api/podium/oauth/start.js`, `callback.js`, `status.js`) + real `podium_oauth` round-trip against the Neon dev branch — increment 2.
- Settings "Connect my Podium account" UI, gated to `sales`-role holders via `lib/rbac.js` `hasRole` — increment 3 (after this backbone lands).

### Guardrails
- **No schema change** — `podium_oauth` (§4.2) already shipped in F0's `0001_podium.sql`.
- **No `src/` changes** — CRA build unaffected (`main.c51b66b2.js`, `Compiled successfully`).
- **P1 upheld** — the service performs no DB writes of message bodies; Podium stays the system of record.
- Preview is dev-DB scoped with `PODIUM_MOCK=true` / `FEATURE_MYOB=false`. **Do not merge** — review gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
