### PR TITLE
F1b: Native conversation assignment — portal → Podium

### DIFF
--- a/api/podium/assign.js
+++ b/api/podium/assign.js
@@ -1,0 +1,113 @@
+// api/podium/assign.js — native conversation assignment, PORTAL → PODIUM (feature F1b).
+//
+// Keeps Podium's native "assigned to" identical to the portal owner, driven by the
+// logged-in rep (execution-plan.md §F1b step 2, P4). Standalone serverless function
+// (NOT the api/[...path].js catch-all), gated to sales/superadmin via the login JWT.
+//
+//   GET  /api/podium/assign?conversationId=<uid>
+//        → read the conversation's current Podium assignee.
+//   POST /api/podium/assign  { conversationId, userId? }
+//        → assign the conversation. Omit userId to CLAIM it for yourself. The call to
+//          Podium runs on the ACTING rep's token; the assignee is the TARGET user's
+//          Podium member uid. The owner is also mirrored onto the matching lead.
+//
+// Mock-first (Golden Rule 6): with PODIUM_MOCK=true the Podium hop is served by
+// lib/podium.mock.js, so the flow is reviewable on the Preview without live creds.
+// The Podium → portal direction (assignment webhook → leads.assigned_to) lands with
+// F2's webhook receiver and reuses mirrorAssignmentToLead() from lib/podiumAssign.js.
+//
+// P1: no message bodies are read or written here — only CRM metadata (the assignee).
+
+import { getAuthUser, hasAnyRole } from '../../lib/rbac.js';
+import { assignConversation, getAssignee, isMock } from '../../lib/podium.js';
+import { resolvePodiumUserId, mirrorAssignmentToLead } from '../../lib/podiumAssign.js';
+import { getClientWithTimezone } from '../../lib/db.js';
+
+// P11: working the inbox / owning conversations is a `sales` action; superadmin may
+// also act (support/admin). Server is the real gate (F9), never the client role list.
+const ALLOWED_ROLES = ['sales', 'superadmin'];
+
+export default async function handler(req, res) {
+  const auth = getAuthUser(req);
+  if (!auth) return res.status(401).json({ error: 'Not authenticated' });
+  if (!hasAnyRole(auth.roles, ALLOWED_ROLES)) {
+    return res.status(403).json({ error: 'Requires the sales role to assign conversations' });
+  }
+
+  if (req.method === 'GET') return handleGet(req, res, auth);
+  if (req.method === 'POST') return handlePost(req, res, auth);
+  return res.status(405).json({ error: 'Method not allowed' });
+}
+
+async function handleGet(req, res, auth) {
+  const conversationId = req.query?.conversationId;
+  if (!conversationId) return res.status(400).json({ error: 'conversationId is required' });
+  try {
+    const a = await getAssignee(auth.id, String(conversationId));
+    return res.status(200).json({
+      conversationId: String(conversationId),
+      assignedPodiumUserId: a?.assignedUser?.uid || null,
+      mock: isMock(),
+    });
+  } catch (err) {
+    return respondUpstreamError(res, err, 'read the conversation assignee');
+  }
+}
+
+async function handlePost(req, res, auth) {
+  const { conversationId, userId } = req.body || {};
+  if (!conversationId) return res.status(400).json({ error: 'conversationId is required' });
+
+  // Default action = claim: assign the conversation to the acting rep.
+  const targetPortalId = userId ? String(userId) : auth.id;
+
+  const client = await getClientWithTimezone();
+  try {
+    const ur = await client.query(
+      'SELECT id, email, podium_user_id FROM users WHERE id = $1 LIMIT 1',
+      [targetPortalId]
+    );
+    if (!ur.rowCount) return res.status(404).json({ error: `Target user ${targetPortalId} not found` });
+    const targetUser = ur.rows[0];
+
+    // Turn the target portal user into their Podium member uid (lazily resolving via
+    // GET /v4/users if it wasn't captured at connect). Runs on the ACTING rep's token.
+    const podiumUserId = await resolvePodiumUserId(client, auth.id, targetUser);
+    if (!podiumUserId) {
+      return res.status(409).json({
+        error: `${targetPortalId === auth.id ? 'You have' : `User ${targetPortalId} has`} not linked a Podium account`,
+        code: 'TARGET_NOT_LINKED',
+      });
+    }
+
+    // Drive Podium's native assignment AS the acting rep (their OAuth token).
+    await assignConversation(auth.id, String(conversationId), podiumUserId);
+
+    // Mirror the owner onto the lead (durable portal side). 0 rows until F2/F5 create
+    // leads — the seam is wired now; the same helper serves F2's inbound webhook.
+    const leadsUpdated = await mirrorAssignmentToLead(client, String(conversationId), targetPortalId);
+
+    return res.status(200).json({
+      conversationId: String(conversationId),
+      assignedTo: targetPortalId,
+      assignedPodiumUserId: podiumUserId,
+      claimed: targetPortalId === auth.id,
+      leadsUpdated,
+      mock: isMock(),
+    });
+  } catch (err) {
+    if (err?.code === 'PODIUM_NOT_CONNECTED') {
+      return res.status(409).json({ error: 'You have not linked a Podium account', code: 'NOT_CONNECTED' });
+    }
+    return respondUpstreamError(res, err, 'assign the conversation');
+  } finally {
+    client.release();
+  }
+}
+
+function respondUpstreamError(res, err, action) {
+  // A 404 from Podium (unknown conversation) is a client error; surface it as 404.
+  if (err?.status === 404) return res.status(404).json({ error: 'Conversation not found in Podium' });
+  console.error(`podium assign: could not ${action}:`, err);
+  return res.status(502).json({ error: `Could not ${action}` });
+}

--- a/lib/podiumAssign.js
+++ b/lib/podiumAssign.js
@@ -1,0 +1,100 @@
+// lib/podiumAssign.js — native conversation-assignment glue (feature F1b).
+//
+// F1b keeps Podium's native "assigned to" and the portal's owner in lockstep, driven
+// by the logged-in rep (execution-plan.md §F1b, P4). This module is the shared,
+// direction-agnostic glue used by:
+//   • the PORTAL → PODIUM direction (api/podium/assign.js, this increment): a rep
+//     claims/assigns a conversation → PUT /v4/conversations/{uid}/assignees AS that
+//     rep → mirror the owner onto the matching lead.
+//   • the PODIUM → PORTAL direction (F2's webhook receiver, later): the
+//     conversation-assignment webhook resolves `data.conversation.assignedUser.uid`
+//     → maps it back to a portal user → calls mirrorAssignmentToLead() with the same
+//     helper, so both directions write the lead the same way.
+//
+// Two concerns live here so both directions stay consistent:
+//   1. resolvePodiumUserId — turn a portal user into their Podium member uid
+//      (users.podium_user_id), lazily resolving + persisting via GET /v4/users
+//      (email match) when it wasn't captured at connect time.
+//   2. mirrorAssignmentToLead — set leads.assigned_to for the conversation. Defensive
+//      against a DB without the leads table (42P01) and a no-op (0 rows) until F2/F5
+//      create leads — the seam is wired now, the rows arrive later.
+//
+// P1 note: nothing here reads or writes message bodies. Only CRM metadata
+// (users.podium_user_id, leads.assigned_to) is touched (execution-plan P1/P3).
+
+import { getUsers } from './podium.js';
+
+/**
+ * Resolve a portal user's Podium member uid (users.podium_user_id).
+ *
+ * Fast path: return the stored id if the user already linked their account
+ * (callback.js captures it at connect time). Fallback: call GET /v4/users AS the
+ * acting rep and match the target's email, then persist it so we never re-resolve.
+ *
+ * @param {object} client        pg client (caller owns the connection/txn)
+ * @param {string} actingUserId  portal id whose Podium token makes the API call
+ * @param {{id:string,email?:string,podium_user_id?:string}} targetUser  the user being assigned
+ * @returns {Promise<string|null>} the Podium member uid, or null if it can't be resolved
+ */
+export async function resolvePodiumUserId(client, actingUserId, targetUser) {
+  if (!targetUser) return null;
+  if (targetUser.podium_user_id) return targetUser.podium_user_id;
+
+  const email = String(targetUser.email || '').toLowerCase().trim();
+  if (!email) return null;
+
+  try {
+    const resp = await getUsers(actingUserId, { limit: 100, client });
+    const list = Array.isArray(resp?.data) ? resp.data : [];
+    const match = list.find((u) => String(u.email || '').toLowerCase() === email);
+    if (match?.uid) {
+      // Persist so subsequent assignments skip the lookup. Only fill when empty so we
+      // never clobber a deliberately-set id.
+      await client.query(
+        `UPDATE users SET podium_user_id = $1
+           WHERE id = $2 AND (podium_user_id IS NULL OR podium_user_id = '')`,
+        [match.uid, targetUser.id]
+      );
+      return match.uid;
+    }
+  } catch (err) {
+    // Best-effort: a resolution failure must not break assignment; the caller decides
+    // how to respond (this increment returns a 409 "not linked").
+    console.error('resolvePodiumUserId failed:', err.message);
+  }
+  return null;
+}
+
+/**
+ * Mirror a conversation's owner onto its lead: set leads.assigned_to for every lead
+ * bound to `conversationUid`. Returns the number of lead rows updated.
+ *
+ * Both F1b directions call this so the lead is written identically whether the change
+ * originated in the portal (this increment) or in Podium (F2 webhook). It is:
+ *   • idempotent — re-running with the same owner is a harmless no-op;
+ *   • forward-compatible — returns 0 (not an error) until F2/F5 create leads;
+ *   • defensive — returns 0 if the leads table isn't migrated yet (42P01), so a DB
+ *     without the F0 migration (e.g. Production pre-release) still serves the request.
+ *
+ * @param {object} client          pg client
+ * @param {string} conversationUid  Podium conversation uid (leads.podium_conversation_id)
+ * @param {string|null} portalUserId  the new owner's portal id (null clears the owner)
+ * @returns {Promise<number>} rows updated
+ */
+export async function mirrorAssignmentToLead(client, conversationUid, portalUserId) {
+  if (!conversationUid) return 0;
+  try {
+    const r = await client.query(
+      `UPDATE leads
+          SET assigned_to = $1, updated_at = NOW()
+        WHERE podium_conversation_id = $2`,
+      [portalUserId || null, conversationUid]
+    );
+    return r.rowCount || 0;
+  } catch (err) {
+    if (err?.code === '42P01') return 0; // leads not migrated on this DB yet
+    throw err;
+  }
+}
+
+export default { resolvePodiumUserId, mirrorAssignmentToLead };

--- a/scripts/podium-assign-smoke.mjs
+++ b/scripts/podium-assign-smoke.mjs
@@ -1,0 +1,169 @@
+// scripts/podium-assign-smoke.mjs — offline smoke for the F1b assignment glue + endpoint.
+//
+// Covers the pure/mock-safe logic added in F1b (portal → Podium direction): the
+// lib/podiumAssign.js helpers (resolvePodiumUserId, mirrorAssignmentToLead) exercised
+// with INJECTED fake pg clients, the mock Podium assign/read helpers, and the
+// api/podium/assign.js auth/validation gates that run BEFORE any DB access. NO network,
+// NO database, NO real secrets:
+//
+//   node scripts/podium-assign-smoke.mjs
+//
+// The DB-touching happy paths (POST assign, GET assignee) are validated separately
+// against the Neon dev branch (leads mirror + users resolution round-trip) — see the
+// F1b report. `getClientWithTimezone()`'s pool is lazy, so importing the endpoint here
+// opens no connection as long as we only hit its pre-DB branches.
+
+process.env.PODIUM_MOCK = 'true';
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'smoke_secret';
+process.env.PODIUM_API_VERSION = process.env.PODIUM_API_VERSION || '2021-04-01';
+
+const jwt = (await import('jsonwebtoken')).default;
+const { resolvePodiumUserId, mirrorAssignmentToLead } = await import('../lib/podiumAssign.js');
+const { assignConversation, getAssignee } = await import('../lib/podium.js');
+const assignHandler = (await import('../api/podium/assign.js')).default;
+
+let passed = 0;
+function check(name, cond, detail) {
+  if (!cond) throw new Error(`FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  passed += 1;
+  console.log(`  ✓ ${name}`);
+}
+
+// ---- Fake pg client: records queries, returns scripted results ----------------
+function makeClient(scripts = []) {
+  // `scripts` = array of { match:(sql)=>bool, result } OR a default {result}. Each call
+  // records the (sql, params) and returns the first matching scripted result.
+  const calls = [];
+  return {
+    calls,
+    async query(sql, params) {
+      calls.push({ sql, params });
+      for (const s of scripts) {
+        if (typeof s.match === 'function' ? s.match(sql) : true) {
+          if (s.throws) throw s.throws;
+          return s.result ?? { rowCount: 0, rows: [] };
+        }
+      }
+      return { rowCount: 0, rows: [] };
+    },
+  };
+}
+function err(code) { const e = new Error(code); e.code = code; return e; }
+
+// ---- req/res doubles (Vercel Node handler shape) ------------------------------
+function makeReq({ method = 'GET', roles = ['sales'], id = 'AM', email = 'amelia@graysfitness.com.au', query = {}, body = {}, noAuth = false } = {}) {
+  const headers = {};
+  if (!noAuth) headers.authorization = `Bearer ${jwt.sign({ id, email, roles }, process.env.JWT_SECRET, { expiresIn: '1h' })}`;
+  return { method, headers, query, body };
+}
+function makeRes() {
+  return {
+    statusCode: 0, body: null,
+    status(c) { this.statusCode = c; return this; },
+    json(o) { this.body = o; return this; },
+  };
+}
+
+console.log('Podium assignment (F1b) smoke (PODIUM_MOCK=true)\n');
+
+// 1. resolvePodiumUserId — fast path: already-linked target, no API/UPDATE
+{
+  const client = makeClient();
+  const uid = await resolvePodiumUserId(client, 'AM', { id: 'BN', email: 'x@y.z', podium_user_id: 'pod_usr_bENjin' });
+  check('resolve: returns stored podium_user_id on fast path', uid === 'pod_usr_bENjin');
+  check('resolve: fast path issues no DB query', client.calls.length === 0);
+}
+
+// 2. resolvePodiumUserId — fallback: email matches a mock Podium user → resolves + persists
+{
+  const client = makeClient([{ match: (s) => /UPDATE users/i.test(s), result: { rowCount: 1 } }]);
+  const uid = await resolvePodiumUserId(client, 'AM', { id: 'AM', email: 'amelia@graysfitness.com.au' });
+  check('resolve: fallback matches mock user by email', uid === 'pod_usr_amELia', `got ${uid}`);
+  check('resolve: fallback persists the resolved uid (UPDATE users)', client.calls.some((c) => /UPDATE users/i.test(c.sql)));
+}
+
+// 3. resolvePodiumUserId — target with no email → null (can't resolve)
+{
+  const uid = await resolvePodiumUserId(makeClient(), 'AM', { id: 'ZZ', email: null });
+  check('resolve: null when target has no email', uid === null);
+}
+
+// 4. resolvePodiumUserId — email that matches no Podium member → null
+{
+  const uid = await resolvePodiumUserId(makeClient(), 'AM', { id: 'ZZ', email: 'nobody@nowhere.example' });
+  check('resolve: null when no Podium member matches', uid === null);
+}
+
+// 5. mirrorAssignmentToLead — returns the DB rowCount
+{
+  const client = makeClient([{ match: (s) => /UPDATE leads/i.test(s), result: { rowCount: 2 } }]);
+  const n = await mirrorAssignmentToLead(client, 'pod_cnv_00001', 'AM');
+  check('mirror: returns rows updated', n === 2);
+  const call = client.calls.find((c) => /UPDATE leads/i.test(c.sql));
+  check('mirror: filters by podium_conversation_id', call && call.params[1] === 'pod_cnv_00001');
+  check('mirror: sets assigned_to to the owner', call && call.params[0] === 'AM');
+}
+
+// 6. mirrorAssignmentToLead — leads table missing (42P01) → 0, not a throw
+{
+  const client = makeClient([{ match: (s) => /UPDATE leads/i.test(s), throws: err('42P01') }]);
+  const n = await mirrorAssignmentToLead(client, 'pod_cnv_00001', 'AM');
+  check('mirror: 0 (not error) when leads table absent (42P01)', n === 0);
+}
+
+// 7. mirrorAssignmentToLead — empty conversationUid → 0, no query
+{
+  const client = makeClient();
+  const n = await mirrorAssignmentToLead(client, '', 'AM');
+  check('mirror: 0 and no query for empty conversationUid', n === 0 && client.calls.length === 0);
+}
+
+// 8. mirrorAssignmentToLead — clearing an owner passes NULL through
+{
+  const client = makeClient([{ match: (s) => /UPDATE leads/i.test(s), result: { rowCount: 1 } }]);
+  await mirrorAssignmentToLead(client, 'pod_cnv_00003', null);
+  const call = client.calls.find((c) => /UPDATE leads/i.test(c.sql));
+  check('mirror: null owner is passed as NULL', call && call.params[0] === null);
+}
+
+// 9. assignConversation (mock) — echoes the new assignee
+{
+  const r = await assignConversation('AM', 'pod_cnv_00003', 'pod_usr_amELia');
+  check('assignConversation: mock echoes assigned member', r?.assignedUser?.uid === 'pod_usr_amELia');
+  check('assignConversation: mock echoes conversation', r?.conversationUid === 'pod_cnv_00003');
+}
+
+// 10. getAssignee (mock) — reads the fixture assignee
+{
+  const r = await getAssignee('AM', 'pod_cnv_00001');
+  check('getAssignee: mock returns fixture assignee', r?.assignedUser?.uid === 'pod_usr_amELia');
+}
+
+// 11. endpoint gates (all reached BEFORE any DB access → offline-safe)
+{
+  const res = makeRes();
+  await assignHandler(makeReq({ noAuth: true }), res);
+  check('endpoint: 401 when unauthenticated', res.statusCode === 401);
+}
+{
+  const res = makeRes();
+  await assignHandler(makeReq({ roles: ['technician'] }), res);
+  check('endpoint: 403 without sales/superadmin', res.statusCode === 403);
+}
+{
+  const res = makeRes();
+  await assignHandler(makeReq({ method: 'DELETE', roles: ['sales'] }), res);
+  check('endpoint: 405 on unsupported method', res.statusCode === 405);
+}
+{
+  const res = makeRes();
+  await assignHandler(makeReq({ method: 'GET', roles: ['sales'], query: {} }), res);
+  check('endpoint: GET 400 without conversationId', res.statusCode === 400);
+}
+{
+  const res = makeRes();
+  await assignHandler(makeReq({ method: 'POST', roles: ['superadmin'], body: {} }), res);
+  check('endpoint: POST 400 without conversationId', res.statusCode === 400);
+}
+
+console.log(`\nAll ${passed} checks passed ✅`);


### PR DESCRIPTION
## F1b — Native assignment sync (increment: portal → Podium)

Keeps Podium's native **"assigned to"** identical to the portal owner, driven by the logged-in rep (execution-plan.md §F1b step 2, **P4**). Ships the **portal → Podium** direction now; the **Podium → portal** reflection (assignment webhook → `leads.assigned_to`) lands with **F2's webhook receiver**, and the inbox "My conversations" filter with **F3**. **Mock-first** (`PODIUM_MOCK=true`, Golden Rule 6) so it's fully reviewable on the Preview without live Podium credentials.

### What's here
- **`api/podium/assign.js`** — standalone serverless function (not the catch-all), gated to `sales`/`superadmin` via the login JWT (`getAuthUser`):
  - `GET /api/podium/assign?conversationId=<uid>` → read the conversation's current Podium assignee.
  - `POST /api/podium/assign { conversationId, userId? }` → assign the conversation; **omit `userId` to claim it for yourself**. Drives `PUT /v4/conversations/{uid}/assignees` **as the acting rep** and mirrors the owner onto the matching lead.
- **`lib/podiumAssign.js`** — shared glue (F2's inbound webhook will reuse it so both directions write the lead identically):
  - `resolvePodiumUserId` — portal user → Podium member uid (`users.podium_user_id`), lazily resolved + persisted via `GET /v4/users` email match when not captured at connect.
  - `mirrorAssignmentToLead` — `leads.assigned_to` for the conversation; idempotent, `42P01`-safe, a no-op (0 rows) until F2/F5 create leads.
- **`scripts/podium-assign-smoke.mjs`** — 20 offline checks (injected fake pg clients + mock Podium; endpoint auth/validation gates).

### Verification
- `node scripts/podium-assign-smoke.mjs` → **All 20 checks passed ✅**
- `CI=true npm run build` → **green**; bundle `main.aed8d726.js` **unchanged** (backend-only, no `src/` change).
- **Real Neon `dev`-branch round-trip:** temp lead → mirror `UPDATE` set `assigned_to` correctly; resolve `UPDATE users` SQL validated non-destructively; temp row deleted (dev left as found).

### Notes
- **No migration** — `users.podium_user_id`, `leads.assigned_to`, `leads.podium_conversation_id` all shipped in F0's `0001_podium.sql` (verified on the Neon `dev` branch). **No prod DB changes.**
- **P1 upheld** — no message bodies read or persisted; only CRM metadata (the assignee).
- Live swap = `PODIUM_MOCK=false` + `PODIUM_*` creds; **no code change**.

**Do not merge** — review gate. See the daily Notion report for step-by-step test instructions and the reviewer checklist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)