### PR TITLE
F11 + F5 + F17: Inbox Podium-parity buckets, Lead funnel, Workorder popup (combined review)

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -11,6 +11,7 @@ import workorderHandler from '../lib/handlers/workorder.js';
 import deliveryHandler from '../lib/handlers/delivery.js';
 import collectionsHandler from '../lib/handlers/collections.js';
 import winningsHandler from '../lib/handlers/winnings.js';
+import leadsHandler from '../lib/handlers/leads.js';
 
 /** Robust path segmentation that works on Vercel + Next.js local */
 function segs(req) {
@@ -33,7 +34,8 @@ function methodNotAllowed(res, allow) {
 }
 
 export default async function handler(req, res) {
-  const [root, sub] = segs(req);
+  const parts = segs(req);
+  const [root, sub] = parts;
   try {
     switch (root) {
       case undefined:
@@ -81,6 +83,12 @@ export default async function handler(req, res) {
       // catch-all is behaviourally identical to their old standalone entrypoints.
       case 'workorder':
         return workorderHandler(req, res);
+      // Lead funnel (F5). Pass the segments AFTER "leads" so /api/leads/:id/stage
+      // reaches the handler as ['<id>','stage'] (this catch-all otherwise only
+      // destructures [root, sub]). Handler is JWT-gated to sales/superadmin.
+      case 'leads':
+      case 'lead':
+        return leadsHandler(req, res, parts.slice(1));
       case 'delivery':
         return deliveryHandler(req, res);
       case 'collections':

--- a/db/migrations/0002_lead_lost_reason.sql
+++ b/db/migrations/0002_lead_lost_reason.sql
@@ -1,0 +1,17 @@
+-- 0002_lead_lost_reason.sql — Lead funnel refinements (F5 feedback, 8 Jul 2026)
+--
+-- ADDITIVE + IDEMPOTENT. Apply ONLY to the Neon dev/preview branch — never prod.
+-- Paired rollback: 0002_lead_lost_reason_down.sql.
+--
+-- 1. Structured Lost-reason CATEGORY so loss reasons are quantifiable ("why are we
+--    losing leads"). The free-text `lost_reason` stays as the optional note/detail
+--    (used for the "Other" reason); the category is the countable bucket.
+-- 2. Merge the 'Payment Received' stage into 'Won' (funnel simplified per Nick — the
+--    two were practically the same). The `lead_stage` enum VALUE is left in place
+--    (Postgres can't drop an enum label cleanly) but the app no longer produces it;
+--    existing rows are moved to 'Won'. This data step is idempotent.
+
+ALTER TABLE leads ADD COLUMN IF NOT EXISTS lost_reason_category VARCHAR(40);
+
+-- Merge Payment Received → Won (idempotent — a re-run matches nothing).
+UPDATE leads SET stage = 'Won' WHERE stage = 'Payment Received';

--- a/db/migrations/0002_lead_lost_reason_down.sql
+++ b/db/migrations/0002_lead_lost_reason_down.sql
@@ -1,0 +1,9 @@
+-- 0002_lead_lost_reason_down.sql — reverse of 0002_lead_lost_reason.sql
+--
+-- Idempotent (IF EXISTS). Run ONLY on the Neon dev/preview branch.
+--
+-- NOTE: the 'Payment Received' → 'Won' stage merge is ONE-WAY — which 'Won' rows were
+-- formerly 'Payment Received' is not recorded, so it is deliberately NOT reversed here.
+-- Only the additive column is dropped.
+
+ALTER TABLE leads DROP COLUMN IF EXISTS lost_reason_category;

--- a/lib/handlers/leads.js
+++ b/lib/handlers/leads.js
@@ -1,16 +1,19 @@
 // lib/handlers/leads.js — Lead funnel API (feature F5).
 //
 // The sales pipeline over the `leads` + `lead_stage_log` tables shipped in F0's
-// migration 0001 (§4.3). Stages: New → Contacted → Quoted → Payment Received →
-// Won / Lost. Every stage change appends an append-only `lead_stage_log` row (the
-// same audit pattern as workorder_logs), and a move to Lost requires a `lost_reason`.
+// migration 0001 (§4.3). Stages: New → Contacted → Quoted → Won / Lost ('Payment
+// Received' was merged into 'Won' per Nick, 8 Jul — migration 0002). Every stage
+// change appends an append-only `lead_stage_log` row (the same audit pattern as
+// workorder_logs); a move to Lost requires a structured `lost_reason_category` (so
+// losses are quantifiable) plus an optional note (required when category = 'Other').
 //
 // Routed through the api/[...path].js catch-all as a `leads` case (Hobby-cap
 // discipline: NO new file under api/). The catch-all passes the path segments AFTER
 // "leads", so:
 //   GET  /api/leads                → list the board (optional ?stage= / ?assigned_to=)
-//   POST /api/leads                → create a New lead (+ NULL→New log)
+//   POST /api/leads                → create a lead (+ NULL→<stage> log)
 //   GET  /api/leads/:id            → one lead
+//   GET  /api/leads/:id/history    → the lead's stage history (lead_stage_log, ASC)
 //   PUT  /api/leads/:id/stage      → transition stage (+ from→to log; Lost needs a reason)
 //
 // Gated to sales/superadmin via the login JWT (getAuthUser + hasAnyRole) — the server
@@ -22,13 +25,25 @@ import { getClientWithTimezone } from '../db.js';
 import { getAuthUser, hasAnyRole } from '../rbac.js';
 
 const ALLOWED_ROLES = ['sales', 'superadmin'];
-export const STAGES = ['New', 'Contacted', 'Quoted', 'Payment Received', 'Won', 'Lost'];
+export const STAGES = ['New', 'Contacted', 'Quoted', 'Won', 'Lost'];
+
+// Structured Lost-reason categories (quantifiable). 'Other' requires a free-text note.
+// Keep in sync with the dropdown in src/pages/leads.js.
+export const LOST_REASONS = [
+  'Price / too expensive',
+  'Went with a competitor',
+  'Lead time / stock too long',
+  'Changed mind / no longer needed',
+  'No response (went cold)',
+  'Budget / finance',
+  'Other',
+];
 
 // The joined shape the Kanban board renders (customer + assignee names).
 const LEAD_SELECT = `
   SELECT l.lead_id, l.stage, l.source, l.source_channel, l.customer_id,
          l.podium_conversation_id, l.value_est, l.product_interest,
-         l.quote_invoice_id, l.assigned_to, l.lost_reason, l.notes,
+         l.quote_invoice_id, l.assigned_to, l.lost_reason, l.lost_reason_category, l.notes,
          l.last_contact_at, l.created_at, l.updated_at,
          c.name  AS customer_name, c.email AS customer_email, c.phone AS customer_phone,
          u.name  AS assigned_name
@@ -72,6 +87,7 @@ export default async function handler(req, res, sub = [], deps = {}) {
     if (method === 'GET' && !idSeg) return listLeads(req, res, client);
     if (method === 'POST' && !idSeg) return createLead(req, res, client, auth);
     if (method === 'GET' && idSeg && !action) return getLead(res, client, idSeg);
+    if (method === 'GET' && idSeg && action === 'history') return leadHistory(res, client, idSeg);
     if (method === 'PUT' && idSeg && action === 'stage') return transitionStage(req, res, client, auth, idSeg);
 
     res.setHeader('Allow', ['GET', 'POST', 'PUT']);
@@ -104,6 +120,21 @@ async function getLead(res, client, id) {
   return res.status(200).json(row);
 }
 
+// GET /api/leads/:id/history — the funnel timeline (lead_stage_log, oldest → newest,
+// with the acting user's name). Powers the "funnel history" view in the inbox panel.
+async function leadHistory(res, client, id) {
+  const r = await client.query(
+    `SELECT g.id, g.from_stage, g.to_stage, g.user_id, g.notes_log, g.created_at,
+            u.name AS user_name
+       FROM lead_stage_log g
+       LEFT JOIN users u ON u.id = g.user_id
+      WHERE g.lead_id = $1
+      ORDER BY g.created_at ASC, g.id ASC`,
+    [id]
+  );
+  return res.status(200).json({ lead_id: Number(id), history: r.rows });
+}
+
 // POST /api/leads — create a lead (+ NULL→<stage> stage log).
 // Accepts an optional conversation link (podium_conversation_id) so the inbox can add
 // a conversation to the funnel, an optional workorder link (converted_workorder_id +
@@ -119,11 +150,13 @@ async function createLead(req, res, client, auth) {
     return res.status(400).json({ error: 'A product interest, customer, or conversation is required' });
   }
 
-  // Dedupe: one open lead per conversation.
+  // Dedupe: one lead per conversation (any stage). The inbox only offers "Add to
+  // funnel" when there's no lead at all, so this is a backstop that also keeps a
+  // closed (Won/Lost) conversation from spawning a duplicate.
   if (conversationId) {
     const dup = await client.query(
       `SELECT lead_id FROM leads
-        WHERE podium_conversation_id = $1 AND stage NOT IN ('Won','Lost')
+        WHERE podium_conversation_id = $1
         ORDER BY created_at DESC LIMIT 1`,
       [conversationId]
     );
@@ -169,19 +202,36 @@ async function createLead(req, res, client, auth) {
   }
 }
 
-// PUT /api/leads/:id/stage — transition + append-only log. Lost requires a reason.
+// PUT /api/leads/:id/stage — transition + append-only log. A move to Lost requires a
+// structured lost_reason_category (from LOST_REASONS); category 'Other' also needs a
+// free-text note (lost_reason). The category is stored for quantification; lost_reason
+// keeps the note/detail.
 async function transitionStage(req, res, client, auth, id) {
   const b = req.body || {};
   const toStage = (b.to_stage ?? b.stage ?? '').toString();
   if (!STAGES.includes(toStage)) {
     return res.status(400).json({ error: `Invalid stage. One of: ${STAGES.join(', ')}` });
   }
-  const lostReason = (b.lost_reason ?? '').toString().trim();
-  if (toStage === 'Lost' && !lostReason) {
-    return res.status(400).json({ error: 'A lost_reason is required to mark a lead Lost', code: 'LOST_REASON_REQUIRED' });
+
+  const note = (b.lost_reason ?? b.note ?? '').toString().trim();
+  let lostCategory = null;
+  if (toStage === 'Lost') {
+    lostCategory = (b.lost_reason_category ?? '').toString().trim();
+    if (!lostCategory) {
+      return res.status(400).json({ error: 'A lost_reason_category is required to mark a lead Lost', code: 'LOST_REASON_REQUIRED' });
+    }
+    if (!LOST_REASONS.includes(lostCategory)) {
+      return res.status(400).json({ error: `Invalid lost reason. One of: ${LOST_REASONS.join(', ')}` });
+    }
+    if (lostCategory === 'Other' && !note) {
+      return res.status(400).json({ error: 'A note is required when the lost reason is "Other"', code: 'LOST_NOTE_REQUIRED' });
+    }
   }
   const actor = twoCharId(auth.id);
-  const noteLog = b.notes ? String(b.notes) : (toStage === 'Lost' ? lostReason : null);
+  // Log line: the category + note for a loss, else any provided note.
+  const noteLog = toStage === 'Lost'
+    ? [lostCategory, note].filter(Boolean).join(' — ')
+    : (note || null);
 
   await client.query('BEGIN');
   try {
@@ -201,10 +251,11 @@ async function transitionStage(req, res, client, auth, id) {
       `UPDATE leads
           SET stage = $1::lead_stage,
               lost_reason = CASE WHEN $1 = 'Lost' THEN $2 ELSE lost_reason END,
+              lost_reason_category = CASE WHEN $1 = 'Lost' THEN $3 ELSE lost_reason_category END,
               last_contact_at = NOW(),
               updated_at = NOW()
-        WHERE lead_id = $3`,
-      [toStage, lostReason || null, id]
+        WHERE lead_id = $4`,
+      [toStage, note || null, lostCategory, id]
     );
     await client.query(
       `INSERT INTO lead_stage_log (lead_id, from_stage, to_stage, user_id, notes_log)

--- a/lib/handlers/leads.js
+++ b/lib/handlers/leads.js
@@ -1,0 +1,193 @@
+// lib/handlers/leads.js — Lead funnel API (feature F5).
+//
+// The sales pipeline over the `leads` + `lead_stage_log` tables shipped in F0's
+// migration 0001 (§4.3). Stages: New → Contacted → Quoted → Payment Received →
+// Won / Lost. Every stage change appends an append-only `lead_stage_log` row (the
+// same audit pattern as workorder_logs), and a move to Lost requires a `lost_reason`.
+//
+// Routed through the api/[...path].js catch-all as a `leads` case (Hobby-cap
+// discipline: NO new file under api/). The catch-all passes the path segments AFTER
+// "leads", so:
+//   GET  /api/leads                → list the board (optional ?stage= / ?assigned_to=)
+//   POST /api/leads                → create a New lead (+ NULL→New log)
+//   GET  /api/leads/:id            → one lead
+//   PUT  /api/leads/:id/stage      → transition stage (+ from→to log; Lost needs a reason)
+//
+// Gated to sales/superadmin via the login JWT (getAuthUser + hasAnyRole) — the server
+// is the real authority (F9 formalises nav). Acting rep's 2-char id is the log user_id
+// and the default assignee. No message bodies are touched (P1 is not in scope here —
+// leads carry CRM metadata only).
+
+import { getClientWithTimezone } from '../db.js';
+import { getAuthUser, hasAnyRole } from '../rbac.js';
+
+const ALLOWED_ROLES = ['sales', 'superadmin'];
+export const STAGES = ['New', 'Contacted', 'Quoted', 'Payment Received', 'Won', 'Lost'];
+
+// The joined shape the Kanban board renders (customer + assignee names).
+const LEAD_SELECT = `
+  SELECT l.lead_id, l.stage, l.source, l.source_channel, l.customer_id,
+         l.podium_conversation_id, l.value_est, l.product_interest,
+         l.quote_invoice_id, l.assigned_to, l.lost_reason, l.notes,
+         l.last_contact_at, l.created_at, l.updated_at,
+         c.name  AS customer_name, c.email AS customer_email, c.phone AS customer_phone,
+         u.name  AS assigned_name
+    FROM leads l
+    LEFT JOIN customers c ON c.id = l.customer_id
+    LEFT JOIN users     u ON u.id = l.assigned_to
+`;
+
+/** Clamp a value to varchar(2) (matches twoCharId in the workorder handler). */
+function twoCharId(x) {
+  const s = (x == null ? '' : String(x)).trim().toUpperCase();
+  return (s || 'NA').slice(0, 2);
+}
+
+function toNumberOrNull(v) {
+  if (v === null || v === undefined || v === '') return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+async function fetchLeadRow(client, id) {
+  const r = await client.query(`${LEAD_SELECT} WHERE l.lead_id = $1`, [id]);
+  return r.rowCount ? r.rows[0] : null;
+}
+
+// sub = the path segments AFTER "leads" (e.g. ['5','stage'] for /api/leads/5/stage).
+// deps.getClient lets the offline smoke inject a fake pg client (default = real pool).
+export default async function handler(req, res, sub = [], deps = {}) {
+  const auth = getAuthUser(req);
+  if (!auth) return res.status(401).json({ error: 'Not authenticated' });
+  if (!hasAnyRole(auth.roles, ALLOWED_ROLES)) {
+    return res.status(403).json({ error: 'Requires the sales role to use the lead funnel' });
+  }
+
+  const [idSeg, action] = Array.isArray(sub) ? sub : [];
+  const { method } = req;
+
+  const getClient = deps.getClient || getClientWithTimezone;
+  const client = await getClient();
+  try {
+    if (method === 'GET' && !idSeg) return listLeads(req, res, client);
+    if (method === 'POST' && !idSeg) return createLead(req, res, client, auth);
+    if (method === 'GET' && idSeg && !action) return getLead(res, client, idSeg);
+    if (method === 'PUT' && idSeg && action === 'stage') return transitionStage(req, res, client, auth, idSeg);
+
+    res.setHeader('Allow', ['GET', 'POST', 'PUT']);
+    return res.status(405).json({ error: 'Method not allowed for this leads route' });
+  } catch (err) {
+    console.error('Leads API error:', err);
+    if (err?.code === '23503') return res.status(400).json({ error: 'Unknown customer or user reference' });
+    return res.status(500).json({ error: 'Server error' });
+  } finally {
+    client.release();
+  }
+}
+
+// GET /api/leads — the whole board (optionally filtered).
+async function listLeads(req, res, client) {
+  const { stage, assigned_to } = req.query || {};
+  const where = [];
+  const params = [];
+  if (stage && STAGES.includes(String(stage))) { params.push(String(stage)); where.push(`l.stage = $${params.length}::lead_stage`); }
+  if (assigned_to) { params.push(twoCharId(assigned_to)); where.push(`l.assigned_to = $${params.length}`); }
+  const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
+  const r = await client.query(`${LEAD_SELECT} ${whereSql} ORDER BY l.updated_at DESC`, params);
+  return res.status(200).json(r.rows);
+}
+
+// GET /api/leads/:id
+async function getLead(res, client, id) {
+  const row = await fetchLeadRow(client, id);
+  if (!row) return res.status(404).json({ error: 'Lead not found' });
+  return res.status(200).json(row);
+}
+
+// POST /api/leads — create a New lead (+ NULL→New stage log).
+async function createLead(req, res, client, auth) {
+  const b = req.body || {};
+  const productInterest = (b.product_interest ?? '').toString().trim();
+  const customerId = toNumberOrNull(b.customer_id);
+  if (!productInterest && !customerId) {
+    return res.status(400).json({ error: 'A product interest or a customer is required' });
+  }
+  const sourceChannel = b.source_channel ? String(b.source_channel).slice(0, 20) : null;
+  const valueEst = toNumberOrNull(b.value_est);
+  const notes = b.notes ? String(b.notes) : null;
+  const assignedTo = b.assigned_to ? twoCharId(b.assigned_to) : twoCharId(auth.id);
+  const actor = twoCharId(auth.id);
+
+  await client.query('BEGIN');
+  try {
+    const ins = await client.query(
+      `INSERT INTO leads (source, source_channel, customer_id, product_interest, value_est, assigned_to, notes, stage)
+       VALUES ('manual', $1, $2, $3, $4, $5, $6, 'New')
+       RETURNING lead_id`,
+      [sourceChannel, customerId, productInterest || null, valueEst, assignedTo, notes]
+    );
+    const leadId = ins.rows[0].lead_id;
+    await client.query(
+      `INSERT INTO lead_stage_log (lead_id, from_stage, to_stage, user_id, notes_log)
+       VALUES ($1, NULL, 'New', $2, $3)`,
+      [leadId, actor, 'Lead created']
+    );
+    await client.query('COMMIT');
+    const row = await fetchLeadRow(client, leadId);
+    return res.status(201).json(row);
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  }
+}
+
+// PUT /api/leads/:id/stage — transition + append-only log. Lost requires a reason.
+async function transitionStage(req, res, client, auth, id) {
+  const b = req.body || {};
+  const toStage = (b.to_stage ?? b.stage ?? '').toString();
+  if (!STAGES.includes(toStage)) {
+    return res.status(400).json({ error: `Invalid stage. One of: ${STAGES.join(', ')}` });
+  }
+  const lostReason = (b.lost_reason ?? '').toString().trim();
+  if (toStage === 'Lost' && !lostReason) {
+    return res.status(400).json({ error: 'A lost_reason is required to mark a lead Lost', code: 'LOST_REASON_REQUIRED' });
+  }
+  const actor = twoCharId(auth.id);
+  const noteLog = b.notes ? String(b.notes) : (toStage === 'Lost' ? lostReason : null);
+
+  await client.query('BEGIN');
+  try {
+    const cur = await client.query('SELECT stage FROM leads WHERE lead_id = $1 FOR UPDATE', [id]);
+    if (!cur.rowCount) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ error: 'Lead not found' });
+    }
+    const fromStage = cur.rows[0].stage;
+    if (fromStage === toStage) {
+      // No-op transition — don't write a spurious log row.
+      await client.query('COMMIT');
+      const same = await fetchLeadRow(client, id);
+      return res.status(200).json(same);
+    }
+    await client.query(
+      `UPDATE leads
+          SET stage = $1::lead_stage,
+              lost_reason = CASE WHEN $1 = 'Lost' THEN $2 ELSE lost_reason END,
+              last_contact_at = NOW(),
+              updated_at = NOW()
+        WHERE lead_id = $3`,
+      [toStage, lostReason || null, id]
+    );
+    await client.query(
+      `INSERT INTO lead_stage_log (lead_id, from_stage, to_stage, user_id, notes_log)
+       VALUES ($1, $2::lead_stage, $3::lead_stage, $4, $5)`,
+      [id, fromStage, toStage, actor, noteLog]
+    );
+    await client.query('COMMIT');
+    const row = await fetchLeadRow(client, id);
+    return res.status(200).json(row);
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  }
+}

--- a/lib/handlers/leads.js
+++ b/lib/handlers/leads.js
@@ -104,33 +104,61 @@ async function getLead(res, client, id) {
   return res.status(200).json(row);
 }
 
-// POST /api/leads — create a New lead (+ NULL→New stage log).
+// POST /api/leads — create a lead (+ NULL→<stage> stage log).
+// Accepts an optional conversation link (podium_conversation_id) so the inbox can add
+// a conversation to the funnel, an optional workorder link (converted_workorder_id +
+// quote_invoice_id), and an optional initial `stage` (defaults 'New'). One open lead
+// per conversation: if the conversation already has an open lead, that lead is returned
+// unchanged (idempotent — the inbox's "Add to funnel" is safe to click twice).
 async function createLead(req, res, client, auth) {
   const b = req.body || {};
   const productInterest = (b.product_interest ?? '').toString().trim();
   const customerId = toNumberOrNull(b.customer_id);
-  if (!productInterest && !customerId) {
-    return res.status(400).json({ error: 'A product interest or a customer is required' });
+  const conversationId = b.podium_conversation_id ? String(b.podium_conversation_id) : null;
+  if (!productInterest && !customerId && !conversationId) {
+    return res.status(400).json({ error: 'A product interest, customer, or conversation is required' });
   }
+
+  // Dedupe: one open lead per conversation.
+  if (conversationId) {
+    const dup = await client.query(
+      `SELECT lead_id FROM leads
+        WHERE podium_conversation_id = $1 AND stage NOT IN ('Won','Lost')
+        ORDER BY created_at DESC LIMIT 1`,
+      [conversationId]
+    );
+    if (dup.rowCount) {
+      const existing = await fetchLeadRow(client, dup.rows[0].lead_id);
+      return res.status(200).json(existing); // already in the funnel
+    }
+  }
+
   const sourceChannel = b.source_channel ? String(b.source_channel).slice(0, 20) : null;
   const valueEst = toNumberOrNull(b.value_est);
   const notes = b.notes ? String(b.notes) : null;
   const assignedTo = b.assigned_to ? twoCharId(b.assigned_to) : twoCharId(auth.id);
   const actor = twoCharId(auth.id);
+  const convertedWo = toNumberOrNull(b.converted_workorder_id);
+  const quoteInvoice = b.quote_invoice_id ? String(b.quote_invoice_id) : null;
+  const stage = b.stage && STAGES.includes(String(b.stage)) ? String(b.stage) : 'New';
+  const source = conversationId ? 'podium' : 'manual';
 
   await client.query('BEGIN');
   try {
     const ins = await client.query(
-      `INSERT INTO leads (source, source_channel, customer_id, product_interest, value_est, assigned_to, notes, stage)
-       VALUES ('manual', $1, $2, $3, $4, $5, $6, 'New')
+      `INSERT INTO leads
+         (source, source_channel, podium_conversation_id, customer_id, product_interest,
+          value_est, assigned_to, notes, quote_invoice_id, converted_workorder_id, stage)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::lead_stage)
        RETURNING lead_id`,
-      [sourceChannel, customerId, productInterest || null, valueEst, assignedTo, notes]
+      [source, sourceChannel, conversationId, customerId, productInterest || null,
+        valueEst, assignedTo, notes, quoteInvoice, convertedWo, stage]
     );
     const leadId = ins.rows[0].lead_id;
     await client.query(
       `INSERT INTO lead_stage_log (lead_id, from_stage, to_stage, user_id, notes_log)
-       VALUES ($1, NULL, 'New', $2, $3)`,
-      [leadId, actor, 'Lead created']
+       VALUES ($1, NULL, $2::lead_stage, $3, $4)`,
+      [leadId, stage, actor, conversationId ? 'Added to funnel from inbox' : 'Lead created']
     );
     await client.query('COMMIT');
     const row = await fetchLeadRow(client, leadId);

--- a/lib/podium.js
+++ b/lib/podium.js
@@ -372,6 +372,19 @@ export function getConversation(userId, conversationUid, opts = {}) {
   return request(userId, 'GET', `conversations/${conversationUid}`, { client: opts.client });
 }
 
+/** PATCH /v4/conversations/{uid} — update conversation fields. */
+export function updateConversation(userId, conversationUid, patch, opts = {}) {
+  return request(userId, 'PATCH', `conversations/${conversationUid}`, { body: patch, client: opts.client });
+}
+
+/**
+ * Open or close a conversation. VERIFY the live Podium endpoint/field for this at
+ * wiring — our reference doesn't pin it; the mock accepts a `status` patch.
+ */
+export function setConversationStatus(userId, conversationUid, status, opts = {}) {
+  return updateConversation(userId, conversationUid, { status }, opts);
+}
+
 /** GET /v4/conversations/{uid}/messages (cursor+limit). Bodies are live-only (P1). */
 export function listMessages(userId, conversationUid, opts = {}) {
   const query = {};
@@ -462,7 +475,8 @@ export default {
   buildAuthorizeUrl, exchangeCode, refreshAccessToken,
   getStoredToken, saveUserToken, tokenForUser,
   request, paginate,
-  listConversations, getConversation, listMessages, sendMessage,
+  listConversations, getConversation, updateConversation, setConversationStatus,
+  listMessages, sendMessage,
   getAssignee, assignConversation, getUsers, getContact, requestReview,
   createWebhook, listWebhooks, deleteWebhook,
 };

--- a/lib/podium.js
+++ b/lib/podium.js
@@ -350,12 +350,20 @@ export async function paginate(userId, path, opts = {}) {
 
 // ---- Endpoint helpers (§15.4) ----------------------------------------------
 
-/** GET /v4/conversations (cursor+limit). `scope:'mine'` filters by the rep. */
+/**
+ * GET /v4/conversations (cursor+limit). Filters map to the F11 inbox buckets:
+ *   • assigneeUid — "Assigned to You" / a specific rep (scope=mine)
+ *   • unassigned  — the "Unassigned" bucket (no assignee)
+ *   • status      — 'open' | 'closed' (the Open/Closed split within each bucket)
+ * VERIFY the live Podium query-param names for unassigned + status at live wiring.
+ */
 export function listConversations(userId, opts = {}) {
   const query = { ...(opts.query || {}) };
   if (opts.limit) query.limit = opts.limit;
   if (opts.cursor) query.cursor = opts.cursor;
   if (opts.assigneeUid) query.assigneeUid = opts.assigneeUid;
+  if (opts.unassigned) query.unassigned = 'true';
+  if (opts.status) query.status = opts.status;
   return request(userId, 'GET', 'conversations', { query, client: opts.client });
 }
 

--- a/lib/podium.mock.js
+++ b/lib/podium.mock.js
@@ -33,12 +33,18 @@ const LOCATION_UID = () => process.env.PODIUM_LOCATION_UID || 'pod_loc_GRAYSHQ';
 const ORG_UID = () => process.env.PODIUM_ORG_UID || 'pod_org_GRAYS';
 
 // Conversations — one per contact, spread across channels + assignees.
+// `status` (open|closed) drives the F11 Podium-parity buckets (Open vs Closed within
+// Unassigned / All / Assigned-to-You). Spread so every bucket×status cell has ≥1 row:
+//   Assigned-to-amELia: 00001 open, 00004 closed
+//   Unassigned:         00003 open, 00006 closed
+//   (00002/00005 belong to bENjin, and round out "All").
 const CONVERSATIONS = [
   {
     uid: 'pod_cnv_00001',
     channel: { type: 'phone', identifier: '+61400111222' },
     contact: { uid: 'pod_con_maRIA1' }, // deprecated hint (see §15.6) — resolve via Contacts API
     assignedUser: { uid: 'pod_usr_amELia' },
+    status: 'open',
     location: { uid: LOCATION_UID(), organizationUid: ORG_UID() },
     lastMessageAt: '2026-07-03T09:15:00+10:00',
   },
@@ -47,6 +53,7 @@ const CONVERSATIONS = [
     channel: { type: 'facebook', identifier: 'fb:graysfitness' },
     contact: { uid: 'pod_con_maRIA1' },
     assignedUser: { uid: 'pod_usr_bENjin' },
+    status: 'closed',
     location: { uid: LOCATION_UID(), organizationUid: ORG_UID() },
     lastMessageAt: '2026-07-02T16:40:00+10:00',
   },
@@ -55,6 +62,7 @@ const CONVERSATIONS = [
     channel: { type: 'phone', identifier: '+61400333444' },
     contact: { uid: 'pod_con_toMH20' },
     assignedUser: null, // unassigned — auto-created lead would be unassigned (P12)
+    status: 'open',
     location: { uid: LOCATION_UID(), organizationUid: ORG_UID() },
     lastMessageAt: '2026-07-03T08:02:00+10:00',
   },
@@ -63,6 +71,7 @@ const CONVERSATIONS = [
     channel: { type: 'instagram', identifier: 'ig:graysfitness' },
     contact: { uid: 'pod_con_liNDA3' },
     assignedUser: { uid: 'pod_usr_amELia' },
+    status: 'closed',
     location: { uid: LOCATION_UID(), organizationUid: ORG_UID() },
     lastMessageAt: '2026-07-01T11:20:00+10:00',
   },
@@ -71,8 +80,18 @@ const CONVERSATIONS = [
     channel: { type: 'google', identifier: 'gbm:graysfitness' },
     contact: { uid: 'pod_con_jaKE44' },
     assignedUser: { uid: 'pod_usr_bENjin' },
+    status: 'open',
     location: { uid: LOCATION_UID(), organizationUid: ORG_UID() },
     lastMessageAt: '2026-07-03T07:45:00+10:00',
+  },
+  {
+    uid: 'pod_cnv_00006',
+    channel: { type: 'webchat', identifier: 'web:graysfitness' },
+    contact: { uid: 'pod_con_toMH20' },
+    assignedUser: null, // unassigned + closed — the Unassigned/Closed bucket cell
+    status: 'closed',
+    location: { uid: LOCATION_UID(), organizationUid: ORG_UID() },
+    lastMessageAt: '2026-06-30T14:05:00+10:00',
   },
 ];
 
@@ -96,6 +115,10 @@ const MESSAGES = {
   ],
   pod_cnv_00005: [
     { uid: 'pod_msg_0005a', direction: 'inbound', channel: 'google', body: 'Can I get a quote for a full home gym setup?', createdAt: '2026-07-03T07:45:00+10:00' },
+  ],
+  pod_cnv_00006: [
+    { uid: 'pod_msg_0006a', direction: 'inbound', channel: 'webchat', body: 'Do you deliver to regional Victoria?', createdAt: '2026-06-30T14:00:00+10:00' },
+    { uid: 'pod_msg_0006b', direction: 'outbound', channel: 'webchat', body: 'We do — happy to sort a quote when you are ready. Closing this off for now.', createdAt: '2026-06-30T14:05:00+10:00' },
   ],
 };
 
@@ -198,7 +221,17 @@ export function handle(method, path, opts = {}) {
     // GET /conversations
     if (!segs[1]) {
       let items = CONVERSATIONS;
-      if (query.assigneeUid) items = items.filter((c) => c.assignedUser?.uid === query.assigneeUid);
+      // F11 buckets: `unassigned=true` (no assignee) wins; else `assigneeUid` (mine);
+      // else all. `status=open|closed` narrows either. VERIFY the live Podium param
+      // names for the unassigned + status filters at live wiring (§15.5 note).
+      if (query.unassigned === 'true' || query.unassigned === true) {
+        items = items.filter((c) => !c.assignedUser?.uid);
+      } else if (query.assigneeUid) {
+        items = items.filter((c) => c.assignedUser?.uid === query.assigneeUid);
+      }
+      if (query.status === 'open' || query.status === 'closed') {
+        items = items.filter((c) => (c.status || 'open') === query.status);
+      }
       return paginateList(items, query);
     }
     const convUid = segs[1];

--- a/lib/podium.mock.js
+++ b/lib/podium.mock.js
@@ -252,7 +252,15 @@ export function handle(method, path, opts = {}) {
     }
     // GET|PATCH /conversations/{uid}
     if (!conv) return notFound('conversation', convUid);
-    if (m === 'PATCH') return { ...conv, ...body };
+    if (m === 'PATCH') {
+      // Mutate the in-memory fixture so open/close (and other field patches) persist
+      // for this serverless instance — the conversation then moves between the F11
+      // Open/Closed buckets. (Cold starts reset the mock; fine for a Preview demo.)
+      const idx = CONVERSATIONS.findIndex((c) => c.uid === convUid);
+      if (idx === -1) return { ...conv, ...body };
+      Object.assign(CONVERSATIONS[idx], body);
+      return CONVERSATIONS[idx];
+    }
     return conv;
   }
 

--- a/lib/podiumContact.js
+++ b/lib/podiumContact.js
@@ -215,12 +215,14 @@ export async function activeDeliveriesForCustomer(client, customerId) {
 }
 
 /**
- * The customer's OPEN lead (funnel stage), matched by conversation → contact →
- * customer, whichever we have. Defensive: returns null if the leads table isn't
- * migrated on this DB yet (42P01) — so Production (pre-F0-release) still serves the
- * panel; the funnel just shows empty until leads exist.
+ * The customer's most-recent lead (funnel stage), matched by conversation → contact →
+ * customer, whichever we have. Returns the latest lead at ANY stage (incl. Won/Lost) so
+ * the inbox panel can show the current funnel stage + history even after a deal closes,
+ * and only offers "Add to funnel" when there is no lead at all. Defensive: returns null
+ * if the leads table isn't migrated yet (42P01) — Production (pre-F0-release) still
+ * serves the panel; the funnel just shows empty until leads exist.
  */
-export async function openLeadFor(client, { customerId = null, contactUid = null, conversationId = null } = {}) {
+export async function latestLeadFor(client, { customerId = null, contactUid = null, conversationId = null } = {}) {
   if (!customerId && !contactUid && !conversationId) return null;
   try {
     const r = await client.query(
@@ -228,8 +230,7 @@ export async function openLeadFor(client, { customerId = null, contactUid = null
               quote_invoice_id, payment, converted_workorder_id,
               last_contact_at, created_at, updated_at
          FROM leads
-        WHERE stage NOT IN ('Won','Lost')
-          AND ( ($1::varchar IS NOT NULL AND podium_conversation_id = $1)
+        WHERE ( ($1::varchar IS NOT NULL AND podium_conversation_id = $1)
              OR ($2::varchar IS NOT NULL AND podium_contact_id = $2)
              OR ($3::int     IS NOT NULL AND customer_id = $3) )
         ORDER BY updated_at DESC
@@ -282,7 +283,7 @@ export async function buildCustomerPanel(client, userId, { conversationId, conta
     panel.deliveries = await activeDeliveriesForCustomer(client, customer.id);
   }
 
-  panel.lead = await openLeadFor(client, {
+  panel.lead = await latestLeadFor(client, {
     customerId: customer?.id || null,
     contactUid: contact.uid || null,
     conversationId: conversationId ? String(conversationId) : null,
@@ -300,6 +301,6 @@ export default {
   createCustomerFromContact,
   openWorkordersForCustomer,
   activeDeliveriesForCustomer,
-  openLeadFor,
+  latestLeadFor,
   buildCustomerPanel,
 };

--- a/lib/podiumInbox.js
+++ b/lib/podiumInbox.js
@@ -82,4 +82,28 @@ export function clampLimit(raw, fallback = 30) {
   return Math.min(Math.max(n, 1), 100);
 }
 
-export default { resolveSelfPodiumUid, filterUpdatedSince, clampLimit };
+/**
+ * Normalise the F11 conversation bucket. Accepts the new `bucket` param
+ * (mine|unassigned|all) and the legacy F3 `scope` alias (mine|all). Anything else
+ * falls back to 'mine' — preserving the F1b increment-3 default ("My conversations").
+ */
+export function normalizeBucket(raw) {
+  const v = String(raw ?? '').toLowerCase();
+  if (v === 'all') return 'all';
+  if (v === 'unassigned') return 'unassigned';
+  return 'mine';
+}
+
+/**
+ * Normalise the Open/Closed status filter. 'open'|'closed' narrow the list; anything
+ * else (incl. 'all' or absent) returns null = no status filter. Podium-like default is
+ * chosen by the caller (the route defaults to 'open').
+ */
+export function normalizeStatus(raw) {
+  const v = String(raw ?? '').toLowerCase();
+  return v === 'open' || v === 'closed' ? v : null;
+}
+
+export default {
+  resolveSelfPodiumUid, filterUpdatedSince, clampLimit, normalizeBucket, normalizeStatus,
+};

--- a/lib/podiumRoutes/inbox.js
+++ b/lib/podiumRoutes/inbox.js
@@ -28,7 +28,9 @@
 
 import { getAuthUser, hasAnyRole } from '../rbac.js';
 import { listConversations, listMessages, sendMessage, isMock } from '../podium.js';
-import { resolveSelfPodiumUid, filterUpdatedSince, clampLimit } from '../podiumInbox.js';
+import {
+  resolveSelfPodiumUid, filterUpdatedSince, clampLimit, normalizeBucket, normalizeStatus,
+} from '../podiumInbox.js';
 import { getClientWithTimezone } from '../db.js';
 
 const ALLOWED_ROLES = ['sales', 'superadmin'];
@@ -59,32 +61,38 @@ export default async function handler(req, res) {
   return res.status(400).json({ error: 'Unknown inbox resource', resource: resource || null });
 }
 
-// GET ?resource=conversations — list the rep's conversations (default "mine").
+// GET ?resource=conversations — list conversations for an F11 bucket + status.
+//   bucket = mine (default) | unassigned | all   (legacy `scope` alias still honoured)
+//   status = open (default) | closed | all
 async function listConversationsRoute(req, res, auth) {
-  const scope = req.query?.scope === 'all' ? 'all' : 'mine';
+  const bucket = normalizeBucket(req.query?.bucket ?? req.query?.scope);
+  const status = normalizeStatus(req.query?.status ?? 'open');
   const cursor = req.query?.cursor ? String(req.query.cursor) : undefined;
   const limit = clampLimit(req.query?.limit, 30);
 
   const client = await getClientWithTimezone();
   try {
-    let assigneeUid;
-    if (scope === 'mine') {
-      assigneeUid = await resolveSelfPodiumUid(client, auth);
+    const filters = { cursor, limit, status: status || undefined, client };
+    if (bucket === 'mine') {
+      const assigneeUid = await resolveSelfPodiumUid(client, auth);
       if (!assigneeUid) {
         // Rep hasn't linked their Podium account (or no member match) — there is no
-        // "mine" set. Empty page + a hint so the UI can prompt to connect, rather than
-        // silently falling back to everyone's conversations.
+        // "mine" set. Empty page + a hint so the UI can prompt to connect (or switch to
+        // the Unassigned / All buckets), rather than silently showing everyone's.
         return res.status(200).json({
           data: [], metadata: { nextCursor: null, previousCursor: null },
-          scope, notLinked: true, mock: isMock(),
+          bucket, scope: bucket, status, notLinked: true, mock: isMock(),
         });
       }
+      filters.assigneeUid = assigneeUid;
+    } else if (bucket === 'unassigned') {
+      filters.unassigned = true;
     }
-    const resp = await listConversations(auth.id, { cursor, limit, assigneeUid, client });
+    const resp = await listConversations(auth.id, filters);
     return res.status(200).json({
       data: Array.isArray(resp?.data) ? resp.data : [],
       metadata: resp?.metadata || { nextCursor: null, previousCursor: null },
-      scope, notLinked: false, mock: isMock(),
+      bucket, scope: bucket, status, notLinked: false, mock: isMock(),
     });
   } catch (err) {
     return respondUpstreamError(res, err, 'list conversations');
@@ -125,9 +133,11 @@ async function sendMessageRoute(req, res, auth) {
   }
 }
 
-// GET ?resource=poll — conversations touched since the client's last cursor.
+// GET ?resource=poll — conversations touched since the client's last cursor, within
+// the current bucket + status (so a poll never surfaces rows from a different tab).
 async function pollRoute(req, res, auth) {
-  const scope = req.query?.scope === 'all' ? 'all' : 'mine';
+  const bucket = normalizeBucket(req.query?.bucket ?? req.query?.scope);
+  const status = normalizeStatus(req.query?.status ?? 'open');
   const since = req.query?.since ? String(req.query.since) : null;
   const cursor = req.query?.cursor ? String(req.query.cursor) : undefined;
   const limit = clampLimit(req.query?.limit, 50);
@@ -135,19 +145,22 @@ async function pollRoute(req, res, auth) {
 
   const client = await getClientWithTimezone();
   try {
-    let assigneeUid;
-    if (scope === 'mine') {
-      assigneeUid = await resolveSelfPodiumUid(client, auth);
+    const filters = { cursor, limit, status: status || undefined, client };
+    if (bucket === 'mine') {
+      const assigneeUid = await resolveSelfPodiumUid(client, auth);
       if (!assigneeUid) {
-        return res.status(200).json({ data: [], serverTime, scope, notLinked: true, mock: isMock() });
+        return res.status(200).json({ data: [], serverTime, bucket, scope: bucket, status, notLinked: true, mock: isMock() });
       }
+      filters.assigneeUid = assigneeUid;
+    } else if (bucket === 'unassigned') {
+      filters.unassigned = true;
     }
-    const resp = await listConversations(auth.id, { cursor, limit, assigneeUid, client });
+    const resp = await listConversations(auth.id, filters);
     const updated = filterUpdatedSince(Array.isArray(resp?.data) ? resp.data : [], since);
     return res.status(200).json({
       data: updated, serverTime,
       metadata: resp?.metadata || { nextCursor: null, previousCursor: null },
-      scope, mock: isMock(),
+      bucket, scope: bucket, status, mock: isMock(),
     });
   } catch (err) {
     return respondUpstreamError(res, err, 'poll conversations');

--- a/lib/podiumRoutes/inbox.js
+++ b/lib/podiumRoutes/inbox.js
@@ -27,7 +27,7 @@
 // endpoint writes NO chat content to the database. Podium is the system of record.
 
 import { getAuthUser, hasAnyRole } from '../rbac.js';
-import { listConversations, listMessages, sendMessage, setConversationStatus, isMock } from '../podium.js';
+import { listConversations, getConversation, listMessages, sendMessage, setConversationStatus, isMock } from '../podium.js';
 import {
   resolveSelfPodiumUid, filterUpdatedSince, clampLimit, normalizeBucket, normalizeStatus,
 } from '../podiumInbox.js';
@@ -62,7 +62,25 @@ export default async function handler(req, res) {
     if (method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
     return setStatusRoute(req, res, auth);
   }
+  if (resource === 'conversation') {
+    if (method !== 'GET') return res.status(405).json({ error: 'Method not allowed' });
+    return getConversationRoute(req, res, auth);
+  }
   return res.status(400).json({ error: 'Unknown inbox resource', resource: resource || null });
+}
+
+// GET ?resource=conversation&conversationId=<uid> — fetch a single conversation so the
+// funnel can deep-link straight into its chat (the target may not be in the current
+// bucket/status filter). No DB touched; runs on the rep's token (P4).
+async function getConversationRoute(req, res, auth) {
+  const conversationId = req.query?.conversationId;
+  if (!conversationId) return res.status(400).json({ error: 'conversationId is required' });
+  try {
+    const conversation = await getConversation(auth.id, String(conversationId));
+    return res.status(200).json({ conversation, mock: isMock() });
+  } catch (err) {
+    return respondUpstreamError(res, err, 'load the conversation');
+  }
 }
 
 // POST ?resource=status { conversationId, status:'open'|'closed' } — a salesperson

--- a/lib/podiumRoutes/inbox.js
+++ b/lib/podiumRoutes/inbox.js
@@ -27,7 +27,7 @@
 // endpoint writes NO chat content to the database. Podium is the system of record.
 
 import { getAuthUser, hasAnyRole } from '../rbac.js';
-import { listConversations, listMessages, sendMessage, isMock } from '../podium.js';
+import { listConversations, listMessages, sendMessage, setConversationStatus, isMock } from '../podium.js';
 import {
   resolveSelfPodiumUid, filterUpdatedSince, clampLimit, normalizeBucket, normalizeStatus,
 } from '../podiumInbox.js';
@@ -58,7 +58,28 @@ export default async function handler(req, res) {
     if (method !== 'GET') return res.status(405).json({ error: 'Method not allowed' });
     return pollRoute(req, res, auth);
   }
+  if (resource === 'status') {
+    if (method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+    return setStatusRoute(req, res, auth);
+  }
   return res.status(400).json({ error: 'Unknown inbox resource', resource: resource || null });
+}
+
+// POST ?resource=status { conversationId, status:'open'|'closed' } — a salesperson
+// opens/closes a conversation (drives the F11 Open/Closed buckets). Runs on the rep's
+// token (P4); no DB touched. Live Podium endpoint/field is a VERIFY at wiring.
+async function setStatusRoute(req, res, auth) {
+  const { conversationId, status } = req.body || {};
+  if (!conversationId) return res.status(400).json({ error: 'conversationId is required' });
+  if (status !== 'open' && status !== 'closed') {
+    return res.status(400).json({ error: "status must be 'open' or 'closed'" });
+  }
+  try {
+    const conversation = await setConversationStatus(auth.id, String(conversationId), status);
+    return res.status(200).json({ conversationId: String(conversationId), status, conversation, mock: isMock() });
+  } catch (err) {
+    return respondUpstreamError(res, err, 'update the conversation status');
+  }
 }
 
 // GET ?resource=conversations — list conversations for an F11 bucket + status.

--- a/scripts/podium-contact-smoke.mjs
+++ b/scripts/podium-contact-smoke.mjs
@@ -170,17 +170,17 @@ check('phoneKey: empty → empty', C.phoneKey(null) === '');
   check("deliveries: excludes 'Delivery Completed'", /delivery_status <> 'Delivery Completed'/.test(call.sql));
 }
 
-// 8. openLeadFor — defensive against a DB without the leads table (42P01)
+// 8. latestLeadFor — defensive against a DB without the leads table (42P01)
 {
   const client = makeClient([{ match: isSelLead, result: { rowCount: 1, rows: [{ lead_id: 5, stage: 'Contacted' }] } }]);
-  const lead = await C.openLeadFor(client, { customerId: 7, contactUid: 'pod_con_maRIA1', conversationId: 'pod_cnv_00001' });
-  check('lead: returns the open lead', lead?.stage === 'Contacted');
+  const lead = await C.latestLeadFor(client, { customerId: 7, contactUid: 'pod_con_maRIA1', conversationId: 'pod_cnv_00001' });
+  check('lead: returns the latest lead', lead?.stage === 'Contacted');
 }
 {
   const client = makeClient([{ match: isSelLead, throws: pgErr('42P01') }]);
-  const lead = await C.openLeadFor(client, { customerId: 7 });
+  const lead = await C.latestLeadFor(client, { customerId: 7 });
   check('lead: null (not throw) when leads table absent (42P01)', lead === null);
-  check('lead: null with no identifiers, no query', (await C.openLeadFor(makeClient(), {})) === null);
+  check('lead: null with no identifiers, no query', (await C.latestLeadFor(makeClient(), {})) === null);
 }
 
 // 9. buildCustomerPanel — end-to-end (mock contact + fake DB): email match → backfill → 360

--- a/scripts/podium-inbox-smoke.mjs
+++ b/scripts/podium-inbox-smoke.mjs
@@ -236,6 +236,32 @@ for (const resource of ['conversations', 'poll']) {
   }
 }
 
+// ---- resource=status — open/close a conversation ------------------------------
+console.log('\ninbox resource=status (open/close):');
+{
+  const res = makeRes();
+  await inboxHandler(makeReq({ method: 'GET', query: { resource: 'status' } }), res);
+  check('status: 405 for GET', res.statusCode === 405);
+}
+{
+  const res = makeRes();
+  await inboxHandler(makeReq({ method: 'POST', query: { resource: 'status' }, body: { status: 'closed' } }), res);
+  check('status: 400 without conversationId', res.statusCode === 400);
+}
+{
+  const res = makeRes();
+  await inboxHandler(makeReq({ method: 'POST', query: { resource: 'status' }, body: { conversationId: 'pod_cnv_00006', status: 'weird' } }), res);
+  check('status: 400 for an invalid status value', res.statusCode === 400);
+}
+{
+  const res = makeRes();
+  await inboxHandler(makeReq({ method: 'POST', query: { resource: 'status' }, body: { conversationId: 'pod_cnv_00001', status: 'closed' } }), res);
+  check('status: 200 close mutates the conversation', res.statusCode === 200 && res.body.status === 'closed' && res.body.conversation?.status === 'closed', `status ${res.statusCode}`);
+  // The mock now returns it under the Closed bucket for the assignee.
+  const closedForAmelia = await listConversations('AM', { assigneeUid: 'pod_usr_amELia', status: 'closed' });
+  check('status: closed conversation moves into the Closed bucket', closedForAmelia.data.some((c) => c.uid === 'pod_cnv_00001'));
+}
+
 // ---- direct helper sanity: sendMessage / listMessages via mock ----------------
 console.log('\nmock helpers:');
 {

--- a/scripts/podium-inbox-smoke.mjs
+++ b/scripts/podium-inbox-smoke.mjs
@@ -262,6 +262,24 @@ console.log('\ninbox resource=status (open/close):');
   check('status: closed conversation moves into the Closed bucket', closedForAmelia.data.some((c) => c.uid === 'pod_cnv_00001'));
 }
 
+// ---- resource=conversation — single fetch for the funnel → chat deep-link -------
+console.log('\ninbox resource=conversation (deep-link):');
+{
+  const res = makeRes();
+  await inboxHandler(makeReq({ method: 'POST', query: { resource: 'conversation' } }), res);
+  check('conversation: 405 for POST', res.statusCode === 405);
+}
+{
+  const res = makeRes();
+  await inboxHandler(makeReq({ method: 'GET', query: { resource: 'conversation' } }), res);
+  check('conversation: 400 without conversationId', res.statusCode === 400);
+}
+{
+  const res = makeRes();
+  await inboxHandler(makeReq({ method: 'GET', query: { resource: 'conversation', conversationId: 'pod_cnv_00002' } }), res);
+  check('conversation: 200 returns the single conversation', res.statusCode === 200 && res.body.conversation?.uid === 'pod_cnv_00002', `status ${res.statusCode}`);
+}
+
 // ---- direct helper sanity: sendMessage / listMessages via mock ----------------
 console.log('\nmock helpers:');
 {

--- a/scripts/podium-inbox-smoke.mjs
+++ b/scripts/podium-inbox-smoke.mjs
@@ -22,7 +22,7 @@ process.env.JWT_SECRET = process.env.JWT_SECRET || 'smoke_secret';
 process.env.PODIUM_API_VERSION = process.env.PODIUM_API_VERSION || '2021-04-01';
 
 const jwt = (await import('jsonwebtoken')).default;
-const { clampLimit, filterUpdatedSince, resolveSelfPodiumUid } = await import('../lib/podiumInbox.js');
+const { clampLimit, filterUpdatedSince, resolveSelfPodiumUid, normalizeBucket, normalizeStatus } = await import('../lib/podiumInbox.js');
 const { listConversations, listMessages, sendMessage } = await import('../lib/podium.js');
 const inboxHandler = (await import('../lib/podiumRoutes/inbox.js')).default;
 
@@ -130,8 +130,33 @@ console.log('\nlistConversations mine-filter (mock):');
   check('mine: filters by assignee uid', Array.isArray(mine.data) && mine.data.every((c) => c.assignedUser?.uid === 'pod_usr_amELia'));
   check('mine: amELia owns 2 fixture conversations', mine.data.length === 2, `got ${mine.data.length}`);
   const all = await listConversations('AM', {});
-  check('all: unfiltered returns every fixture conversation', all.data.length === 5, `got ${all.data.length}`);
+  check('all: unfiltered returns every fixture conversation', all.data.length === 6, `got ${all.data.length}`);
   check('all: cursor pagination envelope present', 'metadata' in all && 'nextCursor' in all.metadata);
+}
+
+// ---- F11 buckets: normalizers + unassigned/status filters (mock) --------------
+console.log('\nF11 buckets (normalizers + filters):');
+{
+  check('normalizeBucket: default → mine', normalizeBucket(undefined) === 'mine' && normalizeBucket('nonsense') === 'mine');
+  check('normalizeBucket: legacy scope=all → all', normalizeBucket('all') === 'all');
+  check('normalizeBucket: unassigned', normalizeBucket('unassigned') === 'unassigned');
+  check('normalizeStatus: open/closed pass through', normalizeStatus('open') === 'open' && normalizeStatus('closed') === 'closed');
+  check('normalizeStatus: absent/all → null (no filter)', normalizeStatus(undefined) === null && normalizeStatus('all') === null);
+
+  const unassigned = await listConversations('AM', { unassigned: true });
+  check('unassigned: every row has no assignee', unassigned.data.every((c) => !c.assignedUser?.uid));
+  check('unassigned: 2 fixtures (00003 open, 00006 closed)', unassigned.data.length === 2, `got ${unassigned.data.length}`);
+
+  const open = await listConversations('AM', { status: 'open' });
+  check('status=open: only open conversations', open.data.every((c) => (c.status || 'open') === 'open'));
+  const closed = await listConversations('AM', { status: 'closed' });
+  check('status=closed: only closed conversations', closed.data.every((c) => c.status === 'closed'));
+  check('open + closed partition the 6 fixtures', open.data.length + closed.data.length === 6, `got ${open.data.length}+${closed.data.length}`);
+
+  const mineClosed = await listConversations('AM', { assigneeUid: 'pod_usr_amELia', status: 'closed' });
+  check('mine+closed: amELia has exactly 1 closed (00004)', mineClosed.data.length === 1 && mineClosed.data[0].uid === 'pod_cnv_00004', `got ${mineClosed.data.map((x) => x.uid)}`);
+  const unassignedOpen = await listConversations('AM', { unassigned: true, status: 'open' });
+  check('unassigned+open: exactly 1 (00003)', unassignedOpen.data.length === 1 && unassignedOpen.data[0].uid === 'pod_cnv_00003', `got ${unassignedOpen.data.map((x) => x.uid)}`);
 }
 
 // ---- inbox.js dispatcher — top-level gates + unknown resource -----------------

--- a/scripts/podium-leads-smoke.mjs
+++ b/scripts/podium-leads-smoke.mjs
@@ -117,7 +117,33 @@ console.log('\nPOST /api/leads:');
   check('201 create returns the new lead', res.statusCode === 201 && res.body.lead_id === 99, `status ${res.statusCode}`);
   check('create is transactional (BEGIN + COMMIT)', client.calls.some((c) => /BEGIN/i.test(c.sql)) && client.calls.some((c) => /COMMIT/i.test(c.sql)));
   const logCall = client.calls.find((c) => /lead_stage_log/i.test(c.sql));
-  check('create writes a NULL→New stage log', !!logCall && /NULL,\s*'New'/i.test(logCall.sql) && logCall.params[0] === 99, `sql/params ${logCall && JSON.stringify(logCall.params)}`);
+  check('create writes a NULL→New stage log', !!logCall && /NULL,\s*\$2::lead_stage/i.test(logCall.sql) && logCall.params[0] === 99 && logCall.params[1] === 'New', `sql/params ${logCall && JSON.stringify(logCall.params)}`);
+}
+// Add-to-funnel: create from a conversation with a workorder link + initial stage.
+{
+  const client = makeClient([
+    { match: /SELECT lead_id FROM leads/i, result: { rowCount: 0, rows: [] } }, // no dup
+    { match: /INSERT INTO leads/i, result: { rowCount: 1, rows: [{ lead_id: 120 }] } },
+    { match: /FROM leads l/i, result: { rowCount: 1, rows: [{ lead_id: 120, stage: 'Payment Received' }] } },
+  ]);
+  const res = makeRes();
+  await leadsHandler(makeReq({ method: 'POST', body: { podium_conversation_id: 'pod_cnv_00005', customer_id: 555, converted_workorder_id: 751, quote_invoice_id: '99999', stage: 'Payment Received' } }), res, [], depsFor(client));
+  check('201 add-to-funnel with conversation + workorder link', res.statusCode === 201 && res.body.lead_id === 120);
+  const ins = client.calls.find((c) => /INSERT INTO leads/i.test(c.sql));
+  check('add-to-funnel: source=podium, conversation + WO + invoice + stage persisted',
+    ins && ins.params[0] === 'podium' && ins.params[2] === 'pod_cnv_00005' && ins.params[9] === 751 && ins.params[8] === '99999' && ins.params[10] === 'Payment Received',
+    `params ${ins && JSON.stringify(ins.params)}`);
+}
+// Add-to-funnel is idempotent: an open lead already on the conversation → return it, no insert.
+{
+  const client = makeClient([
+    { match: /SELECT lead_id FROM leads/i, result: { rowCount: 1, rows: [{ lead_id: 121 }] } }, // dup exists
+    { match: /FROM leads l/i, result: { rowCount: 1, rows: [{ lead_id: 121, stage: 'Payment Received' }] } },
+  ]);
+  const res = makeRes();
+  await leadsHandler(makeReq({ method: 'POST', body: { podium_conversation_id: 'pod_cnv_00005', customer_id: 555 } }), res, [], depsFor(client));
+  check('add-to-funnel: existing open lead returned (200), no duplicate insert',
+    res.statusCode === 200 && res.body.lead_id === 121 && !client.calls.some((c) => /INSERT INTO leads/i.test(c.sql)));
 }
 
 // ---- PUT stage ----------------------------------------------------------------

--- a/scripts/podium-leads-smoke.mjs
+++ b/scripts/podium-leads-smoke.mjs
@@ -14,7 +14,7 @@ process.env.JWT_SECRET = process.env.JWT_SECRET || 'smoke_secret';
 
 const jwt = (await import('jsonwebtoken')).default;
 const leadsHandler = (await import('../lib/handlers/leads.js')).default;
-const { STAGES } = await import('../lib/handlers/leads.js');
+const { STAGES, LOST_REASONS } = await import('../lib/handlers/leads.js');
 
 let passed = 0;
 function check(name, cond, detail) {
@@ -60,9 +60,10 @@ function makeRes() {
 
 console.log('Lead funnel (F5) smoke — fake client, no DB\n');
 
-// ---- exported constant --------------------------------------------------------
+// ---- exported constants -------------------------------------------------------
 console.log('STAGES:');
-check('STAGES are the canonical funnel stages', JSON.stringify(STAGES) === JSON.stringify(['New', 'Contacted', 'Quoted', 'Payment Received', 'Won', 'Lost']));
+check('STAGES: Payment Received merged into Won', JSON.stringify(STAGES) === JSON.stringify(['New', 'Contacted', 'Quoted', 'Won', 'Lost']));
+check('LOST_REASONS include Other', Array.isArray(LOST_REASONS) && LOST_REASONS.includes('Other') && LOST_REASONS.length >= 5);
 
 // ---- auth gates (return before any DB) ----------------------------------------
 console.log('\nauth gates:');
@@ -124,14 +125,14 @@ console.log('\nPOST /api/leads:');
   const client = makeClient([
     { match: /SELECT lead_id FROM leads/i, result: { rowCount: 0, rows: [] } }, // no dup
     { match: /INSERT INTO leads/i, result: { rowCount: 1, rows: [{ lead_id: 120 }] } },
-    { match: /FROM leads l/i, result: { rowCount: 1, rows: [{ lead_id: 120, stage: 'Payment Received' }] } },
+    { match: /FROM leads l/i, result: { rowCount: 1, rows: [{ lead_id: 120, stage: 'Won' }] } },
   ]);
   const res = makeRes();
-  await leadsHandler(makeReq({ method: 'POST', body: { podium_conversation_id: 'pod_cnv_00005', customer_id: 555, converted_workorder_id: 751, quote_invoice_id: '99999', stage: 'Payment Received' } }), res, [], depsFor(client));
+  await leadsHandler(makeReq({ method: 'POST', body: { podium_conversation_id: 'pod_cnv_00005', customer_id: 555, converted_workorder_id: 751, quote_invoice_id: '99999', stage: 'Won' } }), res, [], depsFor(client));
   check('201 add-to-funnel with conversation + workorder link', res.statusCode === 201 && res.body.lead_id === 120);
   const ins = client.calls.find((c) => /INSERT INTO leads/i.test(c.sql));
   check('add-to-funnel: source=podium, conversation + WO + invoice + stage persisted',
-    ins && ins.params[0] === 'podium' && ins.params[2] === 'pod_cnv_00005' && ins.params[9] === 751 && ins.params[8] === '99999' && ins.params[10] === 'Payment Received',
+    ins && ins.params[0] === 'podium' && ins.params[2] === 'pod_cnv_00005' && ins.params[9] === 751 && ins.params[8] === '99999' && ins.params[10] === 'Won',
     `params ${ins && JSON.stringify(ins.params)}`);
 }
 // Add-to-funnel is idempotent: an open lead already on the conversation → return it, no insert.
@@ -156,7 +157,17 @@ console.log('\nPUT /api/leads/:id/stage:');
 {
   const res = makeRes();
   await leadsHandler(makeReq({ method: 'PUT', body: { to_stage: 'Lost' } }), res, ['5', 'stage'], depsFor(makeClient()));
-  check('400 LOST_REASON_REQUIRED when Lost has no reason', res.statusCode === 400 && res.body.code === 'LOST_REASON_REQUIRED');
+  check('400 LOST_REASON_REQUIRED when Lost has no category', res.statusCode === 400 && res.body.code === 'LOST_REASON_REQUIRED');
+}
+{
+  const res = makeRes();
+  await leadsHandler(makeReq({ method: 'PUT', body: { to_stage: 'Lost', lost_reason_category: 'Not a real reason' } }), res, ['5', 'stage'], depsFor(makeClient()));
+  check('400 for an unknown lost reason category', res.statusCode === 400);
+}
+{
+  const res = makeRes();
+  await leadsHandler(makeReq({ method: 'PUT', body: { to_stage: 'Lost', lost_reason_category: 'Other' } }), res, ['5', 'stage'], depsFor(makeClient()));
+  check('400 LOST_NOTE_REQUIRED when category is Other with no note', res.statusCode === 400 && res.body.code === 'LOST_NOTE_REQUIRED');
 }
 {
   const client = makeClient([
@@ -181,17 +192,19 @@ console.log('\nPUT /api/leads/:id/stage:');
   check('no-op transition returns 200 and writes NO log', res.statusCode === 200 && !client.calls.some((c) => /lead_stage_log/i.test(c.sql)));
 }
 {
-  // Lost with a reason updates + logs
+  // Lost with a valid category + note updates (category + note) + logs
   const client = makeClient([
     { match: /SELECT stage FROM leads/i, result: { rowCount: 1, rows: [{ stage: 'Quoted' }] } },
     { match: /UPDATE leads/i, result: { rowCount: 1 } },
-    { match: /FROM leads l/i, result: { rowCount: 1, rows: [{ lead_id: 7, stage: 'Lost', lost_reason: 'Bought elsewhere' }] } },
+    { match: /FROM leads l/i, result: { rowCount: 1, rows: [{ lead_id: 7, stage: 'Lost' }] } },
   ]);
   const res = makeRes();
-  await leadsHandler(makeReq({ method: 'PUT', body: { to_stage: 'Lost', lost_reason: 'Bought elsewhere' } }), res, ['7', 'stage'], depsFor(client));
-  check('200 Lost with a reason', res.statusCode === 200 && res.body.stage === 'Lost');
+  await leadsHandler(makeReq({ method: 'PUT', body: { to_stage: 'Lost', lost_reason_category: 'Went with a competitor', lost_reason: 'chose BrandX' } }), res, ['7', 'stage'], depsFor(client));
+  check('200 Lost with a valid category', res.statusCode === 200 && res.body.stage === 'Lost');
   const upd = client.calls.find((c) => /UPDATE leads/i.test(c.sql));
-  check('lost_reason passed to UPDATE', !!upd && upd.params.includes('Bought elsewhere'));
+  check('category + note passed to UPDATE', !!upd && upd.params.includes('Went with a competitor') && upd.params.includes('chose BrandX'));
+  const logCall = client.calls.find((c) => /lead_stage_log/i.test(c.sql));
+  check('stage log note combines category + note', !!logCall && /Went with a competitor — chose BrandX/.test(logCall.params[4] || ''));
 }
 {
   // lead not found
@@ -199,6 +212,22 @@ console.log('\nPUT /api/leads/:id/stage:');
   const res = makeRes();
   await leadsHandler(makeReq({ method: 'PUT', body: { to_stage: 'Contacted' } }), res, ['404', 'stage'], depsFor(client));
   check('404 when the lead does not exist', res.statusCode === 404);
+}
+
+// ---- GET /api/leads/:id/history -----------------------------------------------
+console.log('\nGET /api/leads/:id/history:');
+{
+  const client = makeClient([
+    { match: /FROM lead_stage_log/i, result: { rowCount: 2, rows: [
+      { id: 1, from_stage: null, to_stage: 'New', created_at: 't1' },
+      { id: 2, from_stage: 'New', to_stage: 'Contacted', created_at: 't2' },
+    ] } },
+  ]);
+  const res = makeRes();
+  await leadsHandler(makeReq({ method: 'GET' }), res, ['7', 'history'], depsFor(client));
+  check('200 returns the stage history (ASC)', res.statusCode === 200 && res.body.lead_id === 7 && res.body.history.length === 2);
+  const q = client.calls.find((c) => /FROM lead_stage_log/i.test(c.sql));
+  check('history query ordered oldest → newest', !!q && /ORDER BY .*created_at ASC/i.test(q.sql));
 }
 
 console.log(`\n✅ leads smoke: ${passed} checks passed`);

--- a/scripts/podium-leads-smoke.mjs
+++ b/scripts/podium-leads-smoke.mjs
@@ -1,0 +1,178 @@
+// scripts/podium-leads-smoke.mjs — offline smoke for the F5 lead-funnel handler.
+//
+// Exercises lib/handlers/leads.js with an INJECTED fake pg client (deps.getClient), so
+// there is NO network, NO database, NO secrets:
+//
+//   node scripts/podium-leads-smoke.mjs
+//
+// Covers: auth/role gates, routing (list/create/getById/stage), stage validation
+// (invalid stage, Lost-requires-reason), the NULL→New create log, from→to transition
+// logging, the no-op transition (no spurious log), and 404s. The end-to-end SQL is
+// additionally round-tripped against the Neon dev branch (see report).
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'smoke_secret';
+
+const jwt = (await import('jsonwebtoken')).default;
+const leadsHandler = (await import('../lib/handlers/leads.js')).default;
+const { STAGES } = await import('../lib/handlers/leads.js');
+
+let passed = 0;
+function check(name, cond, detail) {
+  if (!cond) throw new Error(`FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  passed += 1;
+  console.log(`  ✓ ${name}`);
+}
+
+// ---- Fake pg client (records queries, returns scripted results) ---------------
+function makeClient(scripts = []) {
+  const calls = [];
+  return {
+    calls,
+    released: false,
+    release() { this.released = true; },
+    async query(sql, params) {
+      calls.push({ sql, params });
+      for (const s of scripts) {
+        if (typeof s.match === 'function' ? s.match(sql) : s.match.test(sql)) {
+          if (s.throws) throw s.throws;
+          return s.result ?? { rowCount: 0, rows: [] };
+        }
+      }
+      return { rowCount: 0, rows: [] };
+    },
+  };
+}
+const depsFor = (client) => ({ getClient: async () => client });
+
+function makeReq({ method = 'GET', roles = ['sales'], id = 'SA', email = 'sales@graysfitness.com.au', query = {}, body = {}, noAuth = false } = {}) {
+  const headers = {};
+  if (!noAuth) headers.authorization = `Bearer ${jwt.sign({ id, email, roles }, process.env.JWT_SECRET, { expiresIn: '1h' })}`;
+  return { method, headers, query, body };
+}
+function makeRes() {
+  return {
+    statusCode: 0, body: null, headers: {},
+    setHeader(k, v) { this.headers[k] = v; },
+    status(c) { this.statusCode = c; return this; },
+    json(o) { this.body = o; return this; },
+  };
+}
+
+console.log('Lead funnel (F5) smoke — fake client, no DB\n');
+
+// ---- exported constant --------------------------------------------------------
+console.log('STAGES:');
+check('STAGES are the canonical funnel stages', JSON.stringify(STAGES) === JSON.stringify(['New', 'Contacted', 'Quoted', 'Payment Received', 'Won', 'Lost']));
+
+// ---- auth gates (return before any DB) ----------------------------------------
+console.log('\nauth gates:');
+{
+  const res = makeRes();
+  await leadsHandler(makeReq({ noAuth: true }), res, [], depsFor(makeClient()));
+  check('401 without auth', res.statusCode === 401);
+}
+{
+  const res = makeRes();
+  await leadsHandler(makeReq({ roles: ['technician'] }), res, [], depsFor(makeClient()));
+  check('403 for a non-sales role', res.statusCode === 403);
+}
+{
+  const res = makeRes();
+  await leadsHandler(makeReq({ roles: ['superadmin'], method: 'DELETE' }), res, [], depsFor(makeClient()));
+  check('405 for an unsupported method', res.statusCode === 405);
+}
+
+// ---- GET list -----------------------------------------------------------------
+console.log('\nGET /api/leads:');
+{
+  const client = makeClient([{ match: /FROM leads l/i, result: { rowCount: 2, rows: [{ lead_id: 1, stage: 'New' }, { lead_id: 2, stage: 'Won' }] } }]);
+  const res = makeRes();
+  await leadsHandler(makeReq(), res, [], depsFor(client));
+  check('200 returns the board rows', res.statusCode === 200 && Array.isArray(res.body) && res.body.length === 2, `status ${res.statusCode}`);
+  check('client released', client.released === true);
+}
+{
+  // ?stage= filter adds a WHERE clause
+  const client = makeClient([{ match: /FROM leads l/i, result: { rowCount: 1, rows: [{ lead_id: 3, stage: 'Quoted' }] } }]);
+  const res = makeRes();
+  await leadsHandler(makeReq({ query: { stage: 'Quoted' } }), res, [], depsFor(client));
+  const listCall = client.calls.find((c) => /FROM leads l/i.test(c.sql));
+  check('stage filter param passed', res.statusCode === 200 && listCall.params.includes('Quoted'));
+}
+
+// ---- POST create --------------------------------------------------------------
+console.log('\nPOST /api/leads:');
+{
+  const res = makeRes();
+  await leadsHandler(makeReq({ method: 'POST', body: {} }), res, [], depsFor(makeClient()));
+  check('400 when neither product_interest nor customer given', res.statusCode === 400);
+}
+{
+  const client = makeClient([
+    { match: /INSERT INTO leads/i, result: { rowCount: 1, rows: [{ lead_id: 99 }] } },
+    { match: /FROM leads l/i, result: { rowCount: 1, rows: [{ lead_id: 99, stage: 'New', product_interest: 'Rowing machine' }] } },
+  ]);
+  const res = makeRes();
+  await leadsHandler(makeReq({ method: 'POST', body: { product_interest: 'Rowing machine', value_est: 1795, source_channel: 'phone' } }), res, [], depsFor(client));
+  check('201 create returns the new lead', res.statusCode === 201 && res.body.lead_id === 99, `status ${res.statusCode}`);
+  check('create is transactional (BEGIN + COMMIT)', client.calls.some((c) => /BEGIN/i.test(c.sql)) && client.calls.some((c) => /COMMIT/i.test(c.sql)));
+  const logCall = client.calls.find((c) => /lead_stage_log/i.test(c.sql));
+  check('create writes a NULL→New stage log', !!logCall && /NULL,\s*'New'/i.test(logCall.sql) && logCall.params[0] === 99, `sql/params ${logCall && JSON.stringify(logCall.params)}`);
+}
+
+// ---- PUT stage ----------------------------------------------------------------
+console.log('\nPUT /api/leads/:id/stage:');
+{
+  const res = makeRes();
+  await leadsHandler(makeReq({ method: 'PUT', body: { to_stage: 'Nonsense' } }), res, ['5', 'stage'], depsFor(makeClient()));
+  check('400 for an invalid stage', res.statusCode === 400);
+}
+{
+  const res = makeRes();
+  await leadsHandler(makeReq({ method: 'PUT', body: { to_stage: 'Lost' } }), res, ['5', 'stage'], depsFor(makeClient()));
+  check('400 LOST_REASON_REQUIRED when Lost has no reason', res.statusCode === 400 && res.body.code === 'LOST_REASON_REQUIRED');
+}
+{
+  const client = makeClient([
+    { match: /SELECT stage FROM leads/i, result: { rowCount: 1, rows: [{ stage: 'New' }] } },
+    { match: /UPDATE leads/i, result: { rowCount: 1 } },
+    { match: /FROM leads l/i, result: { rowCount: 1, rows: [{ lead_id: 5, stage: 'Contacted' }] } },
+  ]);
+  const res = makeRes();
+  await leadsHandler(makeReq({ method: 'PUT', body: { to_stage: 'Contacted' } }), res, ['5', 'stage'], depsFor(client));
+  check('200 transitions the lead', res.statusCode === 200 && res.body.stage === 'Contacted', `status ${res.statusCode}`);
+  const logCall = client.calls.find((c) => /lead_stage_log/i.test(c.sql));
+  check('logs from→to (New→Contacted)', !!logCall && logCall.params[1] === 'New' && logCall.params[2] === 'Contacted');
+}
+{
+  // no-op: from === to → no log row
+  const client = makeClient([
+    { match: /SELECT stage FROM leads/i, result: { rowCount: 1, rows: [{ stage: 'Contacted' }] } },
+    { match: /FROM leads l/i, result: { rowCount: 1, rows: [{ lead_id: 5, stage: 'Contacted' }] } },
+  ]);
+  const res = makeRes();
+  await leadsHandler(makeReq({ method: 'PUT', body: { to_stage: 'Contacted' } }), res, ['5', 'stage'], depsFor(client));
+  check('no-op transition returns 200 and writes NO log', res.statusCode === 200 && !client.calls.some((c) => /lead_stage_log/i.test(c.sql)));
+}
+{
+  // Lost with a reason updates + logs
+  const client = makeClient([
+    { match: /SELECT stage FROM leads/i, result: { rowCount: 1, rows: [{ stage: 'Quoted' }] } },
+    { match: /UPDATE leads/i, result: { rowCount: 1 } },
+    { match: /FROM leads l/i, result: { rowCount: 1, rows: [{ lead_id: 7, stage: 'Lost', lost_reason: 'Bought elsewhere' }] } },
+  ]);
+  const res = makeRes();
+  await leadsHandler(makeReq({ method: 'PUT', body: { to_stage: 'Lost', lost_reason: 'Bought elsewhere' } }), res, ['7', 'stage'], depsFor(client));
+  check('200 Lost with a reason', res.statusCode === 200 && res.body.stage === 'Lost');
+  const upd = client.calls.find((c) => /UPDATE leads/i.test(c.sql));
+  check('lost_reason passed to UPDATE', !!upd && upd.params.includes('Bought elsewhere'));
+}
+{
+  // lead not found
+  const client = makeClient([{ match: /SELECT stage FROM leads/i, result: { rowCount: 0, rows: [] } }]);
+  const res = makeRes();
+  await leadsHandler(makeReq({ method: 'PUT', body: { to_stage: 'Contacted' } }), res, ['404', 'stage'], depsFor(client));
+  check('404 when the lead does not exist', res.statusCode === 404);
+}
+
+console.log(`\n✅ leads smoke: ${passed} checks passed`);

--- a/scripts/podium-smoke.mjs
+++ b/scripts/podium-smoke.mjs
@@ -64,7 +64,7 @@ const page2 = await podium.listConversations(REP, { limit: 2, cursor: page1.meta
 check('listConversations page2 is a different page', page2.data[0].uid !== page1.data[0].uid);
 
 const allConvos = await podium.paginate(REP, 'conversations', { limit: 2 });
-check('paginate() walks every conversation', allConvos.length === 5, `got ${allConvos.length}`);
+check('paginate() walks every conversation', allConvos.length === 6, `got ${allConvos.length}`);
 
 // 7. "My conversations" filter (drives F1b/F3 default view)
 const mine = await podium.listConversations(REP, { assigneeUid: 'pod_usr_amELia' });

--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import Register from './pages/register';
 import LandingPage from './pages/landingpage';
 import Settings from './pages/settings';
 import Inbox from './pages/inbox';
+import Leads from './pages/leads';
 
 import ProductsPage from './pages/products';
 import EditProduct from './pages/products/edit';
@@ -104,6 +105,7 @@ function App() {
         <Route path="/dashboard" element={<Dashboard />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/inbox" element={<Inbox />} />
+        <Route path="/leads" element={<Leads />} />
 
         <Route path="/products" element={<ProductsPage />} />
         <Route path="/products/:sku/edit" element={<EditProduct />} />

--- a/src/pages/dashboard.js
+++ b/src/pages/dashboard.js
@@ -43,8 +43,10 @@ export default function Dashboard() {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
   const isWorkshop = user?.email === 'workshop@graysfitness.com.au';
-  // F3: the in-portal Inbox is a sales tool (server also gates /api/podium/inbox).
+  // F3/F5: the in-portal Inbox and lead funnel are sales tools (the server also gates
+  // /api/podium/inbox and /api/leads).
   const canUseInbox = hasAnyRole(getRoles(), ['sales', 'superadmin']);
+  const canUseLeads = canUseInbox;
 
   // base datasets
   const [products, setProducts] = useState([]);
@@ -264,6 +266,13 @@ export default function Dashboard() {
           {canUseInbox && (
             <Link to="/inbox" className="text-gray-700 hover:bg-gray-200 p-2 rounded">
               Inbox
+            </Link>
+          )}
+
+          {/* Lead funnel — sales/superadmin (F5) */}
+          {canUseLeads && (
+            <Link to="/leads" className="text-gray-700 hover:bg-gray-200 p-2 rounded">
+              Lead Funnel
             </Link>
           )}
 

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -148,6 +148,9 @@ export default function Inbox() {
   // Feedback (8 Jul): open/close a conversation + add a conversation to the funnel.
   const [statusSaving, setStatusSaving] = useState(false);
   const [addingLead, setAddingLead] = useState(false);
+  // Funnel stage history (timeline) for the conversation's lead.
+  const [leadHistory, setLeadHistory] = useState([]);
+  const deepLinkedRef = useRef(false); // one-shot: open ?conversation= from a funnel deep-link
 
   const sinceRef = useRef(null); // last poll cursor timestamp (server echoes serverTime)
 
@@ -248,10 +251,54 @@ export default function Inbox() {
     }
   }, [navigate]);
 
+  // Funnel stage history (timeline) for the panel's lead — when/if there is one.
+  const loadLeadHistory = useCallback(async (leadId) => {
+    if (!leadId) { setLeadHistory([]); return; }
+    try {
+      const res = await fetch(`/api/leads/${leadId}/history`, { headers: authHeaders() });
+      if (!res.ok) { setLeadHistory([]); return; }
+      const data = await parseMaybeJson(res);
+      setLeadHistory(Array.isArray(data?.history) ? data.history : []);
+    } catch {
+      setLeadHistory([]);
+    }
+  }, []);
+
+  // Fetch the timeline whenever the panel resolves a lead.
+  useEffect(() => {
+    loadLeadHistory(panel?.lead?.lead_id || null);
+  }, [panel, loadLeadHistory]);
+
   // Load (and reload on scope change) once authorized.
   useEffect(() => {
     if (authorized) loadConversations();
   }, [authorized, loadConversations]);
+
+  // Funnel → chat deep-link: open ?conversation=<uid> once, even if it's not in the
+  // current bucket/status. Fetches the conversation directly and opens its thread+panel.
+  useEffect(() => {
+    if (!authorized || deepLinkedRef.current) return;
+    const convId = new URLSearchParams(window.location.search).get('conversation');
+    if (!convId) return;
+    deepLinkedRef.current = true;
+    setBucket('all'); // widen the list so the deep-linked thread isn't behind a notLinked prompt
+    (async () => {
+      try {
+        const res = await fetch(
+          `/api/podium/inbox?resource=conversation&conversationId=${encodeURIComponent(convId)}`,
+          { headers: authHeaders() },
+        );
+        if (res.status === 401) { navigate('/'); return; }
+        const data = await parseMaybeJson(res);
+        if (res.ok && data?.conversation) {
+          setSelectedId(convId);
+          setSelectedConv(data.conversation);
+          loadThread(convId);
+          loadPanel(convId);
+        }
+      } catch { /* deep-link is best-effort */ }
+    })();
+  }, [authorized, navigate, loadThread, loadPanel]);
 
   // ---- Poll: refresh the list (and the open thread) for new activity -------------
   const pollNow = useCallback(async () => {
@@ -328,6 +375,7 @@ export default function Inbox() {
     setCreateEmail('');
     setWoOpenId(null);
     setWoDetail(null);
+    setLeadHistory([]);
   };
 
   const switchBucket = (next) => {
@@ -396,7 +444,7 @@ export default function Inbox() {
       if (wo) {
         payload.converted_workorder_id = wo.workorder_id;
         if (wo.invoice_id) payload.quote_invoice_id = wo.invoice_id;
-        payload.stage = 'Payment Received';
+        payload.stage = 'Won'; // a raised workorder = a closed-won deal
       }
       const res = await fetch('/api/leads', {
         method: 'POST',
@@ -725,6 +773,7 @@ export default function Inbox() {
                   onOpenWorkorder={openWorkorder}
                   onAddToFunnel={addToFunnel}
                   addingLead={addingLead}
+                  leadHistory={leadHistory}
                 />
               </aside>
             )}
@@ -756,7 +805,7 @@ export default function Inbox() {
 // lead's funnel stage. Leaves a labelled slot at the top for the F16 AI summary.
 function CustomerPanel({
   loading, panel, creating, needEmail, createEmail, setCreateEmail, onCreate, onOpenWorkorder,
-  onAddToFunnel, addingLead,
+  onAddToFunnel, addingLead, leadHistory,
 }) {
   const customer = panel?.customer || null;
   const contact = panel?.contact || null;
@@ -836,7 +885,7 @@ function CustomerPanel({
             )}
           </section>
 
-          {/* Funnel stage (open lead) */}
+          {/* Funnel stage + history timeline */}
           <section>
             <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">Funnel stage</div>
             {lead ? (
@@ -847,10 +896,11 @@ function CustomerPanel({
                 {lead.product_interest && <Field label="Interest" value={lead.product_interest} />}
                 {money(lead.value_est) && <Field label="Est. value" value={money(lead.value_est)} />}
                 {lead.quote_invoice_id && <Field label="Quote/Invoice" value={lead.quote_invoice_id} />}
+                <FunnelTimeline history={leadHistory} />
               </div>
             ) : (
               <div className="space-y-2">
-                <div className="text-gray-400">No open lead for this conversation.</div>
+                <div className="text-gray-400">Not in the funnel yet.</div>
                 {customer && onAddToFunnel && (
                   <button
                     type="button"
@@ -947,6 +997,30 @@ function Field({ label, value }) {
     <div className="flex gap-2 text-xs">
       <span className="text-gray-400 w-20 shrink-0">{label}</span>
       <span className="text-gray-700 break-words min-w-0">{value}</span>
+    </div>
+  );
+}
+
+// Funnel stage history (timeline) — when the lead arrived, was quoted, won/lost, etc.
+// Fed by GET /api/leads/:id/history (oldest → newest).
+function FunnelTimeline({ history }) {
+  const rows = Array.isArray(history) ? history : [];
+  if (rows.length === 0) return null;
+  return (
+    <div className="pt-2">
+      <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">Funnel history</div>
+      <ol className="space-y-1.5 border-l border-gray-200 pl-3">
+        {rows.map((h) => (
+          <li key={h.id} className="relative">
+            <span className="absolute -left-[0.95rem] top-1.5 w-1.5 h-1.5 rounded-full bg-blue-400" />
+            <div className="text-xs font-medium text-gray-800">{h.to_stage}</div>
+            <div className="text-[11px] text-gray-400">
+              {formatTime(h.created_at)}{h.user_name ? ` · ${h.user_name}` : ''}
+            </div>
+            {h.notes_log && <div className="text-[11px] text-gray-500 break-words">{h.notes_log}</div>}
+          </li>
+        ))}
+      </ol>
     </div>
   );
 }

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -5,10 +5,14 @@
 // nothing (P1 — Podium is the system of record). It talks only to the F3 live-proxy
 // dispatcher shipped in increment 1:
 //
-//   GET  /api/podium/inbox?resource=conversations&scope=mine|all   → the conversation list
+//   GET  /api/podium/inbox?resource=conversations&bucket=&status=  → the conversation list
 //   GET  /api/podium/inbox?resource=messages&conversationId=<uid>  → a live thread
 //   POST /api/podium/inbox?resource=messages {conversationId, body}→ send a reply as the rep
-//   GET  /api/podium/inbox?resource=poll&since=<ISO>&scope=        → recently-touched convos (5–10s poll)
+//   GET  /api/podium/inbox?resource=poll&since=<ISO>&bucket=&status= → recently-touched convos (5–10s poll)
+//
+// F11 adds Podium-parity conversation buckets: bucket ∈ {mine (Assigned to You,
+// default), unassigned, all} × status ∈ {open (default), closed}. The default
+// bucket=mine preserves the F1b increment-3 "My conversations" view.
 //
 // F4 increment 2 adds the Podium-style split-view CUSTOMER PANEL beside the thread,
 // backed by the F4 increment-1 bridge (on main):
@@ -113,7 +117,9 @@ export default function Inbox() {
   const [authorized, setAuthorized] = useState(false);
   const [myPodiumUid, setMyPodiumUid] = useState(null);
 
-  const [scope, setScope] = useState('mine');
+  // F11 Podium-parity buckets: bucket (mine|unassigned|all) × status (open|closed).
+  const [bucket, setBucket] = useState('mine');
+  const [status, setStatus] = useState('open');
   const [conversations, setConversations] = useState([]);
   const [notLinked, setNotLinked] = useState(false);
   const [mock, setMock] = useState(false);
@@ -162,7 +168,7 @@ export default function Inbox() {
     if (!silent) setLoadingConvos(true);
     try {
       const res = await fetch(
-        `/api/podium/inbox?resource=conversations&scope=${scope}&limit=30`,
+        `/api/podium/inbox?resource=conversations&bucket=${bucket}&status=${status}&limit=30`,
         { headers: authHeaders() },
       );
       if (res.status === 401) { navigate('/'); return; }
@@ -181,7 +187,7 @@ export default function Inbox() {
     } finally {
       if (!silent) setLoadingConvos(false);
     }
-  }, [scope, navigate]);
+  }, [bucket, status, navigate]);
 
   const loadThread = useCallback(async (convId, { silent = false } = {}) => {
     if (!convId) return;
@@ -243,7 +249,7 @@ export default function Inbox() {
     try {
       const since = sinceRef.current ? `&since=${encodeURIComponent(sinceRef.current)}` : '';
       const res = await fetch(
-        `/api/podium/inbox?resource=poll&scope=${scope}${since}`,
+        `/api/podium/inbox?resource=poll&bucket=${bucket}&status=${status}${since}`,
         { headers: authHeaders() },
       );
       if (!res.ok) return;
@@ -259,7 +265,7 @@ export default function Inbox() {
     } catch {
       /* polls are best-effort; ignore transient errors */
     }
-  }, [scope, selectedId, loadConversations, loadThread]);
+  }, [bucket, status, selectedId, loadConversations, loadThread]);
 
   useEffect(() => {
     if (!authorized || notLinked) return undefined;
@@ -277,9 +283,16 @@ export default function Inbox() {
     setCreateEmail('');
   };
 
-  const switchScope = (next) => {
-    if (next === scope) return;
-    setScope(next);
+  const switchBucket = (next) => {
+    if (next === bucket) return;
+    setBucket(next);
+    clearSelection();
+    sinceRef.current = null;
+  };
+
+  const switchStatus = (next) => {
+    if (next === status) return;
+    setStatus(next);
     clearSelection();
     sinceRef.current = null;
   };
@@ -391,7 +404,7 @@ export default function Inbox() {
 
       <div className="min-h-screen bg-gray-100 pt-16 pb-4 px-3 md:px-6">
         <div className="max-w-7xl mx-auto">
-          <div className="flex items-center justify-between mb-4">
+          <div className="flex flex-col gap-3 mb-4 lg:flex-row lg:items-center lg:justify-between">
             <div className="flex items-center gap-2">
               <h1 className="text-2xl font-bold">Inbox</h1>
               {mock && (
@@ -400,22 +413,40 @@ export default function Inbox() {
                 </span>
               )}
             </div>
-            {/* Scope toggle: My conversations (default) vs All */}
-            <div className="inline-flex rounded-lg border border-gray-300 overflow-hidden text-sm">
-              <button
-                type="button"
-                onClick={() => switchScope('mine')}
-                className={scope === 'mine' ? 'px-3 py-1.5 bg-blue-500 text-white' : 'px-3 py-1.5 bg-white text-gray-700 hover:bg-gray-50'}
-              >
-                My conversations
-              </button>
-              <button
-                type="button"
-                onClick={() => switchScope('all')}
-                className={scope === 'all' ? 'px-3 py-1.5 bg-blue-500 text-white' : 'px-3 py-1.5 bg-white text-gray-700 hover:bg-gray-50'}
-              >
-                All
-              </button>
+            {/* F11 Podium-parity: bucket tabs (Assigned to You / Unassigned / All) +
+                an Open/Closed split. */}
+            <div className="flex flex-wrap items-center gap-2">
+              <div className="inline-flex rounded-lg border border-gray-300 overflow-hidden text-sm">
+                {[
+                  { key: 'mine', label: 'Assigned to You' },
+                  { key: 'unassigned', label: 'Unassigned' },
+                  { key: 'all', label: 'All' },
+                ].map((b) => (
+                  <button
+                    key={b.key}
+                    type="button"
+                    onClick={() => switchBucket(b.key)}
+                    className={bucket === b.key ? 'px-3 py-1.5 bg-blue-500 text-white' : 'px-3 py-1.5 bg-white text-gray-700 hover:bg-gray-50'}
+                  >
+                    {b.label}
+                  </button>
+                ))}
+              </div>
+              <div className="inline-flex rounded-lg border border-gray-300 overflow-hidden text-sm">
+                {[
+                  { key: 'open', label: 'Open' },
+                  { key: 'closed', label: 'Closed' },
+                ].map((s) => (
+                  <button
+                    key={s.key}
+                    type="button"
+                    onClick={() => switchStatus(s.key)}
+                    className={status === s.key ? 'px-3 py-1.5 bg-gray-800 text-white' : 'px-3 py-1.5 bg-white text-gray-700 hover:bg-gray-50'}
+                  >
+                    {s.label}
+                  </button>
+                ))}
+              </div>
             </div>
           </div>
 
@@ -439,7 +470,7 @@ export default function Inbox() {
                     </button>
                     <button
                       type="button"
-                      onClick={() => switchScope('all')}
+                      onClick={() => switchBucket('all')}
                       className="w-full border border-gray-300 text-gray-700 py-2 rounded hover:bg-gray-50"
                     >
                       View all conversations instead
@@ -448,7 +479,9 @@ export default function Inbox() {
                 )}
 
                 {!loadingConvos && !notLinked && conversations.length === 0 && (
-                  <div className="p-4 text-sm text-gray-500">No conversations{scope === 'mine' ? ' assigned to you' : ''} yet.</div>
+                  <div className="p-4 text-sm text-gray-500">
+                    No {status} conversations{bucket === 'mine' ? ' assigned to you' : bucket === 'unassigned' ? ' unassigned' : ''}.
+                  </div>
                 )}
 
                 {!loadingConvos && conversations.map((c) => {

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -140,6 +140,11 @@ export default function Inbox() {
   const [createEmail, setCreateEmail] = useState('');
   const [needEmail, setNeedEmail] = useState(false);
 
+  // F17 — workorder detail modal (opened from a workorder card in the panel).
+  const [woDetail, setWoDetail] = useState(null);
+  const [woLoading, setWoLoading] = useState(false);
+  const [woOpenId, setWoOpenId] = useState(null);
+
   const sinceRef = useRef(null); // last poll cursor timestamp (server echoes serverTime)
 
   // ---- Gate (client-side display only; the server re-checks every request) -------
@@ -273,6 +278,42 @@ export default function Inbox() {
     return () => clearInterval(id);
   }, [authorized, notLinked, pollNow]);
 
+  // F17 — open a workorder's full detail in a modal. Reuses the existing
+  // GET /api/workorder?id= endpoint, which returns { ...workorder, items, activity }.
+  // It only exposes selling_price to a superadmin actor (via x-user-id, which the inbox
+  // never sends) — so a plain sales rep sees item name/qty/condition/status + workorder
+  // payment only, honouring the selling_price visibility rule.
+  const openWorkorder = useCallback(async (workorderId) => {
+    if (!workorderId) return;
+    setWoOpenId(workorderId);
+    setWoDetail(null);
+    setWoLoading(true);
+    try {
+      const res = await fetch(`/api/workorder?id=${encodeURIComponent(workorderId)}`, {
+        headers: authHeaders(),
+      });
+      if (res.status === 401) { navigate('/'); return; }
+      const data = await parseMaybeJson(res);
+      if (!res.ok) {
+        toast.error(data?.error || 'Could not load the workorder');
+        setWoOpenId(null);
+        return;
+      }
+      setWoDetail(data);
+    } catch {
+      toast.error('Server error loading the workorder');
+      setWoOpenId(null);
+    } finally {
+      setWoLoading(false);
+    }
+  }, [navigate]);
+
+  const closeWorkorder = () => {
+    setWoOpenId(null);
+    setWoDetail(null);
+    setWoLoading(false);
+  };
+
   // ---- Actions -------------------------------------------------------------------
   const clearSelection = () => {
     setSelectedId(null);
@@ -281,6 +322,8 @@ export default function Inbox() {
     setPanel(null);
     setNeedEmail(false);
     setCreateEmail('');
+    setWoOpenId(null);
+    setWoDetail(null);
   };
 
   const switchBucket = (next) => {
@@ -597,6 +640,7 @@ export default function Inbox() {
                   createEmail={createEmail}
                   setCreateEmail={setCreateEmail}
                   onCreate={createCustomer}
+                  onOpenWorkorder={openWorkorder}
                 />
               </aside>
             )}
@@ -608,6 +652,16 @@ export default function Inbox() {
           </p>
         </div>
       </div>
+
+      {/* F17 — workorder detail modal (opened from a workorder card in the panel). */}
+      {woOpenId && (
+        <WorkorderModal
+          workorderId={woOpenId}
+          detail={woDetail}
+          loading={woLoading}
+          onClose={closeWorkorder}
+        />
+      )}
     </>
   );
 }
@@ -617,7 +671,7 @@ export default function Inbox() {
 // action when unmatched), their OPEN workorders + ACTIVE deliveries, and the open
 // lead's funnel stage. Leaves a labelled slot at the top for the F16 AI summary.
 function CustomerPanel({
-  loading, panel, creating, needEmail, createEmail, setCreateEmail, onCreate,
+  loading, panel, creating, needEmail, createEmail, setCreateEmail, onCreate, onOpenWorkorder,
 }) {
   const customer = panel?.customer || null;
   const contact = panel?.contact || null;
@@ -727,20 +781,28 @@ function CustomerPanel({
                   const owing = money(w.outstanding_balance);
                   const paid = Number(w.outstanding_balance) === 0;
                   return (
-                    <li key={w.workorder_id} className="rounded-lg border border-gray-200 p-2">
-                      <div className="flex items-center justify-between gap-2">
-                        <span className="font-medium text-gray-900">#{w.workorder_id}</span>
-                        <span className="text-xs text-gray-500">{w.status}</span>
-                      </div>
-                      {w.invoice_id && <Field label="Invoice" value={w.invoice_id} />}
-                      {(w.delivery_suburb || w.delivery_state) && (
-                        <Field label="Deliver to" value={[w.delivery_suburb, w.delivery_state].filter(Boolean).join(', ')} />
-                      )}
-                      {owing && (
-                        <div className={`text-xs mt-0.5 ${paid ? 'text-green-700' : 'text-amber-700'}`}>
-                          {paid ? 'Paid in full' : `Outstanding ${owing}`}
+                    <li key={w.workorder_id}>
+                      <button
+                        type="button"
+                        onClick={() => onOpenWorkorder && onOpenWorkorder(w.workorder_id)}
+                        className="w-full text-left rounded-lg border border-gray-200 p-2 hover:border-blue-300 hover:bg-blue-50 transition"
+                        title="View workorder detail"
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          <span className="font-medium text-gray-900">#{w.workorder_id}</span>
+                          <span className="text-xs text-gray-500">{w.status}</span>
                         </div>
-                      )}
+                        {w.invoice_id && <Field label="Invoice" value={w.invoice_id} />}
+                        {(w.delivery_suburb || w.delivery_state) && (
+                          <Field label="Deliver to" value={[w.delivery_suburb, w.delivery_state].filter(Boolean).join(', ')} />
+                        )}
+                        {owing && (
+                          <div className={`text-xs mt-0.5 ${paid ? 'text-green-700' : 'text-amber-700'}`}>
+                            {paid ? 'Paid in full' : `Outstanding ${owing}`}
+                          </div>
+                        )}
+                        <div className="text-[11px] text-blue-600 mt-1">View detail →</div>
+                      </button>
                     </li>
                   );
                 })}
@@ -784,6 +846,111 @@ function Field({ label, value }) {
     <div className="flex gap-2 text-xs">
       <span className="text-gray-400 w-20 shrink-0">{label}</span>
       <span className="text-gray-700 break-words min-w-0">{value}</span>
+    </div>
+  );
+}
+
+// ---- Workorder detail modal (F17) ---------------------------------------------
+// Shows a workorder's items + per-item status, the key payment/delivery details, and
+// a read-only, scrollable log of every workorder_logs entry (oldest → newest). Fed by
+// GET /api/workorder?id= (which omits selling_price for a non-superadmin actor), so a
+// sales rep sees item name/qty/condition/status + workorder-level payment only.
+function WorkorderModal({ workorderId, detail, loading, onClose }) {
+  const items = Array.isArray(detail?.items) ? detail.items : [];
+  // The endpoint returns activity newest-first; the log field reads oldest-first.
+  const activity = Array.isArray(detail?.activity) ? detail.activity.slice().reverse() : [];
+  const logText = activity
+    .map((l) => {
+      const bits = [l.ts, l.event_type];
+      if (l.user_id) bits.push(`· ${l.user_id}`);
+      if (l.current_item_status) bits.push(`· [${l.current_item_status}]`);
+      if (l.product_name) bits.push(`· ${l.product_name}`);
+      let line = bits.filter(Boolean).join('  ');
+      if (l.notes_log) line += `  — ${l.notes_log}`;
+      return line;
+    })
+    .join('\n');
+  const owing = money(detail?.outstanding_balance);
+  const paid = Number(detail?.outstanding_balance) === 0;
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4" onClick={onClose}>
+      <div
+        className="bg-white rounded-lg shadow-lg w-full max-w-2xl max-h-[90vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex items-center justify-between px-5 py-3 border-b border-gray-200">
+          <div className="flex items-center gap-2">
+            <h2 className="text-lg font-bold">Workorder #{workorderId}</h2>
+            {detail?.status && (
+              <span className="text-xs font-semibold px-2 py-0.5 rounded-full bg-gray-100 text-gray-700">{detail.status}</span>
+            )}
+          </div>
+          <button type="button" onClick={onClose} className="text-gray-400 hover:text-gray-700 text-xl leading-none" aria-label="Close">×</button>
+        </header>
+
+        <div className="flex-1 overflow-y-auto p-5 space-y-4 text-sm">
+          {loading && <div className="text-gray-500">Loading workorder…</div>}
+
+          {!loading && !detail && <div className="text-gray-400">Workorder details unavailable.</div>}
+
+          {!loading && detail && (
+            <>
+              {/* Payment / delivery details */}
+              <section className="grid grid-cols-2 gap-x-4 gap-y-1">
+                {detail.customer_name && <Field label="Customer" value={detail.customer_name} />}
+                {detail.invoice_id && <Field label="Invoice" value={detail.invoice_id} />}
+                {owing && <Field label="Outstanding" value={paid ? 'Paid in full' : owing} />}
+                {money(detail.delivery_charged) && <Field label="Delivery" value={money(detail.delivery_charged)} />}
+                {(detail.delivery_suburb || detail.delivery_state) && (
+                  <Field label="Deliver to" value={[detail.delivery_suburb, detail.delivery_state].filter(Boolean).join(', ')} />
+                )}
+                {detail.estimated_completion && <Field label="ETA" value={formatDate(detail.estimated_completion)} />}
+                {detail.date_created && <Field label="Created" value={formatDate(detail.date_created)} />}
+              </section>
+
+              {/* Items + per-item status */}
+              <section>
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">
+                  Items{items.length ? ` (${items.length})` : ''}
+                </div>
+                {items.length === 0 ? (
+                  <div className="text-gray-400">No items.</div>
+                ) : (
+                  <ul className="divide-y divide-gray-100 border border-gray-200 rounded-lg">
+                    {items.map((it) => (
+                      <li key={it.workorder_items_id} className="flex items-center justify-between gap-3 px-3 py-2">
+                        <div className="min-w-0">
+                          <div className="font-medium text-gray-900 truncate">
+                            {it.quantity} × {it.product_name || it.product_id}
+                          </div>
+                          <div className="text-xs text-gray-500">
+                            {[it.condition, it.item_sn ? `SN ${it.item_sn}` : null].filter(Boolean).join(' · ')}
+                          </div>
+                        </div>
+                        <span className="text-xs font-semibold px-2 py-0.5 rounded-full bg-gray-100 text-gray-700 shrink-0">
+                          {it.status}
+                        </span>
+                      </li>
+                    ))}
+                  </ul>
+                )}
+              </section>
+
+              {/* Full activity log (read-only, scrollable, oldest → newest) */}
+              <section>
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">Activity log</div>
+                <textarea
+                  readOnly
+                  value={logText || 'No activity recorded.'}
+                  rows={8}
+                  className="w-full border border-gray-200 rounded-lg px-3 py-2 text-xs font-mono bg-gray-50 text-gray-700 resize-none"
+                />
+              </section>
+            </>
+          )}
+        </div>
+      </div>
     </div>
   );
 }

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -145,6 +145,10 @@ export default function Inbox() {
   const [woLoading, setWoLoading] = useState(false);
   const [woOpenId, setWoOpenId] = useState(null);
 
+  // Feedback (8 Jul): open/close a conversation + add a conversation to the funnel.
+  const [statusSaving, setStatusSaving] = useState(false);
+  const [addingLead, setAddingLead] = useState(false);
+
   const sinceRef = useRef(null); // last poll cursor timestamp (server echoes serverTime)
 
   // ---- Gate (client-side display only; the server re-checks every request) -------
@@ -345,6 +349,70 @@ export default function Inbox() {
     setSelectedConv(c);
     loadThread(c.uid);
     loadPanel(c.uid);
+  };
+
+  // Feedback (8 Jul): a salesperson opens/closes the selected conversation. It then
+  // moves between the Open/Closed buckets — refresh the list (it may leave the current
+  // status filter). The thread stays open so it can be reopened.
+  const toggleConversationStatus = async () => {
+    if (!selectedId || statusSaving) return;
+    const current = selectedConv?.status || 'open';
+    const next = current === 'open' ? 'closed' : 'open';
+    setStatusSaving(true);
+    try {
+      const res = await fetch('/api/podium/inbox?resource=status', {
+        method: 'POST',
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({ conversationId: selectedId, status: next }),
+      });
+      if (res.status === 401) { navigate('/'); return; }
+      const data = await parseMaybeJson(res);
+      if (!res.ok) { toast.error(data?.error || 'Could not update the conversation'); return; }
+      setSelectedConv((c) => (c ? { ...c, status: next } : c));
+      toast.success(next === 'closed' ? 'Conversation closed' : 'Conversation reopened');
+      loadConversations({ silent: true });
+    } catch {
+      toast.error('Server error updating the conversation');
+    } finally {
+      setStatusSaving(false);
+    }
+  };
+
+  // Feedback (8 Jul): add the open conversation to the lead funnel. Links the matched
+  // customer + this conversation; if the customer has an open workorder, links it and
+  // opens the lead at "Payment Received" (money in / workorder raised). Idempotent —
+  // the backend returns the existing open lead if there already is one.
+  const addToFunnel = async () => {
+    if (!selectedId || addingLead || !panel?.customer) return;
+    setAddingLead(true);
+    try {
+      const wo = (panel.workorders || [])[0];
+      const payload = {
+        podium_conversation_id: selectedId,
+        customer_id: panel.customer.id,
+        source_channel: selectedConv?.channel?.type || undefined,
+        product_interest: wo ? `Workorder #${wo.workorder_id}` : 'Enquiry from chat',
+      };
+      if (wo) {
+        payload.converted_workorder_id = wo.workorder_id;
+        if (wo.invoice_id) payload.quote_invoice_id = wo.invoice_id;
+        payload.stage = 'Payment Received';
+      }
+      const res = await fetch('/api/leads', {
+        method: 'POST',
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify(payload),
+      });
+      if (res.status === 401) { navigate('/'); return; }
+      const data = await parseMaybeJson(res);
+      if (!res.ok) { toast.error(data?.error || 'Could not add this conversation to the funnel'); return; }
+      toast.success('Added to the funnel');
+      loadPanel(selectedId); // refresh so the funnel-stage badge shows the new lead
+    } catch {
+      toast.error('Server error adding to the funnel');
+    } finally {
+      setAddingLead(false);
+    }
   };
 
   const sendReply = async (e) => {
@@ -569,13 +637,27 @@ export default function Inbox() {
                     >
                       ← Back
                     </button>
-                    <div className="min-w-0">
+                    <div className="min-w-0 flex-1">
                       <div className="flex items-center gap-2">
                         <span className="font-semibold text-gray-900 truncate">{headerTitle}</span>
                         <ChannelBadge type={selectedConv?.channel?.type} />
+                        {(selectedConv?.status || 'open') === 'closed' && (
+                          <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full bg-gray-200 text-gray-700">Closed</span>
+                        )}
                       </div>
                       <div className="text-xs text-gray-400">{assigneeLabel(selectedConv).text}</div>
                     </div>
+                    {/* Open/close the conversation (feedback 8 Jul) */}
+                    <button
+                      type="button"
+                      onClick={toggleConversationStatus}
+                      disabled={statusSaving}
+                      className="shrink-0 text-sm px-3 py-1.5 rounded-lg border border-gray-300 text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                    >
+                      {statusSaving
+                        ? 'Saving…'
+                        : (selectedConv?.status || 'open') === 'open' ? 'Close' : 'Reopen'}
+                    </button>
                   </header>
 
                   <div className="flex-1 overflow-y-auto p-4 space-y-3 bg-gray-50">
@@ -641,6 +723,8 @@ export default function Inbox() {
                   setCreateEmail={setCreateEmail}
                   onCreate={createCustomer}
                   onOpenWorkorder={openWorkorder}
+                  onAddToFunnel={addToFunnel}
+                  addingLead={addingLead}
                 />
               </aside>
             )}
@@ -672,6 +756,7 @@ export default function Inbox() {
 // lead's funnel stage. Leaves a labelled slot at the top for the F16 AI summary.
 function CustomerPanel({
   loading, panel, creating, needEmail, createEmail, setCreateEmail, onCreate, onOpenWorkorder,
+  onAddToFunnel, addingLead,
 }) {
   const customer = panel?.customer || null;
   const contact = panel?.contact || null;
@@ -764,7 +849,23 @@ function CustomerPanel({
                 {lead.quote_invoice_id && <Field label="Quote/Invoice" value={lead.quote_invoice_id} />}
               </div>
             ) : (
-              <div className="text-gray-400">No open lead for this conversation.</div>
+              <div className="space-y-2">
+                <div className="text-gray-400">No open lead for this conversation.</div>
+                {customer && onAddToFunnel && (
+                  <button
+                    type="button"
+                    onClick={onAddToFunnel}
+                    disabled={addingLead}
+                    className="w-full bg-blue-500 text-white py-2 rounded text-sm hover:bg-blue-600 disabled:opacity-50"
+                  >
+                    {addingLead
+                      ? 'Adding…'
+                      : workorders.length
+                        ? `Add to funnel (link WO #${workorders[0].workorder_id})`
+                        : 'Add to funnel'}
+                  </button>
+                )}
+              </div>
             )}
           </section>
 

--- a/src/pages/leads.js
+++ b/src/pages/leads.js
@@ -1,0 +1,400 @@
+// src/pages/leads.js — Lead funnel Kanban (feature F5).
+//
+// The sales pipeline over the F5 backend (lib/handlers/leads.js → /api/leads),
+// itself over the leads + lead_stage_log tables from F0's migration 0001 (§4.3).
+// Columns are the canonical stages New → Contacted → Quoted → Payment Received →
+// Won / Lost. Moving a card PUTs /api/leads/:id/stage (which appends a stage-log
+// row); moving to Lost requires a reason (prompted in a small modal). A "+ New lead"
+// form makes the funnel demonstrable on a fresh DB.
+//
+// Gated to sales/superadmin (display-only here; /api/leads re-checks server-side and
+// runs on the login JWT). No message bodies are touched — leads are CRM metadata.
+
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import toast from 'react-hot-toast';
+import BackButton from '../components/backbutton';
+import HomeButton from '../components/homebutton';
+import { authHeaders, getToken, getRoles, hasAnyRole } from '../utils/auth';
+import { parseMaybeJson } from '../utils/http';
+
+const LEADS_ROLES = ['sales', 'superadmin'];
+
+// Canonical funnel stages (mirrors execution-plan §1c / the lead_stage enum).
+const STAGES = ['New', 'Contacted', 'Quoted', 'Payment Received', 'Won', 'Lost'];
+
+// Per-column accent (header). Mirrors the inbox STAGE_CLS badge colours.
+const COLUMN_CLS = {
+  New: 'bg-gray-100 text-gray-700',
+  Contacted: 'bg-blue-100 text-blue-800',
+  Quoted: 'bg-amber-100 text-amber-800',
+  'Payment Received': 'bg-purple-100 text-purple-800',
+  Won: 'bg-green-100 text-green-800',
+  Lost: 'bg-red-100 text-red-700',
+};
+
+const CHANNELS = {
+  phone: 'SMS', sms: 'SMS', email: 'Email', facebook: 'Facebook',
+  instagram: 'Instagram', google: 'Google', webchat: 'Webchat', whatsapp: 'WhatsApp',
+};
+
+function money(v) {
+  if (v === null || v === undefined || v === '') return null;
+  const n = Number(v);
+  if (Number.isNaN(n)) return null;
+  return n.toLocaleString('en-AU', { style: 'currency', currency: 'AUD' });
+}
+
+export default function Leads() {
+  const navigate = useNavigate();
+
+  const [authorized, setAuthorized] = useState(false);
+  const [leads, setLeads] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [savingId, setSavingId] = useState(null);
+
+  // Create form
+  const [showNew, setShowNew] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [form, setForm] = useState({ product_interest: '', value_est: '', source_channel: '', notes: '' });
+
+  // Lost-reason modal
+  const [lostFor, setLostFor] = useState(null); // { lead_id } | null
+  const [lostReason, setLostReason] = useState('');
+
+  useEffect(() => {
+    if (!getToken()) { navigate('/'); return; }
+    if (!hasAnyRole(getRoles(), LEADS_ROLES)) {
+      toast.error('The lead funnel is for sales users');
+      navigate('/dashboard');
+      return;
+    }
+    setAuthorized(true);
+  }, [navigate]);
+
+  const loadLeads = useCallback(async ({ silent = false } = {}) => {
+    if (!silent) setLoading(true);
+    try {
+      const res = await fetch('/api/leads', { headers: authHeaders() });
+      if (res.status === 401) { navigate('/'); return; }
+      if (res.status === 403) { toast.error('The lead funnel is for sales users'); navigate('/dashboard'); return; }
+      const data = await parseMaybeJson(res);
+      if (!res.ok) { toast.error(data?.error || 'Could not load leads'); return; }
+      setLeads(Array.isArray(data) ? data : []);
+    } catch {
+      toast.error('Server error loading leads');
+    } finally {
+      if (!silent) setLoading(false);
+    }
+  }, [navigate]);
+
+  useEffect(() => {
+    if (authorized) loadLeads();
+  }, [authorized, loadLeads]);
+
+  // Replace a lead in state after a server round-trip returns the updated row.
+  const upsertLead = (row) => {
+    if (!row?.lead_id) return;
+    setLeads((prev) => {
+      const idx = prev.findIndex((l) => l.lead_id === row.lead_id);
+      if (idx === -1) return [row, ...prev];
+      const next = prev.slice();
+      next[idx] = row;
+      return next;
+    });
+  };
+
+  const submitStage = useCallback(async (leadId, toStage, reason) => {
+    setSavingId(leadId);
+    try {
+      const payload = { to_stage: toStage };
+      if (reason) payload.lost_reason = reason;
+      const res = await fetch(`/api/leads/${leadId}/stage`, {
+        method: 'PUT',
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify(payload),
+      });
+      if (res.status === 401) { navigate('/'); return false; }
+      const data = await parseMaybeJson(res);
+      if (res.status === 400 && data?.code === 'LOST_REASON_REQUIRED') {
+        return false; // caller opens the lost-reason modal
+      }
+      if (!res.ok) { toast.error(data?.error || 'Could not move the lead'); return false; }
+      upsertLead(data);
+      toast.success(`Moved to ${toStage}`);
+      return true;
+    } catch {
+      toast.error('Server error moving the lead');
+      return false;
+    } finally {
+      setSavingId(null);
+    }
+  }, [navigate]);
+
+  const onChangeStage = async (lead, toStage) => {
+    if (!toStage || toStage === lead.stage) return;
+    if (toStage === 'Lost') {
+      setLostReason('');
+      setLostFor(lead);
+      return;
+    }
+    await submitStage(lead.lead_id, toStage);
+  };
+
+  const confirmLost = async () => {
+    if (!lostFor) return;
+    const reason = lostReason.trim();
+    if (!reason) { toast.error('Please give a reason'); return; }
+    const ok = await submitStage(lostFor.lead_id, 'Lost', reason);
+    if (ok) { setLostFor(null); setLostReason(''); }
+  };
+
+  const createLead = async (e) => {
+    e.preventDefault();
+    const productInterest = form.product_interest.trim();
+    if (!productInterest) { toast.error('Product interest is required'); return; }
+    setCreating(true);
+    try {
+      const payload = {
+        product_interest: productInterest,
+        value_est: form.value_est === '' ? undefined : Number(form.value_est),
+        source_channel: form.source_channel || undefined,
+        notes: form.notes.trim() || undefined,
+      };
+      const res = await fetch('/api/leads', {
+        method: 'POST',
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify(payload),
+      });
+      if (res.status === 401) { navigate('/'); return; }
+      const data = await parseMaybeJson(res);
+      if (!res.ok) { toast.error(data?.error || 'Could not create the lead'); return; }
+      upsertLead(data);
+      setForm({ product_interest: '', value_est: '', source_channel: '', notes: '' });
+      setShowNew(false);
+      toast.success('Lead created');
+    } catch {
+      toast.error('Server error creating the lead');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  if (!authorized) return null;
+
+  const byStage = (stage) => leads.filter((l) => l.stage === stage);
+
+  return (
+    <>
+      <div className="fixed top-4 left-6 z-50 flex gap-2">
+        <HomeButton />
+        <BackButton />
+      </div>
+
+      <div className="min-h-screen bg-gray-100 pt-16 pb-6 px-3 md:px-6">
+        <div className="max-w-[90rem] mx-auto">
+          <div className="flex items-center justify-between mb-4">
+            <h1 className="text-2xl font-bold">Lead Funnel</h1>
+            <button
+              type="button"
+              onClick={() => setShowNew(true)}
+              className="bg-blue-500 text-white px-4 py-2 rounded-lg text-sm hover:bg-blue-600"
+            >
+              + New lead
+            </button>
+          </div>
+
+          {loading ? (
+            <div className="text-sm text-gray-500">Loading leads…</div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-3">
+              {STAGES.map((stage) => {
+                const cards = byStage(stage);
+                return (
+                  <div key={stage} className="bg-white rounded-lg shadow-sm flex flex-col min-h-[8rem]">
+                    <div className={`flex items-center justify-between px-3 py-2 rounded-t-lg ${COLUMN_CLS[stage] || 'bg-gray-100 text-gray-700'}`}>
+                      <span className="font-semibold text-sm">{stage}</span>
+                      <span className="text-xs font-semibold">{cards.length}</span>
+                    </div>
+                    <div className="flex-1 p-2 space-y-2 overflow-y-auto" style={{ maxHeight: 'calc(100vh - 12rem)' }}>
+                      {cards.length === 0 && (
+                        <div className="text-xs text-gray-400 px-1 py-2">No leads.</div>
+                      )}
+                      {cards.map((lead) => (
+                        <LeadCard
+                          key={lead.lead_id}
+                          lead={lead}
+                          saving={savingId === lead.lead_id}
+                          onChangeStage={onChangeStage}
+                        />
+                      ))}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          <p className="text-xs text-gray-400 mt-4">
+            Every stage change is recorded to the lead's history. Leads are created here or
+            automatically from an inbound Podium message (P12).
+          </p>
+        </div>
+      </div>
+
+      {/* New lead modal */}
+      {showNew && (
+        <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
+          <form onSubmit={createLead} className="bg-white rounded-lg shadow-lg w-full max-w-md p-5 space-y-3">
+            <h2 className="text-lg font-bold">New lead</h2>
+            <div>
+              <label className="block text-xs font-semibold text-gray-500 mb-1">Product interest *</label>
+              <input
+                type="text"
+                value={form.product_interest}
+                onChange={(e) => setForm((f) => ({ ...f, product_interest: e.target.value }))}
+                placeholder="e.g. Adjustable dumbbell set"
+                className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+              />
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs font-semibold text-gray-500 mb-1">Est. value (AUD)</label>
+                <input
+                  type="number"
+                  min="0"
+                  step="1"
+                  value={form.value_est}
+                  onChange={(e) => setForm((f) => ({ ...f, value_est: e.target.value }))}
+                  className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
+                />
+              </div>
+              <div>
+                <label className="block text-xs font-semibold text-gray-500 mb-1">Source</label>
+                <select
+                  value={form.source_channel}
+                  onChange={(e) => setForm((f) => ({ ...f, source_channel: e.target.value }))}
+                  className="w-full border border-gray-300 rounded px-3 py-2 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-blue-400"
+                >
+                  <option value="">—</option>
+                  <option value="phone">SMS</option>
+                  <option value="email">Email</option>
+                  <option value="facebook">Facebook</option>
+                  <option value="instagram">Instagram</option>
+                  <option value="google">Google</option>
+                  <option value="webchat">Webchat</option>
+                </select>
+              </div>
+            </div>
+            <div>
+              <label className="block text-xs font-semibold text-gray-500 mb-1">Notes</label>
+              <textarea
+                value={form.notes}
+                onChange={(e) => setForm((f) => ({ ...f, notes: e.target.value }))}
+                rows={3}
+                className="w-full border border-gray-300 rounded px-3 py-2 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-blue-400"
+              />
+            </div>
+            <div className="flex justify-end gap-2 pt-1">
+              <button
+                type="button"
+                onClick={() => setShowNew(false)}
+                className="px-4 py-2 rounded text-sm border border-gray-300 text-gray-700 hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={creating}
+                className="px-4 py-2 rounded text-sm bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-50"
+              >
+                {creating ? 'Creating…' : 'Create lead'}
+              </button>
+            </div>
+          </form>
+        </div>
+      )}
+
+      {/* Lost-reason modal */}
+      {lostFor && (
+        <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
+          <div className="bg-white rounded-lg shadow-lg w-full max-w-md p-5 space-y-3">
+            <h2 className="text-lg font-bold">Mark lead Lost</h2>
+            <p className="text-sm text-gray-600">
+              Why was this lead lost? A reason is required and kept in the lead's history.
+            </p>
+            <textarea
+              value={lostReason}
+              onChange={(e) => setLostReason(e.target.value)}
+              rows={3}
+              placeholder="e.g. Bought elsewhere / out of budget / no response"
+              className="w-full border border-gray-300 rounded px-3 py-2 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-red-400"
+            />
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => { setLostFor(null); setLostReason(''); }}
+                className="px-4 py-2 rounded text-sm border border-gray-300 text-gray-700 hover:bg-gray-50"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={confirmLost}
+                disabled={savingId === lostFor.lead_id}
+                className="px-4 py-2 rounded text-sm bg-red-600 text-white hover:bg-red-700 disabled:opacity-50"
+              >
+                Mark Lost
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </>
+  );
+}
+
+// A single lead card with a stage mover.
+function LeadCard({ lead, saving, onChangeStage }) {
+  const title = lead.customer_name || lead.product_interest || `Lead #${lead.lead_id}`;
+  const est = money(lead.value_est);
+  const channel = lead.source_channel ? (CHANNELS[String(lead.source_channel).toLowerCase()] || lead.source_channel) : null;
+
+  return (
+    <div className="rounded-lg border border-gray-200 p-2.5 bg-white">
+      <div className="font-medium text-sm text-gray-900 truncate">{title}</div>
+      {lead.customer_name && lead.product_interest && (
+        <div className="text-xs text-gray-500 truncate">{lead.product_interest}</div>
+      )}
+      <div className="flex items-center flex-wrap gap-1.5 mt-1.5">
+        {channel && (
+          <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full bg-gray-100 text-gray-700">{channel}</span>
+        )}
+        {est && (
+          <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full bg-green-100 text-green-800">{est}</span>
+        )}
+        {lead.assigned_name && (
+          <span className="text-[11px] text-gray-500">{lead.assigned_name}</span>
+        )}
+      </div>
+      {lead.stage === 'Lost' && lead.lost_reason && (
+        <div className="text-[11px] text-red-600 mt-1 truncate" title={lead.lost_reason}>
+          Lost: {lead.lost_reason}
+        </div>
+      )}
+      <div className="mt-2">
+        <select
+          value={lead.stage}
+          disabled={saving}
+          onChange={(e) => onChangeStage(lead, e.target.value)}
+          className="w-full border border-gray-300 rounded px-2 py-1 text-xs bg-white disabled:opacity-50 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          aria-label={`Move lead ${lead.lead_id} to another stage`}
+        >
+          {STAGES.map((s) => (
+            <option key={s} value={s}>{s}</option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/leads.js
+++ b/src/pages/leads.js
@@ -2,10 +2,12 @@
 //
 // The sales pipeline over the F5 backend (lib/handlers/leads.js → /api/leads),
 // itself over the leads + lead_stage_log tables from F0's migration 0001 (§4.3).
-// Columns are the canonical stages New → Contacted → Quoted → Payment Received →
-// Won / Lost. Moving a card PUTs /api/leads/:id/stage (which appends a stage-log
-// row); moving to Lost requires a reason (prompted in a small modal). A "+ New lead"
-// form makes the funnel demonstrable on a fresh DB.
+// Columns are New → Contacted → Quoted → Won / Lost ('Payment Received' was merged
+// into 'Won'). Moving a card PUTs /api/leads/:id/stage (which appends a stage-log
+// row); moving to Lost prompts for a structured reason (dropdown + "Other" note) so
+// losses are quantifiable. The board is GLOBAL (all reps' leads) with a My/All filter,
+// and each card shows its owner. A "+ New lead" form makes the funnel demonstrable, and
+// clicking a card opens the linked Podium conversation in the Inbox.
 //
 // Gated to sales/superadmin (display-only here; /api/leads re-checks server-side and
 // runs on the login JWT). No message bodies are touched — leads are CRM metadata.
@@ -15,20 +17,30 @@ import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import BackButton from '../components/backbutton';
 import HomeButton from '../components/homebutton';
-import { authHeaders, getToken, getRoles, hasAnyRole } from '../utils/auth';
+import { authHeaders, getToken, getRoles, hasAnyRole, getStoredUser } from '../utils/auth';
 import { parseMaybeJson } from '../utils/http';
 
 const LEADS_ROLES = ['sales', 'superadmin'];
 
-// Canonical funnel stages (mirrors execution-plan §1c / the lead_stage enum).
-const STAGES = ['New', 'Contacted', 'Quoted', 'Payment Received', 'Won', 'Lost'];
+// Funnel stages (Payment Received merged into Won — migration 0002).
+const STAGES = ['New', 'Contacted', 'Quoted', 'Won', 'Lost'];
+
+// Structured Lost-reason categories (keep in sync with lib/handlers/leads.js LOST_REASONS).
+const LOST_REASONS = [
+  'Price / too expensive',
+  'Went with a competitor',
+  'Lead time / stock too long',
+  'Changed mind / no longer needed',
+  'No response (went cold)',
+  'Budget / finance',
+  'Other',
+];
 
 // Per-column accent (header). Mirrors the inbox STAGE_CLS badge colours.
 const COLUMN_CLS = {
   New: 'bg-gray-100 text-gray-700',
   Contacted: 'bg-blue-100 text-blue-800',
   Quoted: 'bg-amber-100 text-amber-800',
-  'Payment Received': 'bg-purple-100 text-purple-800',
   Won: 'bg-green-100 text-green-800',
   Lost: 'bg-red-100 text-red-700',
 };
@@ -52,15 +64,18 @@ export default function Leads() {
   const [leads, setLeads] = useState([]);
   const [loading, setLoading] = useState(true);
   const [savingId, setSavingId] = useState(null);
+  const [ownerScope, setOwnerScope] = useState('all'); // 'all' | 'mine'
+  const myId = getStoredUser()?.id || null;
 
   // Create form
   const [showNew, setShowNew] = useState(false);
   const [creating, setCreating] = useState(false);
   const [form, setForm] = useState({ product_interest: '', value_est: '', source_channel: '', notes: '' });
 
-  // Lost-reason modal
-  const [lostFor, setLostFor] = useState(null); // { lead_id } | null
-  const [lostReason, setLostReason] = useState('');
+  // Lost-reason modal (structured: a category + an optional note; "Other" needs a note)
+  const [lostFor, setLostFor] = useState(null); // the lead being marked Lost | null
+  const [lostCategory, setLostCategory] = useState('');
+  const [lostNote, setLostNote] = useState('');
 
   useEffect(() => {
     if (!getToken()) { navigate('/'); return; }
@@ -104,11 +119,14 @@ export default function Leads() {
     });
   };
 
-  const submitStage = useCallback(async (leadId, toStage, reason) => {
+  const submitStage = useCallback(async (leadId, toStage, lost) => {
     setSavingId(leadId);
     try {
       const payload = { to_stage: toStage };
-      if (reason) payload.lost_reason = reason;
+      if (lost) {
+        payload.lost_reason_category = lost.category;
+        if (lost.note) payload.lost_reason = lost.note;
+      }
       const res = await fetch(`/api/leads/${leadId}/stage`, {
         method: 'PUT',
         headers: authHeaders({ 'Content-Type': 'application/json' }),
@@ -116,8 +134,9 @@ export default function Leads() {
       });
       if (res.status === 401) { navigate('/'); return false; }
       const data = await parseMaybeJson(res);
-      if (res.status === 400 && data?.code === 'LOST_REASON_REQUIRED') {
-        return false; // caller opens the lost-reason modal
+      if (res.status === 400 && (data?.code === 'LOST_REASON_REQUIRED' || data?.code === 'LOST_NOTE_REQUIRED')) {
+        toast.error(data?.error || 'A reason is required');
+        return false;
       }
       if (!res.ok) { toast.error(data?.error || 'Could not move the lead'); return false; }
       upsertLead(data);
@@ -134,7 +153,8 @@ export default function Leads() {
   const onChangeStage = async (lead, toStage) => {
     if (!toStage || toStage === lead.stage) return;
     if (toStage === 'Lost') {
-      setLostReason('');
+      setLostCategory('');
+      setLostNote('');
       setLostFor(lead);
       return;
     }
@@ -143,10 +163,10 @@ export default function Leads() {
 
   const confirmLost = async () => {
     if (!lostFor) return;
-    const reason = lostReason.trim();
-    if (!reason) { toast.error('Please give a reason'); return; }
-    const ok = await submitStage(lostFor.lead_id, 'Lost', reason);
-    if (ok) { setLostFor(null); setLostReason(''); }
+    if (!lostCategory) { toast.error('Please choose a reason'); return; }
+    if (lostCategory === 'Other' && !lostNote.trim()) { toast.error('Please add a note for "Other"'); return; }
+    const ok = await submitStage(lostFor.lead_id, 'Lost', { category: lostCategory, note: lostNote.trim() });
+    if (ok) { setLostFor(null); setLostCategory(''); setLostNote(''); }
   };
 
   const createLead = async (e) => {
@@ -180,9 +200,18 @@ export default function Leads() {
     }
   };
 
+  // Open the lead's linked Podium conversation in the Inbox (deep-link).
+  const openChat = (lead) => {
+    if (!lead?.podium_conversation_id) return;
+    navigate(`/inbox?conversation=${encodeURIComponent(lead.podium_conversation_id)}`);
+  };
+
   if (!authorized) return null;
 
-  const byStage = (stage) => leads.filter((l) => l.stage === stage);
+  const visibleLeads = ownerScope === 'mine' && myId
+    ? leads.filter((l) => l.assigned_to === myId)
+    : leads;
+  const byStage = (stage) => visibleLeads.filter((l) => l.stage === stage);
 
   return (
     <>
@@ -193,21 +222,40 @@ export default function Leads() {
 
       <div className="min-h-screen bg-gray-100 pt-16 pb-6 px-3 md:px-6">
         <div className="max-w-[90rem] mx-auto">
-          <div className="flex items-center justify-between mb-4">
+          <div className="flex flex-col gap-3 mb-4 sm:flex-row sm:items-center sm:justify-between">
             <h1 className="text-2xl font-bold">Lead Funnel</h1>
-            <button
-              type="button"
-              onClick={() => setShowNew(true)}
-              className="bg-blue-500 text-white px-4 py-2 rounded-lg text-sm hover:bg-blue-600"
-            >
-              + New lead
-            </button>
+            <div className="flex items-center gap-2">
+              {/* Global board — filter to your own leads or show everyone's */}
+              <div className="inline-flex rounded-lg border border-gray-300 overflow-hidden text-sm">
+                <button
+                  type="button"
+                  onClick={() => setOwnerScope('all')}
+                  className={ownerScope === 'all' ? 'px-3 py-1.5 bg-blue-500 text-white' : 'px-3 py-1.5 bg-white text-gray-700 hover:bg-gray-50'}
+                >
+                  All leads
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setOwnerScope('mine')}
+                  className={ownerScope === 'mine' ? 'px-3 py-1.5 bg-blue-500 text-white' : 'px-3 py-1.5 bg-white text-gray-700 hover:bg-gray-50'}
+                >
+                  My leads
+                </button>
+              </div>
+              <button
+                type="button"
+                onClick={() => setShowNew(true)}
+                className="bg-blue-500 text-white px-4 py-2 rounded-lg text-sm hover:bg-blue-600"
+              >
+                + New lead
+              </button>
+            </div>
           </div>
 
           {loading ? (
             <div className="text-sm text-gray-500">Loading leads…</div>
           ) : (
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-3">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-3">
               {STAGES.map((stage) => {
                 const cards = byStage(stage);
                 return (
@@ -226,6 +274,7 @@ export default function Leads() {
                           lead={lead}
                           saving={savingId === lead.lead_id}
                           onChangeStage={onChangeStage}
+                          onOpenChat={openChat}
                         />
                       ))}
                     </div>
@@ -236,8 +285,8 @@ export default function Leads() {
           )}
 
           <p className="text-xs text-gray-400 mt-4">
-            Every stage change is recorded to the lead's history. Leads are created here or
-            automatically from an inbound Podium message (P12).
+            This is the whole team's funnel — use “My leads” to see only yours. Every stage
+            change is recorded to the lead's history; click a card to open its chat.
           </p>
         </div>
       </div>
@@ -315,25 +364,44 @@ export default function Leads() {
         </div>
       )}
 
-      {/* Lost-reason modal */}
+      {/* Lost-reason modal — a structured category (quantifiable) + an optional note.
+          "Other" requires the note. */}
       {lostFor && (
         <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4">
           <div className="bg-white rounded-lg shadow-lg w-full max-w-md p-5 space-y-3">
             <h2 className="text-lg font-bold">Mark lead Lost</h2>
             <p className="text-sm text-gray-600">
-              Why was this lead lost? A reason is required and kept in the lead's history.
+              Why was this lead lost? The reason is recorded so we can see what's costing us leads.
             </p>
-            <textarea
-              value={lostReason}
-              onChange={(e) => setLostReason(e.target.value)}
-              rows={3}
-              placeholder="e.g. Bought elsewhere / out of budget / no response"
-              className="w-full border border-gray-300 rounded px-3 py-2 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-red-400"
-            />
+            <div>
+              <label className="block text-xs font-semibold text-gray-500 mb-1">Reason *</label>
+              <select
+                value={lostCategory}
+                onChange={(e) => setLostCategory(e.target.value)}
+                className="w-full border border-gray-300 rounded px-3 py-2 text-sm bg-white focus:outline-none focus:ring-2 focus:ring-red-400"
+              >
+                <option value="">Choose a reason…</option>
+                {LOST_REASONS.map((r) => (
+                  <option key={r} value={r}>{r}</option>
+                ))}
+              </select>
+            </div>
+            <div>
+              <label className="block text-xs font-semibold text-gray-500 mb-1">
+                Note {lostCategory === 'Other' ? '*' : '(optional)'}
+              </label>
+              <textarea
+                value={lostNote}
+                onChange={(e) => setLostNote(e.target.value)}
+                rows={3}
+                placeholder={lostCategory === 'Other' ? 'Please describe the reason' : 'Any extra detail'}
+                className="w-full border border-gray-300 rounded px-3 py-2 text-sm resize-none focus:outline-none focus:ring-2 focus:ring-red-400"
+              />
+            </div>
             <div className="flex justify-end gap-2">
               <button
                 type="button"
-                onClick={() => { setLostFor(null); setLostReason(''); }}
+                onClick={() => { setLostFor(null); setLostCategory(''); setLostNote(''); }}
                 className="px-4 py-2 rounded text-sm border border-gray-300 text-gray-700 hover:bg-gray-50"
               >
                 Cancel
@@ -354,32 +422,52 @@ export default function Leads() {
   );
 }
 
-// A single lead card with a stage mover.
-function LeadCard({ lead, saving, onChangeStage }) {
+// A single lead card: click the body to open its chat; a stage mover in the footer.
+function LeadCard({ lead, saving, onChangeStage, onOpenChat }) {
   const title = lead.customer_name || lead.product_interest || `Lead #${lead.lead_id}`;
   const est = money(lead.value_est);
   const channel = lead.source_channel ? (CHANNELS[String(lead.source_channel).toLowerCase()] || lead.source_channel) : null;
+  const hasChat = !!lead.podium_conversation_id;
+  const lostText = lead.lost_reason_category
+    ? [lead.lost_reason_category, lead.lost_reason].filter(Boolean).join(' — ')
+    : lead.lost_reason;
 
   return (
     <div className="rounded-lg border border-gray-200 p-2.5 bg-white">
-      <div className="font-medium text-sm text-gray-900 truncate">{title}</div>
-      {lead.customer_name && lead.product_interest && (
-        <div className="text-xs text-gray-500 truncate">{lead.product_interest}</div>
-      )}
-      <div className="flex items-center flex-wrap gap-1.5 mt-1.5">
-        {channel && (
-          <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full bg-gray-100 text-gray-700">{channel}</span>
+      {/* Body — clickable to open the linked conversation in the Inbox */}
+      <button
+        type="button"
+        onClick={() => hasChat && onOpenChat && onOpenChat(lead)}
+        className={`w-full text-left ${hasChat ? 'cursor-pointer group' : 'cursor-default'}`}
+        title={hasChat ? 'Open chat' : undefined}
+      >
+        <div className="flex items-center justify-between gap-1">
+          <span className={`font-medium text-sm text-gray-900 truncate ${hasChat ? 'group-hover:text-blue-700' : ''}`}>{title}</span>
+          {hasChat && <span className="text-[11px] text-blue-600 shrink-0 opacity-0 group-hover:opacity-100">chat →</span>}
+        </div>
+        {lead.customer_name && lead.product_interest && (
+          <div className="text-xs text-gray-500 truncate">{lead.product_interest}</div>
         )}
-        {est && (
-          <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full bg-green-100 text-green-800">{est}</span>
-        )}
-        {lead.assigned_name && (
-          <span className="text-[11px] text-gray-500">{lead.assigned_name}</span>
-        )}
+        <div className="flex items-center flex-wrap gap-1.5 mt-1.5">
+          {channel && (
+            <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full bg-gray-100 text-gray-700">{channel}</span>
+          )}
+          {est && (
+            <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full bg-green-100 text-green-800">{est}</span>
+          )}
+        </div>
+      </button>
+
+      {/* Owner (global board — always show who it's assigned to) */}
+      <div className="text-[11px] text-gray-500 mt-1">
+        {lead.assigned_name
+          ? <>Owner: <span className="font-medium text-gray-700">{lead.assigned_name}</span></>
+          : <span className="text-gray-400">Unassigned</span>}
       </div>
-      {lead.stage === 'Lost' && lead.lost_reason && (
-        <div className="text-[11px] text-red-600 mt-1 truncate" title={lead.lost_reason}>
-          Lost: {lead.lost_reason}
+
+      {lead.stage === 'Lost' && lostText && (
+        <div className="text-[11px] text-red-600 mt-1 truncate" title={lostText}>
+          Lost: {lostText}
         </div>
       )}
       <div className="mt-2">


### PR DESCRIPTION
Combined review run (Nick's 7 Jul directive): ships **F11 + F5 + F17** together on one branch/PR/Preview so the improved inbox (with the clickable workorder popup) and the sales funnel can be reviewed side by side. Three commits, one Preview. **No migration. No new serverless function** (stays `nodejs:3`). Mock-first (`PODIUM_MOCK=true`); P1 (no chat bodies persisted) + P4 (rep's own token) held throughout.

## F11 — Inbox Podium-parity buckets
Conversation buckets **Assigned to You / Unassigned / All**, each split **Open vs Closed**.
- `lib/podium.mock.js` — `status:open|closed` on the fixtures + a 6th (unassigned/closed) so every bucket×status cell is reviewable; `GET /conversations` filters by `unassigned` + `status`.
- `lib/podium.js` `listConversations` passes `unassigned`/`status`; `lib/podiumInbox.js` adds pure `normalizeBucket`/`normalizeStatus`; `lib/podiumRoutes/inbox.js` conversations+poll honour `bucket`+`status` (legacy `scope` alias kept).
- `src/pages/inbox.js` — bucket tabs + Open/Closed sub-toggle. Default `bucket=mine` preserves the F1b "My conversations" view.

## F5 — Lead funnel `/leads`
Kanban New → Contacted → Quoted → Payment Received → Won / Lost. Every move appends a `lead_stage_log` row; Lost requires a reason.
- `lib/handlers/leads.js` (routed via a `leads` **case** in `api/[...path].js`, no new function file): GET list, POST create (+ NULL→New log), GET :id, PUT :id/stage. JWT-gated `sales`/`superadmin`.
- `src/pages/leads.js` Kanban + **+ New lead** form; `/leads` route; dashboard nav link.

## F17 — Workorder detail popup
Clicking a workorder card in the F4 customer panel opens a modal: items + per-item status, payment/delivery details, and a read-only scrollable log of all `workorder_logs` (oldest → newest). Reuses `GET /api/workorder?id=` (which omits `selling_price` for a non-superadmin actor), so a `sales` rep sees item name/qty/condition/status + workorder payment only. Frontend-only.

## Tests
- Offline smokes: `podium-inbox` **50/50**, `podium-leads` **19/19**, plus regressions `podium` 27, `oauth` 30, `assign` 20, `webhook` 55, `contact` 46.
- `CI=true npm run build` → **Compiled successfully**.
- Neon dev schema confirmed for F5 (6 enum stages + all leads/lead_stage_log columns present).

## How to test
1. Open the Preview signed into the Grays Support Vercel team, as a `sales`/`superadmin` user.
2. **/inbox** — switch **Assigned to You / Unassigned / All** and **Open / Closed**; buckets repopulate (connect Podium in Settings via the mock loopback to populate "Assigned to You").
3. In a matched conversation's customer panel, click a workorder card → the **detail modal** opens (items, payment, activity log). No cost/price shown.
4. **/leads** — **+ New lead**, then move cards between stages; moving to **Lost** requires a reason. Reload to confirm persistence + history.

**Do not merge without review** — this is the draft/review gate.
