### PR TITLE
F4 (increment 2): Inbox customer side panel

### DIFF
--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -1,4 +1,5 @@
-// src/pages/inbox.js — In-portal Inbox (feature F3, increment 2: the React UI).
+// src/pages/inbox.js — In-portal Inbox (feature F3, increment 2: the React UI;
+// feature F4, increment 2: the customer side panel).
 //
 // Renders the Podium inbox LIVE on the logged-in rep's own token (P4) and stores
 // nothing (P1 — Podium is the system of record). It talks only to the F3 live-proxy
@@ -9,14 +10,28 @@
 //   POST /api/podium/inbox?resource=messages {conversationId, body}→ send a reply as the rep
 //   GET  /api/podium/inbox?resource=poll&since=<ISO>&scope=        → recently-touched convos (5–10s poll)
 //
+// F4 increment 2 adds the Podium-style split-view CUSTOMER PANEL beside the thread,
+// backed by the F4 increment-1 bridge (on main):
+//
+//   GET  /api/podium/contact?conversationId=<uid> → { contact, customer, matchedBy,
+//        linked, workorders[], deliveries[], lead }  (the matched customer + their OPEN
+//        workorders + ACTIVE deliveries + open lead / funnel stage)
+//   POST /api/podium/contact {conversationId, action:'create', customer?} → create a
+//        customer from the contact when none matched (422 EMAIL_REQUIRED → prompt).
+//
+// This directly serves Nick's 6 Jul feedback: customer details in the panel, the
+// attached workorder/invoice so a rep can check order progress without leaving the
+// inbox, and the funnel status. The broader Podium-parity conversation-list rework
+// (Open/Closed within Unassigned / All / Assigned-to-You) is F11; the AI-summary card
+// is F16 — this increment leaves a labelled slot for it.
+//
 // Default view is "My conversations" (scope=mine) — this closes F1b increment 3.
 // Mock-first: while PODIUM_MOCK=true the backend serves lib/podium.mock.js, so the
-// whole inbox is browsable on the Preview without live Podium credentials.
+// whole inbox + panel are browsable on the Preview without live Podium credentials.
 //
 // P1 GUARD: message bodies live only in this component's React state and in the live
-// request/response — nothing is written to the database. Contact NAMES (rather than the
-// raw channel identifier) arrive with the F4 contact↔customer bridge; until then the
-// list is labelled by the conversation's channel identifier.
+// request/response — nothing is written to the database. The panel reads/writes only
+// CRM metadata (customer / workorder / delivery / lead), never message text.
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
@@ -40,6 +55,16 @@ const CHANNELS = {
   whatsapp: { label: 'WhatsApp', cls: 'bg-emerald-100 text-emerald-800' },
 };
 
+// Funnel stage presentation for the lead badge (mirrors execution-plan §1c / §4.3).
+const STAGE_CLS = {
+  New: 'bg-gray-100 text-gray-700',
+  Contacted: 'bg-blue-100 text-blue-800',
+  Quoted: 'bg-amber-100 text-amber-800',
+  'Payment Received': 'bg-purple-100 text-purple-800',
+  Won: 'bg-green-100 text-green-800',
+  Lost: 'bg-red-100 text-red-700',
+};
+
 function ChannelBadge({ type }) {
   const key = String(type || '').toLowerCase();
   const c = CHANNELS[key] || { label: type || 'Chat', cls: 'bg-gray-100 text-gray-700' };
@@ -58,6 +83,23 @@ function formatTime(iso) {
     timeZone: 'Australia/Melbourne',
     day: '2-digit', month: 'short', hour: '2-digit', minute: '2-digit',
   });
+}
+
+function formatDate(iso) {
+  if (!iso) return '';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '';
+  return d.toLocaleDateString('en-AU', {
+    timeZone: 'Australia/Melbourne', day: '2-digit', month: 'short', year: 'numeric',
+  });
+}
+
+// Money (AUD) — returns null for empty/NaN so callers can hide the field.
+function money(v) {
+  if (v === null || v === undefined || v === '') return null;
+  const n = Number(v);
+  if (Number.isNaN(n)) return null;
+  return n.toLocaleString('en-AU', { style: 'currency', currency: 'AUD' });
 }
 
 // A human-ish label for a conversation until F4 resolves real contact names.
@@ -84,6 +126,13 @@ export default function Inbox() {
 
   const [draft, setDraft] = useState('');
   const [sending, setSending] = useState(false);
+
+  // F4 incr 2 — customer side panel state.
+  const [panel, setPanel] = useState(null);
+  const [panelLoading, setPanelLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [createEmail, setCreateEmail] = useState('');
+  const [needEmail, setNeedEmail] = useState(false);
 
   const sinceRef = useRef(null); // last poll cursor timestamp (server echoes serverTime)
 
@@ -156,6 +205,34 @@ export default function Inbox() {
     }
   }, [navigate]);
 
+  // F4 incr 2 — load the customer panel for the open conversation.
+  const loadPanel = useCallback(async (convId) => {
+    if (!convId) return;
+    setPanelLoading(true);
+    setPanel(null);
+    setNeedEmail(false);
+    setCreateEmail('');
+    try {
+      const res = await fetch(
+        `/api/podium/contact?conversationId=${encodeURIComponent(convId)}`,
+        { headers: authHeaders() },
+      );
+      if (res.status === 401) { navigate('/'); return; }
+      const data = await parseMaybeJson(res);
+      if (!res.ok) {
+        // A missing customer is not an error (customer:null comes back 200); only surface
+        // real failures, and keep them quiet — the panel just shows "unavailable".
+        if (res.status !== 403) toast.error(data?.error || 'Could not load customer details');
+        return;
+      }
+      setPanel(data);
+    } catch {
+      toast.error('Server error loading customer details');
+    } finally {
+      setPanelLoading(false);
+    }
+  }, [navigate]);
+
   // Load (and reload on scope change) once authorized.
   useEffect(() => {
     if (authorized) loadConversations();
@@ -191,12 +268,19 @@ export default function Inbox() {
   }, [authorized, notLinked, pollNow]);
 
   // ---- Actions -------------------------------------------------------------------
-  const switchScope = (next) => {
-    if (next === scope) return;
-    setScope(next);
+  const clearSelection = () => {
     setSelectedId(null);
     setSelectedConv(null);
     setMessages([]);
+    setPanel(null);
+    setNeedEmail(false);
+    setCreateEmail('');
+  };
+
+  const switchScope = (next) => {
+    if (next === scope) return;
+    setScope(next);
+    clearSelection();
     sinceRef.current = null;
   };
 
@@ -204,6 +288,7 @@ export default function Inbox() {
     setSelectedId(c.uid);
     setSelectedConv(c);
     loadThread(c.uid);
+    loadPanel(c.uid);
   };
 
   const sendReply = async (e) => {
@@ -243,6 +328,46 @@ export default function Inbox() {
     }
   };
 
+  // F4 incr 2 — create a portal customer from the Podium contact (explicit action).
+  const createCustomer = async () => {
+    if (!selectedId || creating) return;
+    const contactHasEmail = !!panel?.contact?.email;
+    const typedEmail = createEmail.trim();
+    if (!contactHasEmail && !typedEmail) {
+      setNeedEmail(true);
+      return;
+    }
+    setCreating(true);
+    try {
+      const payload = { conversationId: selectedId, action: 'create' };
+      if (!contactHasEmail) payload.customer = { email: typedEmail };
+      const res = await fetch('/api/podium/contact', {
+        method: 'POST',
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify(payload),
+      });
+      const data = await parseMaybeJson(res);
+      if (res.status === 401) { navigate('/'); return; }
+      if (res.status === 422 && data?.code === 'EMAIL_REQUIRED') {
+        setNeedEmail(true);
+        toast.error('An email is required to create this customer');
+        return;
+      }
+      if (!res.ok) {
+        toast.error(data?.error || 'Could not create the customer');
+        return;
+      }
+      setPanel(data); // POST returns the freshly rebuilt panel (now with a matched customer)
+      setNeedEmail(false);
+      setCreateEmail('');
+      toast.success('Customer created and linked to this contact');
+    } catch {
+      toast.error('Server error creating the customer');
+    } finally {
+      setCreating(false);
+    }
+  };
+
   // ---- Render --------------------------------------------------------------------
   if (!authorized) return null;
 
@@ -253,6 +378,10 @@ export default function Inbox() {
     return { text: 'Assigned', cls: 'text-gray-500' };
   };
 
+  // Prefer the resolved customer/contact name in the thread header once the panel loads.
+  const headerTitle =
+    panel?.customer?.name || panel?.contact?.name || convTitle(selectedConv);
+
   return (
     <>
       <div className="fixed top-4 left-6 z-50 flex gap-2">
@@ -261,7 +390,7 @@ export default function Inbox() {
       </div>
 
       <div className="min-h-screen bg-gray-100 pt-16 pb-4 px-3 md:px-6">
-        <div className="max-w-6xl mx-auto">
+        <div className="max-w-7xl mx-auto">
           <div className="flex items-center justify-between mb-4">
             <div className="flex items-center gap-2">
               <h1 className="text-2xl font-bold">Inbox</h1>
@@ -292,7 +421,7 @@ export default function Inbox() {
 
           <div className="bg-white rounded-lg shadow-md flex flex-col md:flex-row overflow-hidden" style={{ height: 'calc(100vh - 8rem)' }}>
             {/* Conversation list */}
-            <aside className={`md:w-80 border-b md:border-b-0 md:border-r border-gray-200 flex flex-col ${selectedId ? 'hidden md:flex' : 'flex'}`}>
+            <aside className={`md:w-72 border-b md:border-b-0 md:border-r border-gray-200 flex flex-col ${selectedId ? 'hidden md:flex' : 'flex'}`}>
               <div className="flex-1 overflow-y-auto">
                 {loadingConvos && (
                   <div className="p-4 text-sm text-gray-500">Loading conversations…</div>
@@ -347,7 +476,7 @@ export default function Inbox() {
             </aside>
 
             {/* Thread + composer */}
-            <section className={`flex-1 flex flex-col ${selectedId ? 'flex' : 'hidden md:flex'}`}>
+            <section className={`flex-1 min-w-0 flex flex-col ${selectedId ? 'flex' : 'hidden md:flex'}`}>
               {!selectedId && (
                 <div className="flex-1 flex items-center justify-center text-sm text-gray-400">
                   Select a conversation to view the chat.
@@ -359,14 +488,14 @@ export default function Inbox() {
                   <header className="px-4 py-3 border-b border-gray-200 flex items-center gap-3">
                     <button
                       type="button"
-                      onClick={() => { setSelectedId(null); setSelectedConv(null); setMessages([]); }}
+                      onClick={clearSelection}
                       className="md:hidden text-blue-600 text-sm"
                     >
                       ← Back
                     </button>
                     <div className="min-w-0">
                       <div className="flex items-center gap-2">
-                        <span className="font-semibold text-gray-900 truncate">{convTitle(selectedConv)}</span>
+                        <span className="font-semibold text-gray-900 truncate">{headerTitle}</span>
                         <ChannelBadge type={selectedConv?.channel?.type} />
                       </div>
                       <div className="text-xs text-gray-400">{assigneeLabel(selectedConv).text}</div>
@@ -422,13 +551,206 @@ export default function Inbox() {
                 </>
               )}
             </section>
+
+            {/* Customer side panel (F4 incr 2) — Podium-style split view. Desktop-only for
+                now; the mobile presentation + the full Podium-parity list layout are F11. */}
+            {selectedId && (
+              <aside className="hidden lg:flex lg:w-80 xl:w-96 border-l border-gray-200 flex-col bg-white">
+                <CustomerPanel
+                  loading={panelLoading}
+                  panel={panel}
+                  creating={creating}
+                  needEmail={needEmail}
+                  createEmail={createEmail}
+                  setCreateEmail={setCreateEmail}
+                  onCreate={createCustomer}
+                />
+              </aside>
+            )}
           </div>
 
           <p className="text-xs text-gray-400 mt-3">
-            Chats are read live from Podium and are never stored in the portal. Contact names arrive with the customer bridge (F4).
+            Chats are read live from Podium and are never stored in the portal. The customer
+            panel shows the matched customer, their open orders/deliveries and funnel stage.
           </p>
         </div>
       </div>
     </>
+  );
+}
+
+// ---- Customer side panel -------------------------------------------------------
+// Renders the F4 bridge result: the matched customer (or a "create from contact"
+// action when unmatched), their OPEN workorders + ACTIVE deliveries, and the open
+// lead's funnel stage. Leaves a labelled slot at the top for the F16 AI summary.
+function CustomerPanel({
+  loading, panel, creating, needEmail, createEmail, setCreateEmail, onCreate,
+}) {
+  const customer = panel?.customer || null;
+  const contact = panel?.contact || null;
+  const lead = panel?.lead || null;
+  const workorders = Array.isArray(panel?.workorders) ? panel.workorders : [];
+  const deliveries = Array.isArray(panel?.deliveries) ? panel.deliveries : [];
+
+  return (
+    <div className="flex-1 overflow-y-auto p-4 space-y-4 text-sm">
+      {/* F16 slot — Podium's auto AI summary + "Jerry" land here (not built this run). */}
+      <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50 p-3">
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">AI summary</div>
+        <div className="text-xs text-gray-400 mt-1">Auto conversation summary arrives with Jerry (F16).</div>
+      </div>
+
+      {loading && <div className="text-gray-500">Loading customer details…</div>}
+
+      {!loading && !panel && (
+        <div className="text-gray-400">Customer details unavailable.</div>
+      )}
+
+      {!loading && panel && (
+        <>
+          {/* Customer identity (or contact + create action when unmatched) */}
+          <section>
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">Customer</div>
+            {customer ? (
+              <div className="space-y-1">
+                <div className="font-semibold text-gray-900">{customer.name || 'Unnamed customer'}</div>
+                {customer.email && <Field label="Email" value={customer.email} />}
+                {customer.phone && <Field label="Phone" value={customer.phone} />}
+                {customer.address && <Field label="Address" value={customer.address} />}
+                {panel.matchedBy && panel.matchedBy !== 'none' && (
+                  <div className="text-[11px] text-gray-400 pt-1">
+                    Matched by {panel.matchedBy === 'podium_contact_id' ? 'linked Podium contact' : panel.matchedBy}
+                  </div>
+                )}
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <div className="text-gray-600">
+                  No portal customer is linked to this conversation yet.
+                </div>
+                {contact && (
+                  <div className="rounded-lg border border-gray-200 p-2 space-y-1 bg-gray-50">
+                    {contact.name && <Field label="Name" value={contact.name} />}
+                    {contact.email && <Field label="Email" value={contact.email} />}
+                    {contact.phone && <Field label="Phone" value={contact.phone} />}
+                    {!contact.name && !contact.email && !contact.phone && (
+                      <div className="text-xs text-gray-400">No contact details available from Podium.</div>
+                    )}
+                  </div>
+                )}
+                {needEmail && (
+                  <input
+                    type="email"
+                    value={createEmail}
+                    onChange={(e) => setCreateEmail(e.target.value)}
+                    placeholder="Email for the new customer"
+                    className="w-full border border-gray-300 rounded px-2 py-1.5 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+                  />
+                )}
+                <button
+                  type="button"
+                  onClick={onCreate}
+                  disabled={creating}
+                  className="w-full bg-blue-500 text-white py-2 rounded text-sm hover:bg-blue-600 disabled:opacity-50"
+                >
+                  {creating ? 'Creating…' : 'Create customer from contact'}
+                </button>
+                {needEmail && (
+                  <div className="text-[11px] text-gray-500">
+                    This contact has no email in Podium — enter one to create the customer.
+                  </div>
+                )}
+              </div>
+            )}
+          </section>
+
+          {/* Funnel stage (open lead) */}
+          <section>
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">Funnel stage</div>
+            {lead ? (
+              <div className="space-y-1">
+                <span className={`inline-block text-xs font-semibold px-2 py-0.5 rounded-full ${STAGE_CLS[lead.stage] || 'bg-gray-100 text-gray-700'}`}>
+                  {lead.stage}
+                </span>
+                {lead.product_interest && <Field label="Interest" value={lead.product_interest} />}
+                {money(lead.value_est) && <Field label="Est. value" value={money(lead.value_est)} />}
+                {lead.quote_invoice_id && <Field label="Quote/Invoice" value={lead.quote_invoice_id} />}
+              </div>
+            ) : (
+              <div className="text-gray-400">No open lead for this conversation.</div>
+            )}
+          </section>
+
+          {/* Open workorders — check order progress without leaving the inbox */}
+          <section>
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">
+              Open workorders{workorders.length ? ` (${workorders.length})` : ''}
+            </div>
+            {workorders.length === 0 ? (
+              <div className="text-gray-400">None open.</div>
+            ) : (
+              <ul className="space-y-2">
+                {workorders.map((w) => {
+                  const owing = money(w.outstanding_balance);
+                  const paid = Number(w.outstanding_balance) === 0;
+                  return (
+                    <li key={w.workorder_id} className="rounded-lg border border-gray-200 p-2">
+                      <div className="flex items-center justify-between gap-2">
+                        <span className="font-medium text-gray-900">#{w.workorder_id}</span>
+                        <span className="text-xs text-gray-500">{w.status}</span>
+                      </div>
+                      {w.invoice_id && <Field label="Invoice" value={w.invoice_id} />}
+                      {(w.delivery_suburb || w.delivery_state) && (
+                        <Field label="Deliver to" value={[w.delivery_suburb, w.delivery_state].filter(Boolean).join(', ')} />
+                      )}
+                      {owing && (
+                        <div className={`text-xs mt-0.5 ${paid ? 'text-green-700' : 'text-amber-700'}`}>
+                          {paid ? 'Paid in full' : `Outstanding ${owing}`}
+                        </div>
+                      )}
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+          </section>
+
+          {/* Active deliveries */}
+          <section>
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">
+              Active deliveries{deliveries.length ? ` (${deliveries.length})` : ''}
+            </div>
+            {deliveries.length === 0 ? (
+              <div className="text-gray-400">None active.</div>
+            ) : (
+              <ul className="space-y-2">
+                {deliveries.map((d) => (
+                  <li key={d.delivery_id} className="rounded-lg border border-gray-200 p-2">
+                    <div className="flex items-center justify-between gap-2">
+                      <span className="font-medium text-gray-900">#{d.delivery_id}</span>
+                      <span className="text-xs text-gray-500">{d.delivery_status}</span>
+                    </div>
+                    {(d.delivery_suburb || d.delivery_state) && (
+                      <Field label="To" value={[d.delivery_suburb, d.delivery_state].filter(Boolean).join(', ')} />
+                    )}
+                    {d.delivery_date && <Field label="Date" value={formatDate(d.delivery_date)} />}
+                  </li>
+                ))}
+              </ul>
+            )}
+          </section>
+        </>
+      )}
+    </div>
+  );
+}
+
+// A compact label/value row for the panel.
+function Field({ label, value }) {
+  return (
+    <div className="flex gap-2 text-xs">
+      <span className="text-gray-400 w-20 shrink-0">{label}</span>
+      <span className="text-gray-700 break-words min-w-0">{value}</span>
+    </div>
   );
 }


### PR DESCRIPTION
## F4 — Contact ↔ Customer bridge · increment 2 of 2 (inbox customer side panel)

Final increment of **F4**. Adds the **Podium-style split-view customer panel** beside the inbox thread, consuming the increment-1 bridge endpoint (`GET/POST /api/podium/contact`, already merged in #47). This closes F4.

Directly serves Nick's 6 Jul feedback: **customer details in the panel**, the **attached workorder/invoice** so a rep can check order progress without leaving the inbox, and the **funnel status**.

### What it does
When a conversation is opened, the panel calls `GET /api/podium/contact?conversationId=<uid>` and renders:
- **Matched customer** (name / email / phone / address), with a small "matched by" note — or, when no customer matches, the resolved Podium **contact** plus a **Create customer from contact** action (explicit `POST action=create`; on `422 EMAIL_REQUIRED` it reveals an email field and retries with `customer:{email}`).
- **Funnel stage** badge from the open lead (New → … → Won/Lost) + interest / est. value / quote-invoice when present.
- **Open workorders** (invoice, deliver-to, paid vs outstanding) and **active deliveries** (status, date, suburb).
- A labelled **AI summary** slot reserved for the "Jerry" AI employee (**F16**, not built here).
- The thread header now shows the resolved customer/contact **name** once the panel loads.

### Scope / guarantees
- **Frontend only** — one file changed (`src/pages/inbox.js`). **No new serverless function** (Preview stays `nodejs:3`), **no migration**.
- **P1** upheld: the panel reads/writes only CRM metadata (customer / workorder / delivery / lead); message bodies are never persisted.
- **P4**: runs on the rep's own Podium token. `sales`/`superadmin` gated (server re-checks every call).
- Still **mock-first** (`PODIUM_MOCK=true`) — browsable on the Preview without live creds (e.g. open the first SMS conversation → resolves the mock contact "Maria").
- Desktop split view (`lg+`); the mobile panel presentation and the full Podium-parity conversation-list layout (Open/Closed within Unassigned / All / Assigned-to-You) are **F11**.

### Verification
- `CI=true npm run build` green (`main.8800e493.js`, +4.26 kB).
- Regression smokes: `podium-contact` **46/46**, `podium-inbox` **38/38**, `podium-assign` **20/20**.
- Design-hook `gray-on-color` flags are the documented false positives on mutually-exclusive ternary classNames (`bg-blue-500 text-white` vs `bg-white text-gray-*`), carried over unchanged from the merged F3 UI.

### How to test
1. Open the Preview (signed into the Grays Support Vercel team — Previews are SSO-protected) and go to **/inbox** as a `sales`/`superadmin` user.
2. Open a conversation → the right-hand **customer panel** loads: for the first SMS thread (mock "Maria") you'll see the resolved contact and, if no customer matches on this DB, a **Create customer from contact** button.
3. Click **Create customer from contact** → a customer is created + linked; the panel rebuilds showing the matched customer. (If the contact has no email, e.g. the Instagram thread "Linda", the button reveals an email field first — `EMAIL_REQUIRED`.)
4. Where a matched customer has open workorders/deliveries or an open lead, confirm they render (funnel stage, invoice, outstanding balance, delivery status).
5. **P1 check:** no message body is read or written by the panel — only customer/workorder/delivery/lead metadata.

**Do not merge without review** — this is the review gate. 🤖 Generated with [Claude Code](https://claude.com/claude-code)
