### PR TITLE
F2: Podium webhook receiver (signature verify, dedupe, event routing)

### DIFF
--- a/api/podium/webhook.js
+++ b/api/podium/webhook.js
@@ -1,0 +1,97 @@
+// api/podium/webhook.js — inbound Podium webhook receiver (feature F2).
+//
+// Location/org-registered endpoint (P4) that Podium POSTs every subscribed event to.
+// Standalone serverless function (NOT the api/[...path].js catch-all). It stays
+// deliberately minimal so it acks well inside Podium's <5 s timeout (§F2, risk in
+// §11): capture the RAW body, verify the HMAC-SHA256 signature, dedupe, route, ack.
+//
+// Raw body: Podium signs the exact bytes, so we MUST verify before any JSON parse.
+// Vercel's Node runtime parses JSON into req.body by default, which would destroy the
+// exact bytes — so we disable the body parser (config below) and read the stream
+// ourselves (no extra dependency).
+//
+// All CRM logic lives in lib/podiumWebhook.js (unit-tested offline). This file is the
+// HTTP shell: method + signature gate, then processEvent().
+//
+// P1: only envelope metadata is persisted (lib/podiumWebhook.buildSyncPayload) —
+// never `data.body`. Podium is the system of record for chat.
+
+import { getClientWithTimezone } from '../../lib/db.js';
+import { verifySignature, parseEnvelope, processEvent } from '../../lib/podiumWebhook.js';
+
+// Disable Vercel's automatic body parsing so we can read the exact signed bytes.
+export const config = { api: { bodyParser: false } };
+
+const SIGNATURE_HEADER = 'podium-signature';   // req.headers keys are lower-cased
+const TIMESTAMP_HEADER = 'podium-timestamp';
+
+/** Read the raw request body as a Buffer without relying on the platform parser. */
+async function readRawBody(req) {
+  // Defensive: if something upstream already buffered it, honour that.
+  if (Buffer.isBuffer(req.body)) return req.body;
+  if (typeof req.body === 'string') return Buffer.from(req.body, 'utf8');
+  const chunks = [];
+  for await (const chunk of req) {
+    chunks.push(typeof chunk === 'string' ? Buffer.from(chunk, 'utf8') : chunk);
+  }
+  return Buffer.concat(chunks);
+}
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.setHeader('Allow', 'POST');
+    return res.status(405).json({ error: 'Method not allowed' });
+  }
+
+  const secret = process.env.PODIUM_WEBHOOK_SECRET;
+  if (!secret) {
+    // No shared secret configured ⇒ we cannot verify any event. Fail closed.
+    // (Set PODIUM_WEBHOOK_SECRET when the location webhook is registered — F2 live.)
+    return res.status(503).json({ error: 'Webhook secret not configured' });
+  }
+
+  let rawBody;
+  try {
+    rawBody = await readRawBody(req);
+  } catch (err) {
+    console.error('podium webhook: failed to read body:', err.message);
+    return res.status(400).json({ error: 'Could not read request body' });
+  }
+
+  const signature = req.headers[SIGNATURE_HEADER];
+  const timestamp = req.headers[TIMESTAMP_HEADER];
+  const verdict = verifySignature({ rawBody, signature, timestamp, secret });
+  if (!verdict.ok) {
+    // 401 for every signature failure (missing/stale/mismatch): reject, don't process.
+    return res.status(401).json({ error: 'Invalid signature', reason: verdict.reason });
+  }
+
+  let payload;
+  try {
+    payload = JSON.parse(rawBody.toString('utf8') || '{}');
+  } catch {
+    return res.status(400).json({ error: 'Invalid JSON body' });
+  }
+
+  const env = parseEnvelope(payload);
+
+  const client = await getClientWithTimezone();
+  try {
+    const result = await processEvent(client, env);
+    // Ack fast. 200 on both fresh-processed and deduped (idempotent replay).
+    return res.status(200).json({
+      ok: true,
+      deduped: !!result.deduped,
+      eventType: env.eventType,
+      action: result.action || null,
+    });
+  } catch (err) {
+    // Processing failed AFTER a valid signature: 500 so Podium retries. The dedupe
+    // gate + idempotent handlers make the retry safe (the sync-log row is marked
+    // 'error' and its reference_id lets a retry re-run cleanly).
+    console.error(`podium webhook: processing failed for ${env.eventType} (${env.eventUid}):`, err.message);
+    return res.status(500).json({ error: 'Processing failed' });
+  } finally {
+    client.release();
+  }
+}

--- a/lib/podium.js
+++ b/lib/podium.js
@@ -422,6 +422,33 @@ export function requestReview(userId, { contactUid, locationUid, channel } = {})
   });
 }
 
+// ---- Webhooks CRUD (§15.6, drives F2 registration) -------------------------
+// Subscriptions are per location/org (NOT per-user) and are created with an admin
+// location-scoped token (F1 step 3). `secret` is the HMAC key the receiver verifies
+// against (PODIUM_WEBHOOK_SECRET). Runs `AS adminUserId` (their OAuth token).
+
+/** POST /v4/webhooks — create the location/org subscription. */
+export function createWebhook(adminUserId, { url, secret, eventTypes, locationUid, organizationUid } = {}) {
+  const body = { url, secret };
+  if (eventTypes) body.eventTypes = Array.isArray(eventTypes) ? eventTypes : [eventTypes];
+  if (locationUid || process.env.PODIUM_LOCATION_UID) body.locationUid = locationUid || process.env.PODIUM_LOCATION_UID;
+  if (organizationUid || process.env.PODIUM_ORG_UID) body.organizationUid = organizationUid || process.env.PODIUM_ORG_UID;
+  return request(adminUserId, 'POST', 'webhooks', { body });
+}
+
+/** GET /v4/webhooks — list existing subscriptions. */
+export function listWebhooks(adminUserId, opts = {}) {
+  return request(adminUserId, 'GET', 'webhooks', {
+    query: { ...(opts.limit ? { limit: opts.limit } : {}), ...(opts.cursor ? { cursor: opts.cursor } : {}) },
+    client: opts.client,
+  });
+}
+
+/** DELETE /v4/webhooks/{uid} — remove a subscription. */
+export function deleteWebhook(adminUserId, webhookUid) {
+  return request(adminUserId, 'DELETE', `webhooks/${webhookUid}`);
+}
+
 export default {
   isMock, apiVersion, scopes, redirectUri, needsRefresh,
   buildAuthorizeUrl, exchangeCode, refreshAccessToken,
@@ -429,4 +456,5 @@ export default {
   request, paginate,
   listConversations, getConversation, listMessages, sendMessage,
   getAssignee, assignConversation, getUsers, getContact, requestReview,
+  createWebhook, listWebhooks, deleteWebhook,
 };

--- a/lib/podiumWebhook.js
+++ b/lib/podiumWebhook.js
@@ -1,0 +1,354 @@
+// lib/podiumWebhook.js — inbound Podium webhook processing (feature F2).
+//
+// The receiver (api/podium/webhook.js) is deliberately thin — it captures the RAW
+// body, verifies the signature, and hands a parsed envelope to this module, which
+// owns all the CRM logic. Keeping the logic here (pure helpers + DB steps that take
+// an injected pg client) makes it unit-testable offline without a live Podium or a
+// running server (see scripts/podium-webhook-smoke.mjs).
+//
+// Contract (execution-plan.md §F2, §10, §15.6):
+//   1. Signature — HMAC-SHA256 over "{Podium-Timestamp}.{raw_body}" keyed by
+//      PODIUM_WEBHOOK_SECRET, constant-time-compared to the `Podium-Signature`
+//      header. Stale timestamps are rejected (replay guard).
+//   2. Dedupe — `integration_sync_log` unique (source, reference_id) on
+//      `metadata.eventUid`. Podium retries for ~10 days, so every handler is
+//      idempotent and a duplicate event is a no-op ack.
+//   3. Route by `metadata.eventType` (§10):
+//        • message.received → P12: auto-create a `New` lead for the conversation
+//          (assigned to the conversation's assignee, else unassigned) if none is
+//          open, else touch `last_contact_at`. Completes the funnel's first touch.
+//        • conversation-assignment → resolve `assignedUser.uid` → portal user →
+//          mirrorAssignmentToLead(). This is F1b's Podium → portal direction.
+//        • message.sent → reconcile (log only for now).
+//        • message.failed → record status='failed' (surfaced by the inbox/F10).
+//        • contact / lead / review events → logged; richer handling lands with
+//          F4/F5/F8 which own those tables.
+//
+// P1 GUARD (execution-plan.md P1): NOTHING here reads or persists `data.body`.
+// parseEnvelope() copies only stable identifiers/metadata; the sync-log payload is
+// an envelope, never message text. Podium remains the system of record for chat.
+
+import crypto from 'crypto';
+import { mirrorAssignmentToLead } from './podiumAssign.js';
+
+// Replay window: reject events whose signed timestamp is more than this far from
+// now (in either direction). Podium retries within ~10 days, but each retry is
+// re-signed with a fresh timestamp, so a tight window here is safe.
+const DEFAULT_TOLERANCE_SEC = 300;
+
+// ---- Signature verification (§15.6) ---------------------------------------
+
+/**
+ * Parse the `Podium-Timestamp` header to epoch milliseconds. Podium's exact
+ * encoding isn't pinned in our verified reference, so accept the common forms:
+ * epoch seconds (10 digits), epoch millis (13 digits), or an ISO-8601 string.
+ * VERIFY the concrete format against docs.podium.com when wiring live creds.
+ * @returns {number|null} epoch ms, or null if unparseable
+ */
+export function parseTimestampMs(ts) {
+  if (ts == null) return null;
+  const s = String(ts).trim();
+  if (/^\d+$/.test(s)) {
+    const n = Number(s);
+    if (!Number.isFinite(n)) return null;
+    // 13+ digits ⇒ already milliseconds; 10-ish digits ⇒ seconds.
+    return s.length >= 13 ? n : n * 1000;
+  }
+  const parsed = Date.parse(s);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+/** Constant-time string compare that never throws on length mismatch. */
+export function safeEqual(a, b) {
+  const ba = Buffer.from(String(a ?? ''), 'utf8');
+  const bb = Buffer.from(String(b ?? ''), 'utf8');
+  if (ba.length !== bb.length) return false;
+  return crypto.timingSafeEqual(ba, bb);
+}
+
+/**
+ * Compute the expected signature for a raw body + timestamp.
+ * signed_payload = "{timestamp}.{raw_body}", HMAC-SHA256, hex.
+ */
+export function computeSignature(rawBody, timestamp, secret) {
+  const raw = Buffer.isBuffer(rawBody) ? rawBody.toString('utf8') : String(rawBody ?? '');
+  return crypto.createHmac('sha256', String(secret))
+    .update(`${timestamp}.${raw}`, 'utf8')
+    .digest('hex');
+}
+
+/**
+ * Verify a Podium webhook request.
+ * @param {{rawBody:(Buffer|string), signature?:string, timestamp?:string,
+ *          secret?:string, toleranceSec?:number, now?:number}} args
+ * @returns {{ok:boolean, reason?:string}}
+ *   reasons: 'no_secret' | 'missing_headers' | 'stale_timestamp' | 'bad_signature'
+ */
+export function verifySignature({ rawBody, signature, timestamp, secret, toleranceSec = DEFAULT_TOLERANCE_SEC, now = Date.now() }) {
+  if (!secret) return { ok: false, reason: 'no_secret' };
+  if (!signature || !timestamp) return { ok: false, reason: 'missing_headers' };
+
+  const tsMs = parseTimestampMs(timestamp);
+  if (tsMs == null) return { ok: false, reason: 'missing_headers' };
+  if (Math.abs(now - tsMs) > toleranceSec * 1000) return { ok: false, reason: 'stale_timestamp' };
+
+  // Podium sends a hex HMAC; tolerate an optional "sha256=" prefix defensively.
+  const provided = String(signature).replace(/^sha256=/i, '');
+  const expected = computeSignature(rawBody, timestamp, secret);
+  return safeEqual(provided, expected) ? { ok: true } : { ok: false, reason: 'bad_signature' };
+}
+
+// ---- Envelope parsing (P1: identifiers/metadata only, never body) ----------
+
+/**
+ * Pull ONLY the durable, non-sensitive fields we're allowed to keep out of a raw
+ * Podium event. Never returns `data.body`. The deprecated `data.contact`/`sender`
+ * hints (§15.6) are read only as a best-effort id fallback; durable identity is the
+ * stable `conversation.uid` + the Users/Contacts APIs (resolved later, F4).
+ * @returns {{eventUid:?string, eventType:?string, version:?string,
+ *   conversationUid:?string, channelType:?string, channelIdentifier:?string,
+ *   assignedUserUid:?string, contactUid:?string, locationUid:?string,
+ *   orgUid:?string, occurredAt:?string, failureReason:?string}}
+ */
+export function parseEnvelope(payload) {
+  const p = payload || {};
+  const meta = p.metadata || {};
+  const data = p.data || {};
+  const conv = data.conversation || {};
+  const channel = conv.channel || {};
+  const loc = data.location || {};
+  // deprecated hint — id only, used solely as a fallback for contact linking
+  const contactHint = data.contact || {};
+
+  return {
+    eventUid: meta.eventUid ?? null,
+    eventType: meta.eventType ?? null,
+    version: meta.version ?? null,
+    conversationUid: conv.uid ?? null,
+    channelType: channel.type ?? null,
+    channelIdentifier: channel.identifier ?? null,
+    assignedUserUid: conv.assignedUser?.uid ?? null,
+    contactUid: contactHint.uid ?? null,
+    locationUid: loc.uid ?? null,
+    orgUid: loc.organizationUid ?? null,
+    occurredAt: meta.occurredAt ?? data.createdAt ?? null,
+    failureReason: data.failureReason ?? null,
+  };
+}
+
+/** Minimal, P1-safe JSON stored in integration_sync_log.payload (no message text). */
+export function buildSyncPayload(env) {
+  return {
+    conversationUid: env.conversationUid,
+    channel: env.channelType,
+    channelIdentifier: env.channelIdentifier,
+    assignedUserUid: env.assignedUserUid,
+    contactUid: env.contactUid,
+    locationUid: env.locationUid,
+    orgUid: env.orgUid,
+    occurredAt: env.occurredAt,
+    version: env.version,
+    ...(env.failureReason ? { failureReason: env.failureReason } : {}),
+  };
+}
+
+// ---- Event classification --------------------------------------------------
+
+/**
+ * Map a raw `metadata.eventType` to a normalized action. Kept liberal on the
+ * assignment match because the exact conversation-assignment event name isn't in
+ * our verified reference yet (VERIFY against docs.podium.com at live-wiring).
+ */
+export function classifyEvent(eventType) {
+  const t = String(eventType || '').toLowerCase();
+  if (t === 'message.received') return 'message.received';
+  if (t === 'message.sent') return 'message.sent';
+  if (t === 'message.failed') return 'message.failed';
+  if (t.includes('assign')) return 'assignment';
+  if (t.startsWith('contact')) return 'contact';
+  if (t.startsWith('lead')) return 'lead';
+  if (t.startsWith('review')) return 'review';
+  return 'unknown';
+}
+
+// ---- DB steps (injected pg client; caller owns the connection) -------------
+
+/**
+ * Idempotency gate: insert the envelope into integration_sync_log, deduping on the
+ * partial unique index uq_sync_ref (source, reference_id) WHERE reference_id NOT NULL.
+ * @returns {Promise<{id:?number, isNew:boolean}>} isNew=false ⇒ already processed.
+ */
+export async function insertSyncLog(client, env, { status = 'received' } = {}) {
+  const r = await client.query(
+    `INSERT INTO integration_sync_log (source, direction, event_type, reference_id, status, payload)
+     VALUES ('podium', 'inbound', $1, $2, $3, $4)
+     ON CONFLICT (source, reference_id) WHERE reference_id IS NOT NULL
+     DO NOTHING
+     RETURNING id`,
+    [env.eventType || 'unknown', env.eventUid || null, status, JSON.stringify(buildSyncPayload(env))]
+  );
+  return { id: r.rows[0]?.id ?? null, isNew: r.rowCount > 0 };
+}
+
+/** Update a sync-log row's final status/error. No-op if id is null. */
+export async function markSyncLog(client, id, status, error = null) {
+  if (id == null) return;
+  await client.query(
+    `UPDATE integration_sync_log SET status = $1, error = $2 WHERE id = $3`,
+    [status, error, id]
+  );
+}
+
+/** Resolve a Podium member uid → portal user id via users.podium_user_id. */
+export async function portalUserForPodiumUid(client, podiumUserUid) {
+  if (!podiumUserUid) return null;
+  try {
+    const r = await client.query(
+      `SELECT id FROM users WHERE podium_user_id = $1 LIMIT 1`,
+      [podiumUserUid]
+    );
+    return r.rows[0]?.id ?? null;
+  } catch (err) {
+    if (err?.code === '42703') return null; // column absent on a pre-F0 DB
+    throw err;
+  }
+}
+
+/**
+ * P12 — auto-create a lead on the first inbound with no open lead for the
+ * conversation, else touch last_contact_at. Idempotent per conversation: a
+ * just-created lead is open, so subsequent inbounds only touch it.
+ * @returns {Promise<{action:string, leadId:?number}>}
+ */
+export async function handleMessageReceived(client, env) {
+  const convUid = env.conversationUid;
+  if (!convUid) return { action: 'skipped_no_conversation', leadId: null };
+
+  // Open lead already tracking this conversation? (open = not Won/Lost)
+  const existing = await client.query(
+    `SELECT lead_id FROM leads
+      WHERE podium_conversation_id = $1 AND stage NOT IN ('Won','Lost')
+      ORDER BY created_at DESC LIMIT 1`,
+    [convUid]
+  );
+  if (existing.rowCount > 0) {
+    const leadId = existing.rows[0].lead_id;
+    await client.query(
+      `UPDATE leads SET last_contact_at = NOW(), updated_at = NOW() WHERE lead_id = $1`,
+      [leadId]
+    );
+    return { action: 'touched_lead', leadId };
+  }
+
+  // Assign to the conversation's Podium assignee if we can map them (else unassigned).
+  const assignedTo = await portalUserForPodiumUid(client, env.assignedUserUid);
+
+  // Best-effort customer link off the (deprecated) contact hint — no API call, id only.
+  // Full contact↔customer bridging is F4; until then customer_id may stay NULL.
+  let customerId = null;
+  if (env.contactUid) {
+    try {
+      const cr = await client.query(
+        `SELECT id FROM customers WHERE podium_contact_id = $1 LIMIT 1`,
+        [env.contactUid]
+      );
+      customerId = cr.rows[0]?.id ?? null;
+    } catch (err) {
+      if (err?.code !== '42703' && err?.code !== '42P01') throw err;
+    }
+  }
+
+  const ins = await client.query(
+    `INSERT INTO leads
+       (source, source_channel, podium_conversation_id, podium_contact_id,
+        customer_id, stage, assigned_to, last_contact_at)
+     VALUES ('podium', $1, $2, $3, $4, 'New', $5, NOW())
+     RETURNING lead_id`,
+    [env.channelType || null, convUid, env.contactUid || null, customerId, assignedTo]
+  );
+  const leadId = ins.rows[0].lead_id;
+
+  // Append-only stage history (mirrors workorder_logs).
+  await client.query(
+    `INSERT INTO lead_stage_log (lead_id, from_stage, to_stage, user_id, notes_log)
+     VALUES ($1, NULL, 'New', $2, 'Auto-created from inbound Podium message (P12)')`,
+    [leadId, assignedTo]
+  );
+
+  return { action: 'created_lead', leadId };
+}
+
+/**
+ * Podium → portal assignment (F1b inbound half): resolve the conversation's
+ * Podium assignee → portal user → mirror onto the lead. A null assignee clears
+ * the owner. Returns rows updated (0 until a lead exists — the seam is wired).
+ */
+export async function handleAssignment(client, env) {
+  const portalUserId = await portalUserForPodiumUid(client, env.assignedUserUid);
+  const rows = await mirrorAssignmentToLead(client, env.conversationUid, portalUserId);
+  return { action: 'mirrored_assignment', portalUserId, leadsUpdated: rows };
+}
+
+/**
+ * Route a verified, non-duplicate event. Returns a small result describing the
+ * action and the final sync-log status to record.
+ */
+export async function routeEvent(client, env) {
+  const kind = classifyEvent(env.eventType);
+  switch (kind) {
+    case 'message.received': {
+      const r = await handleMessageReceived(client, env);
+      return { kind, status: 'processed', ...r };
+    }
+    case 'assignment': {
+      const r = await handleAssignment(client, env);
+      return { kind, status: 'processed', ...r };
+    }
+    case 'message.failed':
+      // §10: record the failure; the inbox/F10 surface it. No lead mutation.
+      return { kind, status: 'failed', action: 'recorded_failure' };
+    case 'message.sent':
+      return { kind, status: 'processed', action: 'reconciled_send' };
+    default:
+      // contact/lead/review/unknown — logged now; owned by F4/F5/F8 later.
+      return { kind, status: 'processed', action: 'logged' };
+  }
+}
+
+/**
+ * Full processing for one verified event, wrapped in a single transaction so it is
+ * idempotent and safe against Podium's ~10-day retry queue:
+ *   • The dedupe-insert + routing + final status commit atomically. If routing
+ *     throws, ROLLBACK discards BOTH the dedupe row and any partial lead write, so
+ *     Podium's retry reprocesses cleanly (handlers are individually idempotent too).
+ *   • A duplicate eventUid short-circuits (the partial unique index yields isNew=false).
+ *   • Concurrent deliveries of the same event serialize on the uncommitted unique
+ *     key: the second INSERT ... ON CONFLICT DO NOTHING blocks until the first
+ *     commits, then sees the row and dedupes.
+ * @returns {Promise<{deduped:boolean, kind?:string, action?:string, leadId?:?number, syncLogId:?number}>}
+ */
+export async function processEvent(client, env) {
+  await client.query('BEGIN');
+  try {
+    const { id, isNew } = await insertSyncLog(client, env);
+    if (!isNew) {
+      await client.query('COMMIT');
+      return { deduped: true, syncLogId: null };
+    }
+    const result = await routeEvent(client, env);
+    await markSyncLog(client, id, result.status);
+    await client.query('COMMIT');
+    return { deduped: false, syncLogId: id, ...result };
+  } catch (err) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw err;
+  }
+}
+
+export default {
+  parseTimestampMs, safeEqual, computeSignature, verifySignature,
+  parseEnvelope, buildSyncPayload, classifyEvent,
+  insertSyncLog, markSyncLog, portalUserForPodiumUid,
+  handleMessageReceived, handleAssignment, routeEvent, processEvent,
+  DEFAULT_TOLERANCE_SEC,
+};

--- a/scripts/podium-webhook-register.mjs
+++ b/scripts/podium-webhook-register.mjs
@@ -1,0 +1,63 @@
+// scripts/podium-webhook-register.mjs — admin-once Podium webhook registration (F2).
+//
+// Registers the location/org webhook subscription so Podium starts POSTing events to
+// our receiver (api/podium/webhook.js). Run ONCE by an admin whose Podium account is
+// linked with a location-scoped token (F1 step 3). Per location/org, NOT per-user (P4).
+//
+//   PODIUM_MOCK=true  node scripts/podium-webhook-register.mjs            # dry, mock echo
+//   PODIUM_MOCK=false PODIUM_CLIENT_ID=… PODIUM_WEBHOOK_SECRET=… \
+//     PODIUM_WEBHOOK_URL=https://<portal>/api/podium/webhook \
+//     node scripts/podium-webhook-register.mjs <adminPortalUserId>        # live
+//
+// The receiver verifies every event's HMAC with PODIUM_WEBHOOK_SECRET, so the SAME
+// secret must be set here and in the receiver's Vercel env. In mock mode the call is
+// served by lib/podium.mock.js (echo) so the wiring is exercisable without live creds.
+//
+// LIVE PREREQ (deferred until Podium creds exist): an admin must have completed the
+// location-scoped OAuth connect (scope_level='location') so createWebhook() runs on a
+// token that can manage webhooks. Until then this script is mock-only.
+
+const adminUserId = process.argv[2] || process.env.PODIUM_ADMIN_USER_ID || 'AD';
+
+process.env.PODIUM_API_VERSION = process.env.PODIUM_API_VERSION || '2021-04-01';
+
+const { createWebhook, isMock } = await import('../lib/podium.js');
+
+const url = process.env.PODIUM_WEBHOOK_URL
+  || (process.env.PODIUM_REDIRECT_URI
+      ? process.env.PODIUM_REDIRECT_URI.replace(/\/oauth\/callback$/, '/webhook')
+      : 'https://example.invalid/api/podium/webhook');
+
+// The event types the receiver routes (§10). message.* + the conversation-assignment
+// event (exact name VERIFY at live wiring) + contact/lead/review as we grow into them.
+const eventTypes = [
+  'message.received',
+  'message.sent',
+  'message.failed',
+  'conversation.assignee.updated', // VERIFY exact assignment event name vs docs.podium.com
+];
+
+console.log(`Podium webhook registration (mock=${isMock()})`);
+console.log(`  admin user : ${adminUserId}`);
+console.log(`  receiver   : ${url}`);
+console.log(`  events     : ${eventTypes.join(', ')}`);
+
+if (!isMock() && !process.env.PODIUM_WEBHOOK_SECRET) {
+  console.error('\n✗ PODIUM_WEBHOOK_SECRET is required for a live registration (it is the HMAC key the receiver verifies).');
+  process.exit(1);
+}
+
+try {
+  const wh = await createWebhook(adminUserId, {
+    url,
+    secret: process.env.PODIUM_WEBHOOK_SECRET || 'mock_secret',
+    eventTypes,
+    locationUid: process.env.PODIUM_LOCATION_UID,
+    organizationUid: process.env.PODIUM_ORG_UID,
+  });
+  console.log('\n✓ Registered webhook:', JSON.stringify(wh, null, 2));
+  if (isMock()) console.log('\n(Mock echo — no real subscription created. Set PODIUM_MOCK=false + creds to register live.)');
+} catch (err) {
+  console.error('\n✗ Registration failed:', err.message);
+  process.exit(1);
+}

--- a/scripts/podium-webhook-smoke.mjs
+++ b/scripts/podium-webhook-smoke.mjs
@@ -1,0 +1,322 @@
+// scripts/podium-webhook-smoke.mjs — offline smoke for the F2 webhook receiver.
+//
+// Exercises the security-critical + CRM logic in lib/podiumWebhook.js with NO network,
+// NO database, and NO real secrets, plus the api/podium/webhook.js pre-DB gates:
+//
+//   node scripts/podium-webhook-smoke.mjs
+//
+// Coverage:
+//   • Signature verify — valid / tampered body / wrong secret / missing headers /
+//     stale timestamp / future-within-tolerance / sha256= prefix / no secret.
+//   • Envelope parse — safe fields only; P1: `body` never appears in the parsed
+//     envelope or the sync-log payload, even when the event carries data.body.
+//   • Event classification.
+//   • Routing with injected fake pg clients — P12 lead auto-create, touch-existing,
+//     assignment mirror, message.failed status, dedupe short-circuit, error rollback.
+//   • Endpoint gates reached BEFORE any DB access (405 / 503 / 401).
+//
+// The DB happy paths are additionally validated against the Neon dev branch (real
+// INSERT + dedupe round-trip) — see the F2 report. getClientWithTimezone()'s pool is
+// lazy, so importing the handler here opens no connection while we hit pre-DB branches.
+
+process.env.PODIUM_MOCK = 'true';
+process.env.PODIUM_API_VERSION = process.env.PODIUM_API_VERSION || '2021-04-01';
+
+const crypto = (await import('crypto')).default;
+const wh = await import('../lib/podiumWebhook.js');
+const webhookHandler = (await import('../api/podium/webhook.js')).default;
+
+let passed = 0;
+function check(name, cond, detail) {
+  if (!cond) throw new Error(`FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  passed += 1;
+  console.log(`  ✓ ${name}`);
+}
+
+const SECRET = 'whsec_test_123';
+function sign(rawBody, timestamp, secret = SECRET) {
+  return crypto.createHmac('sha256', secret).update(`${timestamp}.${rawBody}`, 'utf8').digest('hex');
+}
+
+// ---- Fake pg client (records queries, returns scripted results) ---------------
+function makeClient(scripts = []) {
+  const calls = [];
+  return {
+    calls,
+    async query(sql, params) {
+      calls.push({ sql, params });
+      for (const s of scripts) {
+        if (typeof s.match === 'function' ? s.match(sql) : true) {
+          if (s.throws) throw s.throws;
+          return s.result ?? { rowCount: 0, rows: [] };
+        }
+      }
+      return { rowCount: 0, rows: [] };
+    },
+  };
+}
+const has = (re) => (sql) => re.test(sql);
+
+console.log('Podium webhook (F2) smoke (PODIUM_MOCK=true)\n');
+
+// ============================================================================
+// 1. Signature verification
+// ============================================================================
+{
+  const body = JSON.stringify({ metadata: { eventUid: 'e1', eventType: 'message.received' } });
+  const ts = String(Math.floor(Date.now() / 1000));
+  const sig = sign(body, ts);
+
+  check('sig: valid signature passes', wh.verifySignature({ rawBody: body, signature: sig, timestamp: ts, secret: SECRET }).ok === true);
+
+  check('sig: tampered body fails', wh.verifySignature({ rawBody: body + ' ', signature: sig, timestamp: ts, secret: SECRET }).reason === 'bad_signature');
+
+  check('sig: wrong secret fails', wh.verifySignature({ rawBody: body, signature: sig, timestamp: ts, secret: 'other' }).reason === 'bad_signature');
+
+  check('sig: missing signature → missing_headers', wh.verifySignature({ rawBody: body, timestamp: ts, secret: SECRET }).reason === 'missing_headers');
+
+  check('sig: missing timestamp → missing_headers', wh.verifySignature({ rawBody: body, signature: sig, secret: SECRET }).reason === 'missing_headers');
+
+  check('sig: no secret configured → no_secret', wh.verifySignature({ rawBody: body, signature: sig, timestamp: ts, secret: '' }).reason === 'no_secret');
+
+  const staleTs = String(Math.floor(Date.now() / 1000) - 3600);
+  check('sig: stale timestamp rejected (replay guard)', wh.verifySignature({ rawBody: body, signature: sign(body, staleTs), timestamp: staleTs, secret: SECRET }).reason === 'stale_timestamp');
+
+  const futureTs = String(Math.floor(Date.now() / 1000) + 60);
+  check('sig: small future skew within tolerance passes', wh.verifySignature({ rawBody: body, signature: sign(body, futureTs), timestamp: futureTs, secret: SECRET }).ok === true);
+
+  check('sig: sha256= prefix tolerated', wh.verifySignature({ rawBody: body, signature: `sha256=${sig}`, timestamp: ts, secret: SECRET }).ok === true);
+
+  check('sig: safeEqual false on length mismatch (no throw)', wh.safeEqual('abc', 'abcd') === false);
+
+  check('sig: parseTimestampMs handles seconds', wh.parseTimestampMs('1700000000') === 1700000000000);
+  check('sig: parseTimestampMs handles millis', wh.parseTimestampMs('1700000000000') === 1700000000000);
+  check('sig: parseTimestampMs handles ISO', wh.parseTimestampMs('2026-07-06T00:00:00Z') === Date.parse('2026-07-06T00:00:00Z'));
+}
+
+// ============================================================================
+// 2. Envelope parse — P1: never leak data.body
+// ============================================================================
+{
+  const payload = {
+    metadata: { eventUid: 'evt_9', eventType: 'message.received', version: '2', occurredAt: '2026-07-06T10:00:00+10:00' },
+    data: {
+      body: 'SECRET MESSAGE TEXT that must never be persisted', // P1: must be dropped
+      conversation: {
+        uid: 'pod_cnv_00003',
+        channel: { type: 'phone', identifier: '+61400333444' },
+        assignedUser: { uid: 'pod_usr_amELia' },
+      },
+      contact: { uid: 'pod_con_toMH20', name: 'Tom Harris' }, // deprecated hint
+      location: { uid: 'pod_loc_GRAYSHQ', organizationUid: 'pod_org_GRAYS' },
+    },
+  };
+  const env = wh.parseEnvelope(payload);
+  check('envelope: eventUid extracted', env.eventUid === 'evt_9');
+  check('envelope: eventType extracted', env.eventType === 'message.received');
+  check('envelope: conversationUid extracted', env.conversationUid === 'pod_cnv_00003');
+  check('envelope: channel type + identifier extracted', env.channelType === 'phone' && env.channelIdentifier === '+61400333444');
+  check('envelope: assignedUserUid extracted', env.assignedUserUid === 'pod_usr_amELia');
+  check('envelope: contactUid extracted (id only, from hint)', env.contactUid === 'pod_con_toMH20');
+  check('envelope: location + org extracted', env.locationUid === 'pod_loc_GRAYSHQ' && env.orgUid === 'pod_org_GRAYS');
+
+  const envJson = JSON.stringify(env);
+  check('P1: parsed envelope contains NO message body', !/SECRET MESSAGE TEXT/.test(envJson) && env.body === undefined);
+  check('P1: envelope has no "body" key at all', !Object.prototype.hasOwnProperty.call(env, 'body'));
+
+  const syncPayload = wh.buildSyncPayload(env);
+  check('P1: sync-log payload contains NO message body', !/SECRET MESSAGE TEXT/.test(JSON.stringify(syncPayload)) && syncPayload.body === undefined);
+  check('sync payload: keeps conversation + channel + assignee', syncPayload.conversationUid === 'pod_cnv_00003' && syncPayload.channel === 'phone' && syncPayload.assignedUserUid === 'pod_usr_amELia');
+}
+
+// ============================================================================
+// 3. Event classification
+// ============================================================================
+{
+  check('classify: message.received', wh.classifyEvent('message.received') === 'message.received');
+  check('classify: message.failed', wh.classifyEvent('message.failed') === 'message.failed');
+  check('classify: assignment (liberal match)', wh.classifyEvent('conversation.assignee.updated') === 'assignment');
+  check('classify: contact', wh.classifyEvent('contact.created') === 'contact');
+  check('classify: unknown', wh.classifyEvent('something.weird') === 'unknown');
+}
+
+// ============================================================================
+// 4. Handlers with fake pg clients
+// ============================================================================
+// 4a. P12 — new conversation, no open lead → create lead + stage log, assignee resolved
+{
+  const client = makeClient([
+    { match: has(/SELECT lead_id FROM leads/i), result: { rowCount: 0, rows: [] } },
+    { match: has(/SELECT id FROM users/i), result: { rowCount: 1, rows: [{ id: 'AM' }] } },
+    { match: has(/SELECT id FROM customers/i), result: { rowCount: 0, rows: [] } },
+    { match: has(/INSERT INTO leads/i), result: { rowCount: 1, rows: [{ lead_id: 501 }] } },
+    { match: has(/INSERT INTO lead_stage_log/i), result: { rowCount: 1 } },
+  ]);
+  const env = { conversationUid: 'pod_cnv_new', channelType: 'phone', assignedUserUid: 'pod_usr_amELia', contactUid: 'pod_con_toMH20' };
+  const r = await wh.handleMessageReceived(client, env);
+  check('P12: creates a lead when none open', r.action === 'created_lead' && r.leadId === 501);
+  const leadInsert = client.calls.find((c) => /INSERT INTO leads/i.test(c.sql));
+  check('P12: lead inserted at stage New with conversation id', leadInsert && leadInsert.params[1] === 'pod_cnv_new');
+  check('P12: lead assigned to resolved portal user', leadInsert && leadInsert.params[4] === 'AM');
+  check('P12: stage log written (from NULL → New)', client.calls.some((c) => /INSERT INTO lead_stage_log/i.test(c.sql)));
+}
+
+// 4b. P12 idempotent — existing open lead → touch, no new lead
+{
+  const client = makeClient([
+    { match: has(/SELECT lead_id FROM leads/i), result: { rowCount: 1, rows: [{ lead_id: 777 }] } },
+    { match: has(/UPDATE leads SET last_contact_at/i), result: { rowCount: 1 } },
+  ]);
+  const r = await wh.handleMessageReceived(client, { conversationUid: 'pod_cnv_open' });
+  check('P12: touches existing open lead', r.action === 'touched_lead' && r.leadId === 777);
+  check('P12: does NOT insert a second lead', !client.calls.some((c) => /INSERT INTO leads/i.test(c.sql)));
+}
+
+// 4c. P12 — no conversation uid → skipped
+{
+  const r = await wh.handleMessageReceived(makeClient(), { conversationUid: null });
+  check('P12: skipped when no conversation uid', r.action === 'skipped_no_conversation');
+}
+
+// 4d. P12 — unassigned conversation → lead created unassigned
+{
+  const client = makeClient([
+    { match: has(/SELECT lead_id FROM leads/i), result: { rowCount: 0, rows: [] } },
+    { match: has(/SELECT id FROM users/i), result: { rowCount: 0, rows: [] } },
+    { match: has(/INSERT INTO leads/i), result: { rowCount: 1, rows: [{ lead_id: 502 }] } },
+  ]);
+  await wh.handleMessageReceived(client, { conversationUid: 'pod_cnv_un', assignedUserUid: null });
+  const leadInsert = client.calls.find((c) => /INSERT INTO leads/i.test(c.sql));
+  check('P12: unassigned conversation → assigned_to NULL', leadInsert && leadInsert.params[4] === null);
+}
+
+// 4e. Assignment (F1b inbound half) — resolve assignee → mirror to lead
+{
+  const client = makeClient([
+    { match: has(/SELECT id FROM users/i), result: { rowCount: 1, rows: [{ id: 'BN' }] } },
+    { match: has(/UPDATE leads/i), result: { rowCount: 1 } },
+  ]);
+  const r = await wh.handleAssignment(client, { conversationUid: 'pod_cnv_00001', assignedUserUid: 'pod_usr_bENjin' });
+  check('assignment: resolves Podium uid → portal user', r.portalUserId === 'BN');
+  check('assignment: mirrors owner onto the lead', r.action === 'mirrored_assignment');
+  const upd = client.calls.find((c) => /UPDATE leads/i.test(c.sql));
+  check('assignment: UPDATE leads sets owner from resolved user', upd && upd.params[0] === 'BN' && upd.params[1] === 'pod_cnv_00001');
+}
+
+// 4f. portalUserForPodiumUid — 42703 (column absent) → null, not a throw
+{
+  const client = makeClient([{ match: has(/SELECT id FROM users/i), throws: Object.assign(new Error('col'), { code: '42703' }) }]);
+  const id = await wh.portalUserForPodiumUid(client, 'pod_usr_x');
+  check('resolve: null (not error) when podium_user_id column absent (42703)', id === null);
+}
+
+// ============================================================================
+// 5. processEvent — dedupe, commit, rollback
+// ============================================================================
+// 5a. fresh message.received → BEGIN, insert log, route, mark, COMMIT
+{
+  const client = makeClient([
+    { match: has(/INSERT INTO integration_sync_log/i), result: { rowCount: 1, rows: [{ id: 99 }] } },
+    { match: has(/SELECT lead_id FROM leads/i), result: { rowCount: 0, rows: [] } },
+    { match: has(/SELECT id FROM users/i), result: { rowCount: 1, rows: [{ id: 'AM' }] } },
+    { match: has(/SELECT id FROM customers/i), result: { rowCount: 0, rows: [] } },
+    { match: has(/INSERT INTO leads/i), result: { rowCount: 1, rows: [{ lead_id: 601 }] } },
+    { match: has(/INSERT INTO lead_stage_log/i), result: { rowCount: 1 } },
+    { match: has(/UPDATE integration_sync_log/i), result: { rowCount: 1 } },
+  ]);
+  const env = { eventUid: 'evt_fresh', eventType: 'message.received', conversationUid: 'pod_cnv_z', channelType: 'sms', assignedUserUid: 'pod_usr_amELia' };
+  const r = await wh.processEvent(client, env);
+  check('processEvent: fresh event is processed (not deduped)', r.deduped === false && r.action === 'created_lead');
+  check('processEvent: wrapped in a transaction (BEGIN + COMMIT)', client.calls.some((c) => /^BEGIN/i.test(c.sql)) && client.calls.some((c) => /^COMMIT/i.test(c.sql)));
+  check('processEvent: marks sync-log status processed', client.calls.some((c) => /UPDATE integration_sync_log/i.test(c.sql)));
+}
+
+// 5b. duplicate eventUid → insert returns 0 rows → deduped, no routing, COMMIT
+{
+  const client = makeClient([
+    { match: has(/INSERT INTO integration_sync_log/i), result: { rowCount: 0, rows: [] } },
+  ]);
+  const r = await wh.processEvent(client, { eventUid: 'evt_dupe', eventType: 'message.received', conversationUid: 'pod_cnv_z' });
+  check('processEvent: duplicate short-circuits (deduped)', r.deduped === true);
+  check('processEvent: duplicate does NOT route (no lead queries)', !client.calls.some((c) => /FROM leads|INTO leads/i.test(c.sql)));
+}
+
+// 5c. message.failed → status 'failed', no lead mutation
+{
+  const client = makeClient([
+    { match: has(/INSERT INTO integration_sync_log/i), result: { rowCount: 1, rows: [{ id: 42 }] } },
+    { match: has(/UPDATE integration_sync_log/i), result: { rowCount: 1 } },
+  ]);
+  const r = await wh.processEvent(client, { eventUid: 'evt_fail', eventType: 'message.failed', conversationUid: 'pod_cnv_z', failureReason: 'landline' });
+  check('processEvent: message.failed routes to failed status', r.status === 'failed' && r.action === 'recorded_failure');
+  const mark = client.calls.find((c) => /UPDATE integration_sync_log/i.test(c.sql));
+  check('processEvent: sync-log marked failed', mark && mark.params[0] === 'failed');
+}
+
+// 5d. routing throws → ROLLBACK + rethrow (dedupe claim released for retry)
+{
+  const client = makeClient([
+    { match: has(/INSERT INTO integration_sync_log/i), result: { rowCount: 1, rows: [{ id: 7 }] } },
+    { match: has(/SELECT lead_id FROM leads/i), throws: Object.assign(new Error('boom'), { code: 'XX000' }) },
+  ]);
+  let threw = false;
+  try {
+    await wh.processEvent(client, { eventUid: 'evt_err', eventType: 'message.received', conversationUid: 'pod_cnv_z' });
+  } catch { threw = true; }
+  check('processEvent: rethrows on handler failure', threw === true);
+  check('processEvent: ROLLBACK issued on failure (releases dedupe row)', client.calls.some((c) => /^ROLLBACK/i.test(c.sql)));
+  check('processEvent: did NOT COMMIT on failure', !client.calls.some((c) => /^COMMIT/i.test(c.sql)));
+}
+
+// ============================================================================
+// 6. Endpoint gates (all reached BEFORE any DB access → offline-safe)
+// ============================================================================
+function makeRes() {
+  return {
+    statusCode: 0, body: null, headers: {},
+    setHeader(k, v) { this.headers[k] = v; },
+    status(c) { this.statusCode = c; return this; },
+    json(o) { this.body = o; return this; },
+  };
+}
+// A minimal Vercel-style req that is also async-iterable (raw body stream).
+function makeReq({ method = 'POST', headers = {}, raw = '' } = {}) {
+  return {
+    method,
+    headers,
+    async *[Symbol.asyncIterator]() { if (raw) yield Buffer.from(raw, 'utf8'); },
+  };
+}
+
+{
+  const res = makeRes();
+  await webhookHandler(makeReq({ method: 'GET' }), res);
+  check('endpoint: GET → 405', res.statusCode === 405 && res.headers.Allow === 'POST');
+}
+{
+  const prev = process.env.PODIUM_WEBHOOK_SECRET;
+  delete process.env.PODIUM_WEBHOOK_SECRET;
+  const res = makeRes();
+  await webhookHandler(makeReq({ method: 'POST', raw: '{}' }), res);
+  check('endpoint: POST without secret configured → 503', res.statusCode === 503);
+  if (prev !== undefined) process.env.PODIUM_WEBHOOK_SECRET = prev;
+}
+{
+  process.env.PODIUM_WEBHOOK_SECRET = SECRET;
+  const res = makeRes();
+  const raw = JSON.stringify({ metadata: { eventUid: 'x', eventType: 'message.received' } });
+  const ts = String(Math.floor(Date.now() / 1000));
+  // Wrong signature → 401 (reached before DB)
+  await webhookHandler(makeReq({ method: 'POST', raw, headers: { 'podium-signature': 'deadbeef', 'podium-timestamp': ts } }), res);
+  check('endpoint: POST bad signature → 401', res.statusCode === 401 && res.body?.reason === 'bad_signature');
+}
+{
+  process.env.PODIUM_WEBHOOK_SECRET = SECRET;
+  const res = makeRes();
+  const raw = JSON.stringify({ metadata: { eventUid: 'x', eventType: 'message.received' } });
+  // Missing headers → 401 missing_headers (reached before DB)
+  await webhookHandler(makeReq({ method: 'POST', raw }), res);
+  check('endpoint: POST missing signature headers → 401', res.statusCode === 401 && res.body?.reason === 'missing_headers');
+}
+
+console.log(`\nAll ${passed} checks passed ✅`);


### PR DESCRIPTION
## F2 — Webhook receiver + registration

Inbound Podium webhook receiver. Completes **F1b**'s Podium → portal direction and lays the **P12** auto-create-lead seam. **Mock-first** (`PODIUM_MOCK=true`, Golden Rule 6) — reviewable on the Preview without live Podium credentials.

### What it does
`POST /api/podium/webhook` (standalone fn, NOT the `[...path].js` catch-all):
1. **Raw body** — `bodyParser` disabled; reads the exact signed bytes from the stream (no new dependency).
2. **Signature** — HMAC-SHA256 over `"{Podium-Timestamp}.{raw_body}"` keyed by `PODIUM_WEBHOOK_SECRET`, constant-time compared to `Podium-Signature`; **stale timestamps rejected** (replay guard).
3. **Dedupe** — `integration_sync_log` partial-unique `(source, reference_id)` on `metadata.eventUid`.
4. **Route** by `metadata.eventType` (§10), then **ack <5 s**:
   - `message.received` → **P12**: auto-create a `New` lead for the conversation (assigned to the conversation assignee, else unassigned) if none open, else touch `last_contact_at`; append `lead_stage_log`.
   - conversation-assignment → resolve `assignedUser.uid` → portal user → `mirrorAssignmentToLead` (**this is F1b's inbound half**).
   - `message.failed` → record `status='failed'`; `message.sent`/contact/lead/review → logged.
5. **Idempotent** against Podium's ~10-day retry queue: dedupe-insert + routing + status commit run in **one transaction** (ROLLBACK releases the dedupe claim + any partial write; concurrent duplicate deliveries serialize on the uncommitted unique key).

### Files
- `api/podium/webhook.js` (new) — receiver (405/503/401 gates).
- `lib/podiumWebhook.js` (new) — `verifySignature`, P1-safe `parseEnvelope`, `classifyEvent`, transactional `processEvent`.
- `lib/podium.js` — `createWebhook`/`listWebhooks`/`deleteWebhook` (§15.6).
- `scripts/podium-webhook-register.mjs` (new) — admin-once registration (mock-safe).
- `scripts/podium-webhook-smoke.mjs` (new) — **55 offline checks**.

### Migration
**None.** `integration_sync_log`, `leads`, `lead_stage_log` all shipped in `db/migrations/0001_podium.sql` (F0). Validated against the Neon **dev** branch (dedupe `ON CONFLICT`, resolve, P12 lead + stage-log insert, status update), then cleaned up — dev left as found.

### Feature flags / still mocked
- `PODIUM_MOCK=true` — no live Podium. **Live registration** (`POST /v4/webhooks` via `scripts/podium-webhook-register.mjs`) needs an admin **location-scoped** token + creds — deferred until creds exist. Then set `PODIUM_MOCK=false` + `PODIUM_WEBHOOK_SECRET` (same secret here and in Vercel).
- `FEATURE_MYOB=false` — untouched.

### P1
Only envelope metadata is persisted (`buildSyncPayload`) — **never `data.body`**. A smoke check asserts the body never appears in the parsed envelope or the sync-log payload.

### Test
1. `node scripts/podium-webhook-smoke.mjs` → `All 55 checks passed ✅`.
2. `node scripts/podium-webhook-register.mjs AD` (mock) → echoes a registered webhook.
3. Signature/dedupe/P12 SQL validated on the Neon dev branch (see report).

### Reviewer checklist
- [ ] Signature verification is correct (constant-time, stale-ts reject, raw-body capture)
- [ ] Dedupe + transactional idempotency sound against the retry queue
- [ ] P12 lead auto-create/touch + assignment mirror behave per §10
- [ ] P1 upheld (no message bodies persisted); no migration; build green; no secrets
- [ ] **Do not merge** without review — this is the review gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)