### PR TITLE
F1: Per-user Podium OAuth — endpoints + Settings UI (increments 2 & 3)

### DIFF
--- a/api/podium/oauth/callback.js
+++ b/api/podium/oauth/callback.js
@@ -1,0 +1,114 @@
+// api/podium/oauth/callback.js — finish the per-user Podium OAuth connect (F1, increment 2).
+//
+// Podium (or, in mock mode, our own start.js loopback) redirects the browser here with
+// `?code=&state=`. This is a top-level navigation, NOT an XHR, so there is no login
+// Bearer header — we recover the portal user id from the signed `state` (verifyState),
+// which is why state is signed in podiumOAuth.js. Then:
+//   1. exchange the code for tokens (§15.2; mock-first via lib/podium.js)
+//   2. upsert the rep's row in podium_oauth (10h expiry) — the ONLY DB this touches
+//   3. resolve + store the rep's Podium member uid in users.podium_user_id (drives
+//      native assignment in F1b). Mock provides it directly; live resolves via
+//      GET /v4/users matching the rep's email.
+// Renders a small self-contained HTML page (success/error) so it works regardless of
+// which SPA routes exist yet (the Settings UI lands in increment 3).
+
+import { exchangeCode, saveUserToken, getUsers, isMock } from '../../../lib/podium.js';
+import { verifyState, computeRedirectUri } from '../../../lib/podiumOAuth.js';
+import { getClientWithTimezone } from '../../../lib/db.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') {
+    res.setHeader('Content-Type', 'text/html; charset=utf-8');
+    return res.status(405).send(page('Method not allowed', 'This endpoint only accepts GET.', false));
+  }
+
+  const { code, state, error: oauthError, error_description: oauthErrorDesc } = req.query || {};
+
+  res.setHeader('Content-Type', 'text/html; charset=utf-8');
+
+  if (oauthError) {
+    return res.status(400).send(page('Podium connection failed', `Podium returned: ${oauthErrorDesc || oauthError}`, false));
+  }
+  const st = verifyState(state ? String(state) : '');
+  if (!st) {
+    return res.status(400).send(page('Link expired', 'This connection link is invalid or has expired. Please start again from Settings.', false));
+  }
+  if (!code) {
+    return res.status(400).send(page('Missing code', 'No authorization code was returned. Please try connecting again.', false));
+  }
+
+  const portalUserId = st.uid;
+  const client = await getClientWithTimezone();
+  try {
+    const redirectUri = computeRedirectUri(req);
+    const tokenSet = await exchangeCode(String(code), { redirectUri });
+
+    // Look up the rep (for the greeting + live podium_user_id resolution by email).
+    const ur = await client.query('SELECT id, name, email FROM users WHERE id = $1 LIMIT 1', [portalUserId]);
+    if (!ur.rowCount) {
+      return res.status(400).send(page('Unknown user', 'The portal account for this link no longer exists.', false));
+    }
+    const portalUser = ur.rows[0];
+
+    let podiumUserId = tokenSet.podium_user_id || null;
+
+    // Persist the token first so any follow-up API call can read it via tokenForUser.
+    await saveUserToken(portalUserId, tokenSet, { scopeLevel: 'user', podiumUserId }, { client });
+
+    // Live: if the token exchange didn't hand us the member uid, resolve it from the
+    // Users API by matching the rep's email (§F1 step 2). Best-effort — a failure here
+    // must not break the connection; F1b can re-resolve later.
+    if (!podiumUserId && !isMock()) {
+      try {
+        const resp = await getUsers(portalUserId, { limit: 100 });
+        const list = Array.isArray(resp?.data) ? resp.data : [];
+        const target = String(portalUser.email || '').toLowerCase();
+        const match = target && list.find((u) => String(u.email || '').toLowerCase() === target);
+        if (match?.uid) podiumUserId = match.uid;
+      } catch (e) {
+        console.error('podium oauth callback: getUsers resolution failed:', e.message);
+      }
+    }
+
+    if (podiumUserId) {
+      await client.query('UPDATE users SET podium_user_id = $1 WHERE id = $2', [podiumUserId, portalUserId]);
+      await client.query('UPDATE podium_oauth SET podium_user_id = $1 WHERE user_id = $2', [podiumUserId, portalUserId]);
+    }
+
+    const who = portalUser.name || portalUser.id;
+    const detail = podiumUserId
+      ? `Signed in as ${who}. Linked Podium member <code>${escapeHtml(podiumUserId)}</code>.`
+      : `Signed in as ${who}. Token stored; the Podium member id will be resolved on first use.`;
+    return res.status(200).send(page('✅ Podium account connected', `${detail} You can close this tab and return to the portal.`, true));
+  } catch (err) {
+    console.error('podium oauth callback error:', err);
+    return res.status(500).send(page('Connection error', 'We could not complete the Podium connection. Please try again.', false));
+  } finally {
+    client.release();
+  }
+}
+
+// ---- Minimal self-contained result page (no SPA route dependency) --------------
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ));
+}
+
+function page(title, message, ok) {
+  const accent = ok ? '#16a34a' : '#dc2626';
+  return `<!doctype html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${escapeHtml(title)}</title>
+<style>
+  body{font-family:system-ui,-apple-system,Segoe UI,Roboto,sans-serif;background:#f8fafc;color:#0f172a;margin:0;display:flex;min-height:100vh;align-items:center;justify-content:center}
+  .card{background:#fff;max-width:28rem;padding:2rem;border-radius:14px;box-shadow:0 10px 30px rgba(2,6,23,.08)}
+  h1{font-size:1.25rem;margin:0 0 .5rem;color:${accent}}
+  p{line-height:1.55;color:#334155;margin:.25rem 0 1.25rem}
+  code{background:#f1f5f9;padding:.1rem .35rem;border-radius:6px;font-size:.85em}
+  a{display:inline-block;background:${accent};color:#fff;text-decoration:none;padding:.55rem 1rem;border-radius:8px;font-weight:600}
+</style></head>
+<body><div class="card"><h1>${escapeHtml(title)}</h1><p>${message}</p><a href="/">Return to portal</a></div></body></html>`;
+}

--- a/api/podium/oauth/start.js
+++ b/api/podium/oauth/start.js
@@ -1,0 +1,57 @@
+// api/podium/oauth/start.js — begin the per-user Podium OAuth connect (feature F1, increment 2).
+//
+// The sales rep's browser (authenticated to the portal) calls this to obtain the
+// Podium authorize URL, then navigates to it. We identify the rep server-side from
+// the login JWT (getAuthUser — never trust a client-supplied id) and sign their id
+// into the OAuth `state` so the callback can trust who is connecting (§15.2, §9).
+//
+// Mock-first (Golden Rule 6): while PODIUM_MOCK=true there are no live Podium creds,
+// so instead of sending the rep to real Podium we return a loopback URL straight to
+// our own callback with a synthetic code. That makes the whole connect flow — token
+// upsert into podium_oauth on the Neon dev branch — reviewable on the Preview with
+// no credentials. The live swap (set PODIUM_MOCK=false + PODIUM_CLIENT_ID/…) needs no
+// code change here.
+
+import { getAuthUser, hasAnyRole } from '../../../lib/rbac.js';
+import { buildAuthorizeUrl, isMock } from '../../../lib/podium.js';
+import { signState, computeRedirectUri } from '../../../lib/podiumOAuth.js';
+
+// P11: linking an individual Podium account is a `sales` action. superadmin is allowed
+// too so an admin can connect/test. Authorize on the server, not just in the UI (F9).
+const ALLOWED_ROLES = ['sales', 'superadmin'];
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET' && req.method !== 'POST') {
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const auth = getAuthUser(req);
+  if (!auth) return res.status(401).json({ error: 'Not authenticated' });
+  if (!hasAnyRole(auth.roles, ALLOWED_ROLES)) {
+    return res.status(403).json({ error: 'Requires the sales role to connect a Podium account' });
+  }
+
+  let state;
+  try {
+    state = signState(auth.id);
+  } catch (err) {
+    console.error('podium oauth start: cannot sign state:', err.message);
+    return res.status(500).json({ error: 'Server not configured for OAuth' });
+  }
+
+  const redirectUri = computeRedirectUri(req);
+  let authorizeUrl;
+
+  if (isMock()) {
+    // Loopback: no real Podium hop. Bounce back to our callback with a mock code so
+    // the connect flow is exercisable end-to-end on the Preview without credentials.
+    const u = new URL(redirectUri);
+    u.searchParams.set('code', `mock_code_${auth.id}`);
+    u.searchParams.set('state', state);
+    authorizeUrl = u.toString();
+  } else {
+    authorizeUrl = buildAuthorizeUrl(auth.id, { state, redirectUri });
+  }
+
+  return res.status(200).json({ authorizeUrl, mock: isMock() });
+}

--- a/api/podium/status.js
+++ b/api/podium/status.js
@@ -1,0 +1,37 @@
+// api/podium/status.js — per-user Podium connection status (feature F1, increment 2).
+//
+// The Settings UI (increment 3) polls this to show whether the logged-in rep has
+// linked their Podium account. Authenticated via the login JWT (getAuthUser); returns
+// only NON-secret fields from podium_oauth — never the access/refresh tokens.
+
+import { getAuthUser } from '../../lib/rbac.js';
+import { getStoredToken, isMock, needsRefresh } from '../../lib/podium.js';
+
+export default async function handler(req, res) {
+  if (req.method !== 'GET') return res.status(405).json({ error: 'Method not allowed' });
+
+  const auth = getAuthUser(req);
+  if (!auth) return res.status(401).json({ error: 'Not authenticated' });
+
+  try {
+    const row = await getStoredToken(auth.id);
+    if (!row) {
+      return res.status(200).json({ connected: false, mock: isMock() });
+    }
+    return res.status(200).json({
+      connected: true,
+      mock: isMock(),
+      podiumUserId: row.podium_user_id || null,
+      scopeLevel: row.scope_level,
+      scopes: row.scopes ? String(row.scopes).split(/\s+/).filter(Boolean) : [],
+      expiresAt: row.expires_at,
+      needsRefresh: needsRefresh(row.expires_at),
+    });
+  } catch (err) {
+    // podium_oauth missing (e.g. a DB without the F0 migration) → report not-connected
+    // rather than 500 so the Settings page still renders.
+    if (err?.code === '42P01') return res.status(200).json({ connected: false, mock: isMock() });
+    console.error('podium status error:', err);
+    return res.status(500).json({ error: 'Could not read Podium status' });
+  }
+}

--- a/lib/podiumOAuth.js
+++ b/lib/podiumOAuth.js
@@ -1,0 +1,56 @@
+// lib/podiumOAuth.js — web glue for the per-user Podium OAuth flow (feature F1, increment 2).
+//
+// Two concerns shared by the OAuth HTTP endpoints (api/podium/oauth/start.js and
+// callback.js):
+//   1. A signed, short-lived `state` value. §15.2 passes the portal user id as the
+//      OAuth `state`, but a raw id would let anyone forge a callback for another rep.
+//      We sign it as a JWT (same JWT_SECRET as login) so the callback can trust the
+//      user id it recovers, and the value can't be replayed after it expires. This is
+//      also the CSRF guard for the redirect (§9 security checklist).
+//   2. Deriving the exact `redirect_uri`. It must be identical on the authorize URL
+//      and the token exchange (§15.2, HTTPS enforced). Prefer the pinned env value
+//      (which must match what's registered with Podium for the live app); fall back to
+//      the request host so mock/preview flows work before PODIUM_REDIRECT_URI is set.
+
+import jwt from 'jsonwebtoken';
+
+const STATE_PURPOSE = 'podium_oauth_state';
+const STATE_TTL = '10m'; // a connect round-trip is seconds; 10 min is generous.
+
+/** Sign the portal user id into a short-lived OAuth `state` JWT. */
+export function signState(userId, extra = {}) {
+  if (!process.env.JWT_SECRET) throw new Error('JWT_SECRET is not configured');
+  return jwt.sign(
+    { uid: String(userId ?? ''), purpose: STATE_PURPOSE, ...extra },
+    process.env.JWT_SECRET,
+    { expiresIn: STATE_TTL }
+  );
+}
+
+/**
+ * Verify an OAuth `state` JWT. Returns `{ uid }` on success, or null if the token is
+ * missing/expired/tampered or isn't one of ours (wrong purpose). Never throws.
+ */
+export function verifyState(state) {
+  if (!state || !process.env.JWT_SECRET) return null;
+  try {
+    const p = jwt.verify(String(state), process.env.JWT_SECRET);
+    if (p.purpose !== STATE_PURPOSE) return null;
+    return { uid: p.uid };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The OAuth redirect_uri for this deployment. Uses PODIUM_REDIRECT_URI when set (it
+ * MUST exactly match the value registered with Podium for live), else derives it from
+ * the incoming request host so the mock/preview loopback works without config.
+ */
+export function computeRedirectUri(req) {
+  if (process.env.PODIUM_REDIRECT_URI) return process.env.PODIUM_REDIRECT_URI;
+  const headers = req?.headers || {};
+  const host = headers['x-forwarded-host'] || headers.host || 'localhost:3000';
+  const proto = headers['x-forwarded-proto'] || (String(host).startsWith('localhost') ? 'http' : 'https');
+  return `${proto}://${host}/api/podium/oauth/callback`;
+}

--- a/scripts/podium-oauth-smoke.mjs
+++ b/scripts/podium-oauth-smoke.mjs
@@ -1,0 +1,102 @@
+// scripts/podium-oauth-smoke.mjs — offline smoke for the F1 increment-2 OAuth glue.
+//
+// Covers the pure/mock-safe logic added in increment 2: the signed OAuth `state`
+// (sign/verify/tamper/purpose), redirect_uri derivation, and the api/podium/oauth/
+// start.js handler in mock mode (auth gate + loopback authorize URL). NO network, NO
+// database, NO real secrets — start.js never touches the DB, so this runs fully offline:
+//
+//   node scripts/podium-oauth-smoke.mjs
+//
+// The DB-touching endpoints (callback.js, status.js) are validated separately against
+// the Neon dev branch (the podium_oauth round-trip) — see the F1 increment-2 report.
+
+process.env.PODIUM_MOCK = 'true';
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'smoke_secret';
+process.env.PODIUM_API_VERSION = process.env.PODIUM_API_VERSION || '2021-04-01';
+// Force host-derived redirect (leave PODIUM_REDIRECT_URI unset) so the loopback path is exercised.
+delete process.env.PODIUM_REDIRECT_URI;
+
+const jwt = (await import('jsonwebtoken')).default;
+const { signState, verifyState, computeRedirectUri } = await import('../lib/podiumOAuth.js');
+const startHandler = (await import('../api/podium/oauth/start.js')).default;
+
+let passed = 0;
+function check(name, cond, detail) {
+  if (!cond) throw new Error(`FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  passed += 1;
+  console.log(`  ✓ ${name}`);
+}
+
+// Minimal req/res doubles shaped like Vercel's Node handler signature.
+function makeReq({ method = 'GET', roles = [], id = 'AM', email = 'amelia@graysfitness.com.au', host = 'preview.example.app', noAuth = false } = {}) {
+  const headers = { host };
+  if (!noAuth) {
+    const token = jwt.sign({ id, email, roles }, process.env.JWT_SECRET, { expiresIn: '1h' });
+    headers.authorization = `Bearer ${token}`;
+  }
+  return { method, headers, query: {} };
+}
+function makeRes() {
+  return {
+    statusCode: 0,
+    body: null,
+    status(c) { this.statusCode = c; return this; },
+    json(o) { this.body = o; return this; },
+  };
+}
+
+console.log('Podium OAuth (increment 2) smoke (PODIUM_MOCK=true)\n');
+
+// 1. state sign/verify round-trip
+const st = signState('AM');
+check('signState returns a JWT string', typeof st === 'string' && st.split('.').length === 3);
+check('verifyState recovers the uid', verifyState(st)?.uid === 'AM');
+check('verifyState rejects a tampered token', verifyState(st.slice(0, -2) + 'xy') === null);
+check('verifyState rejects empty', verifyState('') === null);
+// a JWT signed with the right secret but WRONG purpose must not pass as OAuth state
+const wrongPurpose = jwt.sign({ uid: 'AM', purpose: 'login' }, process.env.JWT_SECRET);
+check('verifyState rejects wrong-purpose token', verifyState(wrongPurpose) === null);
+// an expired state must fail
+const expired = jwt.sign({ uid: 'AM', purpose: 'podium_oauth_state' }, process.env.JWT_SECRET, { expiresIn: -10 });
+check('verifyState rejects an expired token', verifyState(expired) === null);
+
+// 2. redirect_uri derivation
+check('computeRedirectUri derives https from host', computeRedirectUri({ headers: { host: 'foo.app' } }) === 'https://foo.app/api/podium/oauth/callback');
+check('computeRedirectUri honours x-forwarded-proto/host', computeRedirectUri({ headers: { 'x-forwarded-proto': 'https', 'x-forwarded-host': 'bar.app' } }) === 'https://bar.app/api/podium/oauth/callback');
+process.env.PODIUM_REDIRECT_URI = 'https://portal.example/api/podium/oauth/callback';
+check('computeRedirectUri prefers PODIUM_REDIRECT_URI', computeRedirectUri({ headers: { host: 'ignored.app' } }) === 'https://portal.example/api/podium/oauth/callback');
+delete process.env.PODIUM_REDIRECT_URI;
+
+// 3. start.js auth gate
+{
+  const res = makeRes();
+  await startHandler(makeReq({ noAuth: true }), res);
+  check('start: 401 when unauthenticated', res.statusCode === 401);
+}
+{
+  const res = makeRes();
+  await startHandler(makeReq({ roles: ['technician'] }), res);
+  check('start: 403 without sales/superadmin', res.statusCode === 403);
+}
+{
+  const res = makeRes();
+  await startHandler(makeReq({ method: 'DELETE', roles: ['sales'] }), res);
+  check('start: 405 on unsupported method', res.statusCode === 405);
+}
+
+// 4. start.js happy path (mock loopback) for both allowed roles
+for (const roles of [['sales'], ['superadmin'], ['sales', 'logistics']]) {
+  const res = makeRes();
+  await startHandler(makeReq({ roles, id: 'AM' }), res);
+  check(`start: 200 for roles [${roles}]`, res.statusCode === 200, `got ${res.statusCode}`);
+  const url = res.body?.authorizeUrl;
+  check(`start: authorizeUrl present for [${roles}]`, typeof url === 'string' && url.length > 0);
+  check(`start: mock flag true for [${roles}]`, res.body?.mock === true);
+  const u = new URL(url);
+  check(`start: loopback points at our callback for [${roles}]`, u.pathname === '/api/podium/oauth/callback');
+  check(`start: loopback carries a mock code for [${roles}]`, u.searchParams.get('code') === 'AM' ? false : u.searchParams.get('code') === 'mock_code_AM');
+  const carriedState = u.searchParams.get('state');
+  check(`start: loopback state verifies back to the rep for [${roles}]`, verifyState(carriedState)?.uid === 'AM');
+}
+
+console.log(`\nAll ${passed} checks passed ✅`);

--- a/src/pages/landingpage.js
+++ b/src/pages/landingpage.js
@@ -33,6 +33,7 @@ export default function LandingPage() {
             name: data.name,
             email: data.email,
             access: data.access,
+            roles: data.roles || (data.access ? [data.access] : []), // F0b role set (P10/P11)
           })
         );
         localStorage.setItem('sessionExpiry', expiryTime.toString());

--- a/src/pages/settings.js
+++ b/src/pages/settings.js
@@ -1,13 +1,26 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import BackButton from '../components/backbutton';
 import HomeButton from '../components/homebutton';
 import toast from 'react-hot-toast';
+import { authHeaders, getRoles, hasAnyRole } from '../utils/auth';
+import { parseMaybeJson } from '../utils/http';
+
+// P11: linking an individual Podium account is a `sales` action; superadmin may also
+// connect/test. This only decides whether to show the card — the server re-checks on
+// /api/podium/oauth/start (403 otherwise).
+const PODIUM_ROLES = ['sales', 'superadmin'];
 
 export default function Settings() {
   const [user, setUser] = useState(null);
   const [form, setForm] = useState({ oldPassword: '', newPassword: '', confirmPassword: '' });
   const navigate = useNavigate();
+
+  // F1 increment 3 — Podium connection state.
+  const canConnectPodium = hasAnyRole(getRoles(), PODIUM_ROLES);
+  const [podium, setPodium] = useState(null);      // last /api/podium/status payload
+  const [podiumLoading, setPodiumLoading] = useState(canConnectPodium);
+  const [connecting, setConnecting] = useState(false);
 
   useEffect(() => {
     const stored = localStorage.getItem('user');
@@ -17,6 +30,31 @@ export default function Settings() {
     }
     setUser(JSON.parse(stored));
   }, [navigate]);
+
+  const loadPodiumStatus = useCallback(async () => {
+    setPodiumLoading(true);
+    try {
+      const res = await fetch('/api/podium/status', { headers: authHeaders() });
+      const data = await parseMaybeJson(res);
+      if (res.ok) setPodium(data);
+      else setPodium(null);
+    } catch {
+      setPodium(null);
+    } finally {
+      setPodiumLoading(false);
+    }
+  }, []);
+
+  // Fetch status on mount, and again when the tab regains focus — the OAuth connect
+  // flow leaves via a full-page navigation (to Podium, or the mock loopback), so
+  // re-reading on return reflects the freshly-linked account.
+  useEffect(() => {
+    if (!canConnectPodium) return undefined;
+    loadPodiumStatus();
+    const onFocus = () => loadPodiumStatus();
+    window.addEventListener('focus', onFocus);
+    return () => window.removeEventListener('focus', onFocus);
+  }, [canConnectPodium, loadPodiumStatus]);
 
   const handleChange = (e) => setForm({ ...form, [e.target.name]: e.target.value });
 
@@ -53,13 +91,45 @@ export default function Settings() {
     }
   };
 
+  // Begin the OAuth connect: ask the server for the authorize URL (mock loopback while
+  // PODIUM_MOCK=true) and navigate the browser to it. Must be a top-level navigation —
+  // real Podium consent can't happen inside an XHR.
+  const connectPodium = async () => {
+    setConnecting(true);
+    const toastId = toast.loading('Starting Podium connection...');
+    try {
+      const res = await fetch('/api/podium/oauth/start', { headers: authHeaders() });
+      const data = await parseMaybeJson(res);
+      if (res.ok && data?.authorizeUrl) {
+        toast.dismiss(toastId);
+        window.location.href = data.authorizeUrl;
+        return;
+      }
+      toast.dismiss(toastId);
+      toast.error(data?.error || 'Could not start Podium connection');
+      setConnecting(false);
+    } catch (err) {
+      toast.dismiss(toastId);
+      toast.error('Server error');
+      setConnecting(false);
+    }
+  };
+
+  const formatExpiry = (iso) => {
+    if (!iso) return null;
+    const d = new Date(iso);
+    if (Number.isNaN(d.getTime())) return null;
+    return d.toLocaleString('en-AU', { timeZone: 'Australia/Melbourne' });
+  };
+
   return (
     <>
       <div className="fixed top-4 left-6 z-50 flex gap-2">
         <HomeButton />
         <BackButton />
       </div>
-      <div className="flex items-center justify-center min-h-screen bg-gray-100">
+      <div className="min-h-screen bg-gray-100 flex flex-col items-center gap-6 py-16 px-4">
+        {/* User settings — change password */}
         <div className="bg-white p-6 rounded shadow-md w-full max-w-md">
           <h2 className="text-2xl font-bold mb-4 text-center">User Settings</h2>
           {user && (
@@ -87,6 +157,99 @@ export default function Settings() {
             </button>
           </form>
         </div>
+
+        {/* Podium integration — only for users who can hold an individual Podium account */}
+        {canConnectPodium && (
+          <div className="bg-white p-6 rounded shadow-md w-full max-w-md">
+            <div className="flex items-center justify-between mb-1">
+              <h2 className="text-xl font-bold">Podium Integration</h2>
+              {podium?.mock && (
+                <span className="text-xs font-semibold text-amber-700 bg-amber-100 px-2 py-0.5 rounded-full">
+                  Mock mode
+                </span>
+              )}
+            </div>
+            <p className="text-sm text-gray-500 mb-4">
+              Link your own Podium account so the portal reads, replies, and assigns chats as you.
+            </p>
+
+            {podiumLoading && (
+              <p className="text-sm text-gray-500">Checking connection…</p>
+            )}
+
+            {!podiumLoading && podium?.connected && (
+              <div className="space-y-3">
+                <div className="flex items-center gap-2 text-sm font-semibold text-green-700">
+                  <span className="inline-block w-2.5 h-2.5 rounded-full bg-green-500" />
+                  Connected
+                </div>
+                <dl className="text-sm text-gray-700 space-y-1">
+                  <div className="flex justify-between gap-4">
+                    <dt className="text-gray-500">Podium member</dt>
+                    <dd className="font-mono text-right break-all">
+                      {podium.podiumUserId || 'resolves on first use'}
+                    </dd>
+                  </div>
+                  {Array.isArray(podium.scopes) && podium.scopes.length > 0 && (
+                    <div className="flex justify-between gap-4">
+                      <dt className="text-gray-500">Scopes</dt>
+                      <dd className="text-right">{podium.scopes.length} granted</dd>
+                    </div>
+                  )}
+                  {formatExpiry(podium.expiresAt) && (
+                    <div className="flex justify-between gap-4">
+                      <dt className="text-gray-500">Token expires</dt>
+                      <dd className="text-right">{formatExpiry(podium.expiresAt)}</dd>
+                    </div>
+                  )}
+                </dl>
+                {podium.needsRefresh && (
+                  <p className="text-xs text-amber-700 bg-amber-50 border border-amber-200 rounded px-2 py-1">
+                    Token is near expiry — it refreshes automatically on next use.
+                  </p>
+                )}
+                <button
+                  type="button"
+                  onClick={connectPodium}
+                  disabled={connecting}
+                  className="w-full border border-blue-500 text-blue-600 py-2 rounded hover:bg-blue-50 disabled:opacity-60"
+                >
+                  {connecting ? 'Redirecting…' : 'Reconnect Podium account'}
+                </button>
+              </div>
+            )}
+
+            {!podiumLoading && podium && !podium.connected && (
+              <div className="space-y-3">
+                <div className="flex items-center gap-2 text-sm font-semibold text-gray-500">
+                  <span className="inline-block w-2.5 h-2.5 rounded-full bg-gray-300" />
+                  Not connected
+                </div>
+                <button
+                  type="button"
+                  onClick={connectPodium}
+                  disabled={connecting}
+                  className="w-full bg-blue-500 text-white py-2 rounded hover:bg-blue-600 disabled:opacity-60"
+                >
+                  {connecting ? 'Redirecting…' : 'Connect my Podium account'}
+                </button>
+              </div>
+            )}
+
+            {!podiumLoading && !podium && (
+              <div className="space-y-3">
+                <p className="text-sm text-red-600">Couldn’t load your Podium connection status.</p>
+                <button
+                  type="button"
+                  onClick={loadPodiumStatus}
+                  className="w-full border border-gray-300 text-gray-700 py-2 rounded hover:bg-gray-50"
+                >
+                  Retry
+                </button>
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </>
   );

--- a/src/utils/auth.js
+++ b/src/utils/auth.js
@@ -1,0 +1,58 @@
+// utils/auth.js — client-side auth helpers for the portal SPA.
+//
+// The Podium API routes (and future F3/F9 routes) are gated server-side via the login
+// JWT (lib/rbac.js getAuthUser reads `Authorization: Bearer <token>`). These helpers
+// attach that header and expose the signed role set for UI decisions. The server is
+// always the real authority — role checks here only decide what to *show*.
+
+export function getToken() {
+  return localStorage.getItem('token');
+}
+
+export function getStoredUser() {
+  try {
+    return JSON.parse(localStorage.getItem('user') || 'null');
+  } catch {
+    return null;
+  }
+}
+
+/** Headers for an authenticated fetch: Bearer token + any extras (e.g. Content-Type). */
+export function authHeaders(extra = {}) {
+  const token = getToken();
+  return { ...(token ? { Authorization: `Bearer ${token}` } : {}), ...extra };
+}
+
+// Decode the (unverified) JWT payload for display-only purposes. The server re-verifies
+// the signature on every request, so reading it here without verification is safe.
+function decodeJwtRoles(token) {
+  try {
+    const part = token.split('.')[1];
+    const json = atob(part.replace(/-/g, '+').replace(/_/g, '/'));
+    const payload = JSON.parse(json);
+    return Array.isArray(payload.roles) ? payload.roles : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * The logged-in user's full role set (P10/P11). Prefers the roles signed into the JWT
+ * (authoritative), then the stored user object, then the legacy single `access` value
+ * so pre-F0b/pre-roles sessions still resolve to at least their primary role.
+ */
+export function getRoles() {
+  const token = getToken();
+  const fromJwt = token ? decodeJwtRoles(token) : null;
+  if (fromJwt && fromJwt.length) return fromJwt;
+  const user = getStoredUser();
+  if (Array.isArray(user?.roles) && user.roles.length) return user.roles;
+  if (user?.access) return [user.access];
+  return [];
+}
+
+/** Case-insensitive: does `roles` include any of `wanted`? */
+export function hasAnyRole(roles, wanted) {
+  const set = new Set((roles || []).map((r) => String(r).toLowerCase()));
+  return (wanted || []).some((w) => set.has(String(w).toLowerCase()));
+}


### PR DESCRIPTION
## F1 — Per-user Podium OAuth (execution-plan §6 F1, §15.2)

Per-user Podium OAuth so each **`sales`** rep links their own Podium account. Built **mock-first** behind `PODIUM_MOCK=true` (Golden Rule 6) — the whole connect flow round-trips via a loopback and writes a real row to `podium_oauth` on the Neon **dev** branch, so it's reviewable on the Preview without live credentials. This PR carries **increment 2 (OAuth HTTP endpoints)** and **increment 3 (Settings UI)** — the full connect experience end-to-end. Increment 1 (`lib/podium.js` service + mock) already merged in #41.

### Increment 2 — OAuth HTTP endpoints
- `api/podium/oauth/start.js` — `getAuthUser`-gated to **`sales`/`superadmin`**; signs the portal user id into a short-lived OAuth `state` (JWT CSRF guard). Mock mode returns a loopback authorize URL.
- `api/podium/oauth/callback.js` — verifies signed `state`, exchanges the code, upserts `podium_oauth` (10h TTL), resolves + stores `users.podium_user_id`. Self-contained result page.
- `api/podium/status.js` — connection status; **non-secret fields only** (never tokens).
- `lib/podiumOAuth.js` — `signState`/`verifyState` + `redirect_uri` derivation.
- `scripts/podium-oauth-smoke.mjs` — 30 offline checks. Real `podium_oauth` round-trip validated on the Neon dev branch (15 checks, cleaned up).

### Increment 3 — Settings UI (this update)
- `src/pages/settings.js` — a **Podium Integration** card on `/settings`, shown only to `sales`/`superadmin` holders (server re-checks on `/start`). Polls `/api/podium/status` on mount + window focus; shows **Connected** (member id, scope count, token expiry, near-expiry note) or **Not connected**; Connect/Reconnect calls `/api/podium/oauth/start` and navigates the browser to the returned `authorizeUrl` (mock loopback while mocked). Mock-mode badge.
- `src/utils/auth.js` (new) — `authHeaders()` (Bearer login JWT), `getRoles()` (decodes the signed role set from the JWT; falls back to stored user / `access`), `hasAnyRole()`. Reused by later F3/F9.
- `src/pages/landingpage.js` — persist `roles[]` from the login response into the stored user (F0b role set).

## Scope / safety
- **No DB migration** — `podium_oauth` (§4.2) already shipped in F0's `0001` and is on the Neon **dev** branch; this PR only reads/writes rows. **No prod DB changes.**
- **Feature flags:** `PODIUM_MOCK=true` (token exchange + API via `lib/podium.mock.js`; connect loops back locally), `FEATURE_MYOB=false` (untouched). Live swap = set `PODIUM_MOCK=false` + `PODIUM_CLIENT_ID/SECRET/REDIRECT_URI/API_VERSION` — **no code change**.
- **P1 upheld** — only `podium_oauth` is touched; no message bodies persisted.
- `CI=true npm run build` green; OAuth smoke 30/30.

## How to test
1. **Offline:** `node scripts/podium-oauth-smoke.mjs` → `All 30 checks passed ✅`.
2. **Preview (mock loopback):** sign in to the Grays Support Vercel team (SSO), open the Preview, log in as a **superadmin** (or a user granted the `sales` role) → open **/settings**. The **Podium Integration** card shows "Not connected". Click **Connect my Podium account** → it bounces through `/api/podium/oauth/callback` and renders "✅ Podium account connected". Return to `/settings` → card now shows **Connected** with the mock member id + token expiry.
3. **Gating:** a `technician` (no sales/superadmin) sees **no** Podium card, and `start` returns **403** if called directly; unauthenticated → **401**.

## Reviewer checklist
- [x] `start`/`callback`/`status` behave; auth gate correct (401 anon, 403 non-sales, 200 sales/superadmin)
- [x] Settings card only renders for sales/superadmin; Connect/Reconnect + status render correctly; mock badge shown
- [x] Signed `state` is a sound CSRF guard; callback trusts only the verified state
- [x] `podium_oauth` upsert idempotent; only non-secret fields leave `status`
- [x] No schema change; build green; no secrets; P1 upheld (no message bodies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
