### PR TITLE
F4 (increment 1): Contact ↔ Customer bridge backend

### DIFF
--- a/api/podium/[...podium].js
+++ b/api/podium/[...podium].js
@@ -21,6 +21,7 @@
 import statusHandler from '../../lib/podiumRoutes/status.js';
 import assignHandler from '../../lib/podiumRoutes/assign.js';
 import inboxHandler from '../../lib/podiumRoutes/inbox.js';
+import contactHandler from '../../lib/podiumRoutes/contact.js';
 import oauthStartHandler from '../../lib/podiumRoutes/oauthStart.js';
 import oauthCallbackHandler from '../../lib/podiumRoutes/oauthCallback.js';
 
@@ -45,6 +46,8 @@ export default async function handler(req, res) {
       return assignHandler(req, res);
     case 'inbox':
       return inboxHandler(req, res);
+    case 'contact':
+      return contactHandler(req, res);
     case 'oauth':
       if (sub === 'start') return oauthStartHandler(req, res);
       if (sub === 'callback') return oauthCallbackHandler(req, res);

--- a/lib/podiumContact.js
+++ b/lib/podiumContact.js
@@ -1,0 +1,305 @@
+// lib/podiumContact.js — Contact ↔ Customer bridge (feature F4).
+//
+// Turns a Podium conversation/contact into the portal's own `customers` row, and
+// gathers the "customer panel" the inbox side-panel needs (execution-plan.md §F4 +
+// the 6 Jul reviewer feedback): the matched customer's details, their OPEN
+// workorders + active deliveries (so a rep can check an order's progress without
+// leaving the inbox), and the open lead (funnel stage).
+//
+// Matching order (execution-plan §F4): customers.podium_contact_id → LOWER(email)
+// → phone (last-8-digits). A match by email/phone lazily backfills
+// customers.podium_contact_id (the same lazy-resolve-and-persist pattern as F1b's
+// resolvePodiumUserId), so the next lookup is an indexed hit on idx_customers_podium.
+// Creating a customer from a contact is a DELIBERATE action (POST action=create),
+// never an implicit side effect of a read — an unmatched read returns customer:null
+// so the UI can offer "Create customer from contact".
+//
+// Mock-first (Golden Rule 6): every Podium hop routes through lib/podium.js, which
+// serves lib/podium.mock.js while PODIUM_MOCK=true, so the whole bridge is reviewable
+// on the Preview without live creds.
+//
+// P1: this module reads/writes only CRM metadata (the contact↔customer link and
+// customer/workorder/delivery/lead rows). It NEVER reads or persists message bodies —
+// Podium remains the system of record for chat (execution-plan P1/P3).
+
+import { getContact, getConversation } from './podium.js';
+
+// ---- Podium contact resolution --------------------------------------------
+
+/**
+ * Normalise a Podium contact object into the compact shape the panel returns.
+ * Live Podium field names may differ (VERIFY against docs.podium.com at live wiring);
+ * the mock uses `phoneNumber` + `email` + `name` (execution-plan §15 / lib/podium.mock.js).
+ */
+export function normalizeContact(raw, conversation = null) {
+  if (!raw && !conversation) return null;
+  const c = raw || {};
+  return {
+    uid: c.uid || null,
+    name: c.name || null,
+    email: c.email || null,
+    phone: c.phoneNumber || c.phone || null,
+    channels: Array.isArray(c.channels) ? c.channels : [],
+    // The conversation's channel is a useful label when there is no contact record.
+    channel: conversation?.channel || null,
+  };
+}
+
+/**
+ * Resolve the Podium contact behind a conversation (or a direct contactId), AS the
+ * logged-in rep (P4). Prefers a direct `contactId`; otherwise reads the conversation
+ * and follows its contact reference (resolved via the Contacts API off the stable
+ * conversation.uid — NOT the deprecated webhook `sender`/`contact` hint, §15.6).
+ *
+ * @returns {Promise<object|null>} normalised contact, or null if neither id resolves.
+ */
+export async function resolveContact(userId, { conversationId, contactId, client } = {}) {
+  let contactUid = contactId ? String(contactId) : null;
+  let conversation = null;
+
+  if (!contactUid && conversationId) {
+    conversation = await getConversation(userId, String(conversationId), { client });
+    // conversation.contact.uid is the durable reference (the Contacts API is the
+    // source of truth; the message-event contact hint is deprecated, §15.6).
+    contactUid = conversation?.contact?.uid || null;
+  }
+
+  if (!contactUid) {
+    // No contact record to resolve. If we at least have the conversation, hand back a
+    // channel-only stub so the UI can still label the thread (e.g. the phone number).
+    if (conversation) {
+      const chan = conversation.channel || null;
+      return {
+        uid: null,
+        name: null,
+        email: null,
+        phone: chan?.type === 'phone' ? chan?.identifier || null : null,
+        channels: [],
+        channel: chan,
+      };
+    }
+    return null;
+  }
+
+  const raw = await getContact(userId, contactUid, { client });
+  return normalizeContact(raw, conversation);
+}
+
+// ---- Customer matching -----------------------------------------------------
+
+/** Keep only digits; return the last `n` (for loose phone equality across formats). */
+export function phoneKey(value, n = 8) {
+  const digits = String(value || '').replace(/\D/g, '');
+  return digits.length > n ? digits.slice(-n) : digits;
+}
+
+const CUSTOMER_COLS =
+  'id, name, email, phone, address, notes, podium_contact_id, myob_uid, woo_customer_id';
+
+/**
+ * Match a Podium contact to a `customers` row: podium_contact_id → LOWER(email) →
+ * phone (last-8-digits). Returns { customer, matchedBy } where matchedBy is one of
+ * 'podium_contact_id' | 'email' | 'phone' | 'none'.
+ */
+export async function matchCustomer(client, contact) {
+  if (!contact) return { customer: null, matchedBy: 'none' };
+
+  // 1) Strong link on the id we may have stored previously (indexed: idx_customers_podium).
+  if (contact.uid) {
+    const r = await client.query(
+      `SELECT ${CUSTOMER_COLS} FROM customers WHERE podium_contact_id = $1 LIMIT 1`,
+      [contact.uid]
+    );
+    if (r.rowCount) return { customer: r.rows[0], matchedBy: 'podium_contact_id' };
+  }
+
+  // 2) Email (indexed: idx_customers_email_lower).
+  const email = String(contact.email || '').toLowerCase().trim();
+  if (email) {
+    const r = await client.query(
+      `SELECT ${CUSTOMER_COLS} FROM customers WHERE LOWER(email) = $1 LIMIT 1`,
+      [email]
+    );
+    if (r.rowCount) return { customer: r.rows[0], matchedBy: 'email' };
+  }
+
+  // 3) Phone, last-8-digits (best-effort; no index — customers is small, and F4's UI
+  //    fetches this once per conversation open, not per render).
+  const key = phoneKey(contact.phone);
+  if (key && key.length >= 6) {
+    const r = await client.query(
+      `SELECT ${CUSTOMER_COLS} FROM customers
+        WHERE phone IS NOT NULL
+          AND right(regexp_replace(phone, '\\D', '', 'g'), 8) = $1
+        LIMIT 1`,
+      [key]
+    );
+    if (r.rowCount) return { customer: r.rows[0], matchedBy: 'phone' };
+  }
+
+  return { customer: null, matchedBy: 'none' };
+}
+
+/**
+ * Link a Podium contact uid onto a customer, but only when the slot is empty — never
+ * clobber an existing link (idempotent; mirrors F1b's persist-only-when-empty rule).
+ * @returns {Promise<boolean>} true if this call wrote the link.
+ */
+export async function linkContactToCustomer(client, customerId, contactUid) {
+  if (!customerId || !contactUid) return false;
+  const r = await client.query(
+    `UPDATE customers SET podium_contact_id = $1
+       WHERE id = $2 AND (podium_contact_id IS NULL OR podium_contact_id = '')`,
+    [contactUid, customerId]
+  );
+  return (r.rowCount || 0) > 0;
+}
+
+/**
+ * Create a `customers` row from a Podium contact. Creation is explicit (POST
+ * action=create) — the UI's "Create customer from contact". `overrides` lets the UI
+ * fill gaps the contact lacks (customers.email is NOT NULL, and some Podium contacts
+ * — e.g. social-only — have no email). Throws EMAIL_REQUIRED if no email is available
+ * from either the contact or the overrides, so the UI can prompt for one.
+ */
+export async function createCustomerFromContact(client, contact, overrides = {}) {
+  const email = String(overrides.email || contact?.email || '').trim();
+  if (!email) {
+    const e = new Error('An email is required to create a customer from this contact');
+    e.code = 'EMAIL_REQUIRED';
+    throw e;
+  }
+  const name =
+    String(overrides.name || contact?.name || '').trim() || email.split('@')[0] || 'Podium Contact';
+  const phone = (overrides.phone ?? contact?.phone) || null;
+  const address = overrides.address || null;
+  const contactUid = contact?.uid || null;
+
+  const r = await client.query(
+    `INSERT INTO customers (name, email, phone, address, podium_contact_id)
+     VALUES ($1,$2,$3,$4,$5)
+     RETURNING ${CUSTOMER_COLS}`,
+    [name, email, phone, address, contactUid]
+  );
+  return r.rows[0];
+}
+
+// ---- Customer 360 (compact) for the inbox side panel -----------------------
+
+/** OPEN workorders (anything not yet Completed) for a customer, newest first. */
+export async function openWorkordersForCustomer(client, customerId) {
+  if (!customerId) return [];
+  const r = await client.query(
+    `SELECT workorder_id, invoice_id, status, outstanding_balance,
+            delivery_suburb, delivery_state, estimated_completion, date_created, ecommerce
+       FROM workorder
+      WHERE customer_id = $1 AND status <> 'Completed'
+      ORDER BY date_created DESC`,
+    [customerId]
+  );
+  return r.rows;
+}
+
+/** ACTIVE deliveries (not yet Delivery Completed) for a customer, newest first. */
+export async function activeDeliveriesForCustomer(client, customerId) {
+  if (!customerId) return [];
+  const r = await client.query(
+    `SELECT delivery_id, invoice_id, workorder_id, delivery_suburb, delivery_state,
+            delivery_date, delivery_status, date_created
+       FROM delivery
+      WHERE customer_id = $1 AND delivery_status <> 'Delivery Completed'
+      ORDER BY date_created DESC`,
+    [customerId]
+  );
+  return r.rows;
+}
+
+/**
+ * The customer's OPEN lead (funnel stage), matched by conversation → contact →
+ * customer, whichever we have. Defensive: returns null if the leads table isn't
+ * migrated on this DB yet (42P01) — so Production (pre-F0-release) still serves the
+ * panel; the funnel just shows empty until leads exist.
+ */
+export async function openLeadFor(client, { customerId = null, contactUid = null, conversationId = null } = {}) {
+  if (!customerId && !contactUid && !conversationId) return null;
+  try {
+    const r = await client.query(
+      `SELECT lead_id, stage, assigned_to, source_channel, value_est, product_interest,
+              quote_invoice_id, payment, converted_workorder_id,
+              last_contact_at, created_at, updated_at
+         FROM leads
+        WHERE stage NOT IN ('Won','Lost')
+          AND ( ($1::varchar IS NOT NULL AND podium_conversation_id = $1)
+             OR ($2::varchar IS NOT NULL AND podium_contact_id = $2)
+             OR ($3::int     IS NOT NULL AND customer_id = $3) )
+        ORDER BY updated_at DESC
+        LIMIT 1`,
+      [conversationId, contactUid, customerId]
+    );
+    return r.rowCount ? r.rows[0] : null;
+  } catch (err) {
+    if (err?.code === '42P01') return null; // leads not migrated on this DB yet
+    throw err;
+  }
+}
+
+/**
+ * Build the full customer panel for a conversation/contact: resolve the Podium
+ * contact, match (and best-effort backfill the link on an email/phone match), then
+ * gather the customer's open workorders, active deliveries, and open lead.
+ *
+ * @param {object} client  pg client (caller owns the connection)
+ * @param {string} userId  acting rep's portal id (their Podium token is used, P4)
+ * @param {{conversationId?:string, contactId?:string, autoLink?:boolean}} opts
+ * @returns {Promise<object>} the panel (see the shape assembled below).
+ */
+export async function buildCustomerPanel(client, userId, { conversationId, contactId, autoLink = true } = {}) {
+  const contact = await resolveContact(userId, { conversationId, contactId, client });
+
+  const panel = {
+    conversationId: conversationId ? String(conversationId) : null,
+    contact: contact || null,
+    customer: null,
+    matchedBy: 'none',
+    linked: false,
+    workorders: [],
+    deliveries: [],
+    lead: null,
+  };
+  if (!contact) return panel;
+
+  const { customer, matchedBy } = await matchCustomer(client, contact);
+  panel.matchedBy = matchedBy;
+
+  if (customer) {
+    // Backfill the durable link when we matched on email/phone (never overwrite one).
+    if (autoLink && matchedBy !== 'podium_contact_id' && contact.uid) {
+      panel.linked = await linkContactToCustomer(client, customer.id, contact.uid);
+      if (panel.linked) customer.podium_contact_id = contact.uid;
+    }
+    panel.customer = customer;
+    panel.workorders = await openWorkordersForCustomer(client, customer.id);
+    panel.deliveries = await activeDeliveriesForCustomer(client, customer.id);
+  }
+
+  panel.lead = await openLeadFor(client, {
+    customerId: customer?.id || null,
+    contactUid: contact.uid || null,
+    conversationId: conversationId ? String(conversationId) : null,
+  });
+
+  return panel;
+}
+
+export default {
+  normalizeContact,
+  resolveContact,
+  phoneKey,
+  matchCustomer,
+  linkContactToCustomer,
+  createCustomerFromContact,
+  openWorkordersForCustomer,
+  activeDeliveriesForCustomer,
+  openLeadFor,
+  buildCustomerPanel,
+};

--- a/lib/podiumRoutes/contact.js
+++ b/lib/podiumRoutes/contact.js
@@ -1,0 +1,131 @@
+// lib/podiumRoutes/contact.js — Contact ↔ Customer bridge endpoint (feature F4).
+//
+// Served via the api/podium/[...podium].js catch-all as /api/podium/contact (Hobby-cap
+// discipline: a new `case`, NOT a new function file). Gated to sales/superadmin via the
+// login JWT — the server is the real gate (F9 formalises nav).
+//
+//   GET  /api/podium/contact?conversationId=<uid>   (or ?contactId=<uid>)
+//        → resolve the Podium contact behind the conversation, match it to a customer
+//          (podium_contact_id → email → phone; backfills the link on an email/phone
+//          match), and return the customer panel: matched customer + OPEN workorders +
+//          ACTIVE deliveries + open lead (funnel stage). customer:null when unmatched,
+//          so the UI can offer "Create customer from contact".
+//   POST /api/podium/contact
+//        { conversationId?|contactId?, action:'create'|'link', customerId?, customer? }
+//        · action:'link'   → link an EXISTING customer (customerId) to this contact.
+//        · action:'create' → create a customer from the contact (customer{} fills gaps
+//                             like a missing email), then link it.
+//        Both return the freshly rebuilt panel.
+//
+// Mock-first (Golden Rule 6): the Podium hops run through lib/podium.js → the mock
+// while PODIUM_MOCK=true, so the bridge is reviewable on the Preview without creds.
+// Runs on the acting rep's token (P4). P1: only CRM metadata is read/written here —
+// no message bodies are ever touched.
+
+import { getAuthUser, hasAnyRole } from '../rbac.js';
+import { isMock } from '../podium.js';
+import { getClientWithTimezone } from '../db.js';
+import {
+  buildCustomerPanel,
+  createCustomerFromContact,
+  linkContactToCustomer,
+  resolveContact,
+} from '../podiumContact.js';
+
+// P11: reading a customer's context in the inbox is a `sales` action; superadmin too.
+const ALLOWED_ROLES = ['sales', 'superadmin'];
+
+export default async function handler(req, res) {
+  const auth = getAuthUser(req);
+  if (!auth) return res.status(401).json({ error: 'Not authenticated' });
+  if (!hasAnyRole(auth.roles, ALLOWED_ROLES)) {
+    return res.status(403).json({ error: 'Requires the sales role to view customer details' });
+  }
+
+  if (req.method === 'GET') return handleGet(req, res, auth);
+  if (req.method === 'POST') return handlePost(req, res, auth);
+  return res.status(405).json({ error: 'Method not allowed' });
+}
+
+// GET — resolve + match + panel (best-effort backfill of the contact link).
+async function handleGet(req, res, auth) {
+  const conversationId = req.query?.conversationId;
+  const contactId = req.query?.contactId;
+  if (!conversationId && !contactId) {
+    return res.status(400).json({ error: 'conversationId or contactId is required' });
+  }
+  const client = await getClientWithTimezone();
+  try {
+    const panel = await buildCustomerPanel(client, auth.id, {
+      conversationId: conversationId ? String(conversationId) : undefined,
+      contactId: contactId ? String(contactId) : undefined,
+    });
+    return res.status(200).json({ ...panel, mock: isMock() });
+  } catch (err) {
+    return respondError(res, err, 'load the customer panel');
+  } finally {
+    client.release();
+  }
+}
+
+// POST — explicit link/create, then return the rebuilt panel.
+async function handlePost(req, res, auth) {
+  const { conversationId, contactId, action, customerId, customer } = req.body || {};
+  if (!conversationId && !contactId) {
+    return res.status(400).json({ error: 'conversationId or contactId is required' });
+  }
+  const act = String(action || '').toLowerCase();
+  if (act !== 'create' && act !== 'link') {
+    return res.status(400).json({ error: "action must be 'create' or 'link'" });
+  }
+
+  const client = await getClientWithTimezone();
+  try {
+    // Resolve the contact once; both actions need its uid (and 'create' its fields).
+    const contact = await resolveContact(auth.id, {
+      conversationId: conversationId ? String(conversationId) : undefined,
+      contactId: contactId ? String(contactId) : undefined,
+      client,
+    });
+    if (!contact || !contact.uid) {
+      return res.status(404).json({ error: 'No Podium contact found for this conversation' });
+    }
+
+    if (act === 'link') {
+      if (!customerId) return res.status(400).json({ error: 'customerId is required to link' });
+      const exists = await client.query('SELECT id FROM customers WHERE id = $1 LIMIT 1', [customerId]);
+      if (!exists.rowCount) return res.status(404).json({ error: `Customer ${customerId} not found` });
+      await linkContactToCustomer(client, Number(customerId), contact.uid);
+    } else {
+      // create
+      await createCustomerFromContact(client, contact, customer || {});
+    }
+
+    // Rebuild the panel so the caller immediately sees the newly-linked customer + 360.
+    const panel = await buildCustomerPanel(client, auth.id, {
+      conversationId: conversationId ? String(conversationId) : undefined,
+      contactId: contactId ? String(contactId) : undefined,
+    });
+    return res.status(act === 'create' ? 201 : 200).json({ ...panel, mock: isMock() });
+  } catch (err) {
+    if (err?.code === 'EMAIL_REQUIRED') {
+      return res.status(422).json({ error: err.message, code: 'EMAIL_REQUIRED' });
+    }
+    if (err?.code === '23505') {
+      // Unlikely (customers.email isn't uniquely constrained today) but safe to surface.
+      return res.status(409).json({ error: 'A customer with these details already exists' });
+    }
+    return respondError(res, err, 'update the customer link');
+  } finally {
+    client.release();
+  }
+}
+
+function respondError(res, err, action) {
+  if (err?.code === 'PODIUM_NOT_CONNECTED') {
+    return res.status(409).json({ error: 'You have not linked a Podium account', code: 'NOT_CONNECTED' });
+  }
+  if (err?.status === 404) return res.status(404).json({ error: 'Not found in Podium' });
+  console.error(`podium contact: could not ${action}:`, err);
+  return res.status(502).json({ error: `Could not ${action}` });
+}

--- a/scripts/podium-contact-smoke.mjs
+++ b/scripts/podium-contact-smoke.mjs
@@ -1,0 +1,245 @@
+// scripts/podium-contact-smoke.mjs — offline smoke for the F4 contact↔customer bridge.
+//
+// Exercises the pure/mock-safe logic added in F4: the lib/podiumContact.js helpers
+// (normalizeContact, phoneKey, matchCustomer, linkContactToCustomer,
+// createCustomerFromContact, open workorders/deliveries/lead, buildCustomerPanel) with
+// INJECTED fake pg clients + the mock Podium service, plus the lib/podiumRoutes/contact.js
+// auth/validation gates that run BEFORE any DB access. NO network, NO database, NO secrets:
+//
+//   node scripts/podium-contact-smoke.mjs
+//
+// The DB-touching happy paths (real match/create/link + 360 gather) are validated
+// separately against the Neon dev branch — see the F4 report. getClientWithTimezone()'s
+// pool is lazy, so importing the endpoint here opens no connection while we only hit its
+// pre-DB branches.
+
+process.env.PODIUM_MOCK = 'true';
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'smoke_secret';
+process.env.PODIUM_API_VERSION = process.env.PODIUM_API_VERSION || '2021-04-01';
+
+const jwt = (await import('jsonwebtoken')).default;
+const C = await import('../lib/podiumContact.js');
+const contactHandler = (await import('../lib/podiumRoutes/contact.js')).default;
+
+let passed = 0;
+function check(name, cond, detail) {
+  if (!cond) throw new Error(`FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  passed += 1;
+  console.log(`  ✓ ${name}`);
+}
+
+// ---- Fake pg client: records queries, returns the first matching scripted result ----
+function makeClient(scripts = []) {
+  const calls = [];
+  return {
+    calls,
+    async query(sql, params) {
+      calls.push({ sql, params });
+      for (const s of scripts) {
+        if (typeof s.match === 'function' ? s.match(sql) : true) {
+          if (s.throws) throw s.throws;
+          return s.result ?? { rowCount: 0, rows: [] };
+        }
+      }
+      return { rowCount: 0, rows: [] };
+    },
+  };
+}
+function pgErr(code) { const e = new Error(code); e.code = code; return e; }
+
+// ---- req/res doubles (Vercel Node handler shape) ------------------------------
+function makeReq({ method = 'GET', roles = ['sales'], id = 'AM', email = 'amelia@graysfitness.com.au', query = {}, body = {}, noAuth = false } = {}) {
+  const headers = {};
+  if (!noAuth) headers.authorization = `Bearer ${jwt.sign({ id, email, roles }, process.env.JWT_SECRET, { expiresIn: '1h' })}`;
+  return { method, headers, query, body };
+}
+function makeRes() {
+  return {
+    statusCode: 0, body: null,
+    status(c) { this.statusCode = c; return this; },
+    json(o) { this.body = o; return this; },
+  };
+}
+
+// Query matchers
+const isSelPodium = (s) => /FROM customers WHERE podium_contact_id = \$1/.test(s);
+const isSelEmail = (s) => /WHERE LOWER\(email\) = \$1/.test(s);
+const isSelPhone = (s) => /right\(regexp_replace\(phone/.test(s);
+const isLinkUpd = (s) => /UPDATE customers SET podium_contact_id/.test(s);
+const isInsCust = (s) => /INSERT INTO customers/.test(s);
+const isSelWO = (s) => /FROM workorder\b/.test(s);
+const isSelDel = (s) => /FROM delivery\b/.test(s);
+const isSelLead = (s) => /FROM leads\b/.test(s);
+
+const CUST = { id: 7, name: 'Maria Papadopoulos', email: 'maria@example.com', phone: '+61400111222', address: null, notes: null, podium_contact_id: null, myob_uid: null, woo_customer_id: null };
+
+console.log('Podium contact↔customer bridge (F4) smoke (PODIUM_MOCK=true)\n');
+
+// 1. phoneKey — last-8-digits, format-agnostic
+check('phoneKey: strips formatting to last 8', C.phoneKey('+61 400 111 222') === '00111222');
+check('phoneKey: short numbers pass through', C.phoneKey('12345') === '12345');
+check('phoneKey: empty → empty', C.phoneKey(null) === '');
+
+// 2. normalizeContact — maps Podium fields → compact shape
+{
+  const n = C.normalizeContact({ uid: 'pod_con_x', name: 'X', phoneNumber: '+61400999888', email: 'x@e.com', channels: ['phone'] });
+  check('normalizeContact: maps phoneNumber→phone', n.phone === '+61400999888');
+  check('normalizeContact: carries uid/name/email', n.uid === 'pod_con_x' && n.name === 'X' && n.email === 'x@e.com');
+  check('normalizeContact: null when nothing given', C.normalizeContact(null) === null);
+}
+
+// 3. resolveContact — conversation → contact.uid → getContact (mock)
+{
+  const contact = await C.resolveContact('AM', { conversationId: 'pod_cnv_00001', client: makeClient() });
+  check('resolveContact: resolves the mock conversation contact', contact?.uid === 'pod_con_maRIA1', `got ${contact?.uid}`);
+  check('resolveContact: pulls email from the Contacts API', contact?.email === 'maria@example.com');
+}
+{
+  const contact = await C.resolveContact('AM', { contactId: 'pod_con_jaKE44', client: makeClient() });
+  check('resolveContact: direct contactId path', contact?.uid === 'pod_con_jaKE44' && contact?.name === 'Jake Wilson');
+}
+
+// 4. matchCustomer — tier 1: podium_contact_id
+{
+  const client = makeClient([{ match: isSelPodium, result: { rowCount: 1, rows: [{ ...CUST, podium_contact_id: 'pod_con_maRIA1' }] } }]);
+  const { customer, matchedBy } = await C.matchCustomer(client, { uid: 'pod_con_maRIA1', email: 'maria@example.com' });
+  check('match: tier1 podium_contact_id hit', matchedBy === 'podium_contact_id' && customer.id === 7);
+  check('match: tier1 stops after one query', client.calls.length === 1);
+}
+// 4b. matchCustomer — tier 2: email (podium miss → email hit)
+{
+  const client = makeClient([{ match: isSelEmail, result: { rowCount: 1, rows: [CUST] } }]);
+  const { matchedBy } = await C.matchCustomer(client, { uid: 'pod_con_new', email: 'maria@example.com', phone: null });
+  check('match: tier2 email hit after podium miss', matchedBy === 'email');
+  check('match: tier2 issued podium+email queries', client.calls.length === 2);
+}
+// 4c. matchCustomer — tier 3: phone
+{
+  const client = makeClient([{ match: isSelPhone, result: { rowCount: 1, rows: [CUST] } }]);
+  const { matchedBy } = await C.matchCustomer(client, { uid: 'pod_con_new', email: null, phone: '+61400111222' });
+  check('match: tier3 phone hit', matchedBy === 'phone');
+  const phoneCall = client.calls.find((c) => isSelPhone(c.sql));
+  check('match: tier3 uses last-8-digits param', phoneCall && phoneCall.params[0] === '00111222');
+}
+// 4d. matchCustomer — none
+{
+  const { customer, matchedBy } = await C.matchCustomer(makeClient(), { uid: 'x', email: 'nobody@nowhere.com', phone: '+61000000000' });
+  check('match: none when no tier hits', customer === null && matchedBy === 'none');
+}
+
+// 5. linkContactToCustomer — only writes when slot empty
+{
+  const client = makeClient([{ match: isLinkUpd, result: { rowCount: 1 } }]);
+  const linked = await C.linkContactToCustomer(client, 7, 'pod_con_maRIA1');
+  const call = client.calls.find((c) => isLinkUpd(c.sql));
+  check('link: returns true when a row was written', linked === true);
+  check('link: guards against clobber (WHERE ... IS NULL/empty)', /podium_contact_id IS NULL OR podium_contact_id = ''/.test(call.sql));
+  check('link: no-op params guard (missing ids → false, no query)', (await C.linkContactToCustomer(makeClient(), null, 'x')) === false);
+}
+
+// 6. createCustomerFromContact — email required; success path
+{
+  let threw = null;
+  try { await C.createCustomerFromContact(makeClient(), { uid: 'pod_con_liNDA3', name: 'Linda', email: null }); }
+  catch (e) { threw = e; }
+  check('create: throws EMAIL_REQUIRED when no email anywhere', threw?.code === 'EMAIL_REQUIRED');
+}
+{
+  const client = makeClient([{ match: isInsCust, result: { rowCount: 1, rows: [{ ...CUST, id: 42, podium_contact_id: 'pod_con_liNDA3', email: 'linda@new.com' }] } }]);
+  const created = await C.createCustomerFromContact(client, { uid: 'pod_con_liNDA3', name: 'Linda', email: null }, { email: 'linda@new.com' });
+  const call = client.calls.find((c) => isInsCust(c.sql));
+  check('create: overrides supply the missing email', created.id === 42 && created.email === 'linda@new.com');
+  check('create: INSERT sets podium_contact_id from the contact', call.params[4] === 'pod_con_liNDA3');
+  check('create: name defaults from the contact', call.params[0] === 'Linda');
+}
+
+// 7. open workorders / active deliveries — filter to not-yet-done
+{
+  const client = makeClient([{ match: isSelWO, result: { rowCount: 1, rows: [{ workorder_id: 100, status: 'In Workshop' }] } }]);
+  const wo = await C.openWorkordersForCustomer(client, 7);
+  const call = client.calls.find((c) => isSelWO(c.sql));
+  check('workorders: returns rows', wo.length === 1 && wo[0].workorder_id === 100);
+  check("workorders: excludes Completed (status <> 'Completed')", /status <> 'Completed'/.test(call.sql));
+  check('workorders: empty for no customer', (await C.openWorkordersForCustomer(client, null)).length === 0);
+}
+{
+  const client = makeClient([{ match: isSelDel, result: { rowCount: 1, rows: [{ delivery_id: 200, delivery_status: 'To Be Booked' }] } }]);
+  const del = await C.activeDeliveriesForCustomer(client, 7);
+  const call = client.calls.find((c) => isSelDel(c.sql));
+  check('deliveries: returns rows', del.length === 1 && del[0].delivery_id === 200);
+  check("deliveries: excludes 'Delivery Completed'", /delivery_status <> 'Delivery Completed'/.test(call.sql));
+}
+
+// 8. openLeadFor — defensive against a DB without the leads table (42P01)
+{
+  const client = makeClient([{ match: isSelLead, result: { rowCount: 1, rows: [{ lead_id: 5, stage: 'Contacted' }] } }]);
+  const lead = await C.openLeadFor(client, { customerId: 7, contactUid: 'pod_con_maRIA1', conversationId: 'pod_cnv_00001' });
+  check('lead: returns the open lead', lead?.stage === 'Contacted');
+}
+{
+  const client = makeClient([{ match: isSelLead, throws: pgErr('42P01') }]);
+  const lead = await C.openLeadFor(client, { customerId: 7 });
+  check('lead: null (not throw) when leads table absent (42P01)', lead === null);
+  check('lead: null with no identifiers, no query', (await C.openLeadFor(makeClient(), {})) === null);
+}
+
+// 9. buildCustomerPanel — end-to-end (mock contact + fake DB): email match → backfill → 360
+{
+  const client = makeClient([
+    { match: isSelPodium, result: { rowCount: 0, rows: [] } },              // no strong link yet
+    { match: isSelEmail, result: { rowCount: 1, rows: [CUST] } },           // matched by email
+    { match: isLinkUpd, result: { rowCount: 1 } },                          // backfilled the link
+    { match: isSelWO, result: { rowCount: 1, rows: [{ workorder_id: 100, status: 'In Workshop' }] } },
+    { match: isSelDel, result: { rowCount: 1, rows: [{ delivery_id: 200, delivery_status: 'To Be Booked' }] } },
+    { match: isSelLead, result: { rowCount: 1, rows: [{ lead_id: 5, stage: 'Contacted' }] } },
+  ]);
+  const panel = await C.buildCustomerPanel(client, 'AM', { conversationId: 'pod_cnv_00001' });
+  check('panel: contact resolved', panel.contact?.uid === 'pod_con_maRIA1');
+  check('panel: matched by email', panel.matchedBy === 'email' && panel.customer?.id === 7);
+  check('panel: backfilled the contact link', panel.linked === true && panel.customer.podium_contact_id === 'pod_con_maRIA1');
+  check('panel: gathered open workorders', panel.workorders.length === 1);
+  check('panel: gathered active deliveries', panel.deliveries.length === 1);
+  check('panel: surfaced the open lead (funnel stage)', panel.lead?.stage === 'Contacted');
+}
+// 9b. buildCustomerPanel — unmatched contact → customer:null (UI offers "create")
+{
+  const client = makeClient(); // every SELECT returns 0 rows
+  const panel = await C.buildCustomerPanel(client, 'AM', { conversationId: 'pod_cnv_00003' }); // Tom, unmatched
+  check('panel: unmatched → customer null, matchedBy none', panel.customer === null && panel.matchedBy === 'none');
+  check('panel: unmatched → empty 360 collections', panel.workorders.length === 0 && panel.deliveries.length === 0);
+  check('panel: contact still resolved for the UI', panel.contact?.uid === 'pod_con_toMH20');
+}
+
+// 10. endpoint gates (all reached BEFORE any DB access → offline-safe)
+{
+  const res = makeRes();
+  await contactHandler(makeReq({ noAuth: true }), res);
+  check('endpoint: 401 when unauthenticated', res.statusCode === 401);
+}
+{
+  const res = makeRes();
+  await contactHandler(makeReq({ roles: ['technician'] }), res);
+  check('endpoint: 403 without sales/superadmin', res.statusCode === 403);
+}
+{
+  const res = makeRes();
+  await contactHandler(makeReq({ method: 'DELETE', roles: ['sales'] }), res);
+  check('endpoint: 405 on unsupported method', res.statusCode === 405);
+}
+{
+  const res = makeRes();
+  await contactHandler(makeReq({ method: 'GET', roles: ['sales'], query: {} }), res);
+  check('endpoint: GET 400 without conversationId/contactId', res.statusCode === 400);
+}
+{
+  const res = makeRes();
+  await contactHandler(makeReq({ method: 'POST', roles: ['superadmin'], body: { action: 'link' } }), res);
+  check('endpoint: POST 400 without conversationId/contactId', res.statusCode === 400);
+}
+{
+  const res = makeRes();
+  await contactHandler(makeReq({ method: 'POST', roles: ['sales'], body: { conversationId: 'pod_cnv_00001', action: 'frobnicate' } }), res);
+  check('endpoint: POST 400 on invalid action', res.statusCode === 400);
+}
+
+console.log(`\nAll ${passed} checks passed ✅`);


### PR DESCRIPTION
## F4 — Contact ↔ Customer bridge (increment 1 of 2: backend)

Turns a Podium conversation/contact into the portal's own `customers` row and assembles the **customer panel** the inbox side-panel needs — directly serving the 6 Jul reviewer feedback (*"customer details… phone/email"*, *"the workorder/invoice attached to the customer conversation panel so sales can check order progress without going to Delivery Operations"*, *"funnel status of each customer"*).

**This increment is backend-only** and branches off `main` (F4's deps — `customers.podium_contact_id`, the podium catch-all, `getContact` — are all on `main` via #39/#41/#45). The inbox **side-panel UI is increment 2** and waits for the F3 UI PR #46 to merge.

### What it does
`GET /api/podium/contact?conversationId=<uid>` (or `?contactId=`) →
- resolves the Podium contact behind the conversation (AS the rep, P4),
- matches a `customers` row: `podium_contact_id` → `LOWER(email)` → `phone` (last-8-digits),
- **lazily backfills** `customers.podium_contact_id` on an email/phone match (never clobbers an existing link),
- returns `{ contact, customer, matchedBy, linked, workorders[], deliveries[], lead }` — the customer's **OPEN workorders**, **ACTIVE deliveries**, and **open lead (funnel stage)**.

`POST /api/podium/contact { conversationId|contactId, action:'link'|'create', customerId?, customer? }` →
- `link` an existing customer to the contact, or `create` a customer from the contact (`customer{}` fills gaps like a missing email; **422 `EMAIL_REQUIRED`** when none is available). Creating is an explicit action — never an implicit read side effect.

### Files
- `lib/podiumContact.js` (new) — resolve/match/link/create + open workorders/deliveries + `openLeadFor` (42P01-safe) + `buildCustomerPanel`.
- `lib/podiumRoutes/contact.js` (new) — GET/POST handler, `sales`/`superadmin` gated (server is the real gate).
- `api/podium/[...podium].js` — routes `contact` as a **case in the catch-all** (no new serverless function — Hobby-cap discipline; Preview stays `nodejs:3`).
- `scripts/podium-contact-smoke.mjs` (new) — **46 offline checks**.

### Safety
- **No migration** — `customers.podium_contact_id` + `idx_customers_podium` + `idx_customers_email_lower` shipped in F0's `0001`. All SQL round-tripped against the Neon **dev** branch (match tiers, non-clobbering link, INSERT, open workorder/delivery/lead reads), temp rows cleaned up.
- **Mock-first** (`PODIUM_MOCK=true`) — reviewable on the Preview without live creds.
- **P1** upheld — only CRM metadata (contact↔customer link, customer/workorder/delivery/lead) is read/written; **no message bodies** are ever touched. **P4** — runs on the rep's own token.
- `CI=true npm run build` green (backend-only; `src/` bundle unchanged).

**Not merged — review gate.** Increment 2 (inbox side-panel UI consuming this endpoint) lands after PR #46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)