### PR TITLE
Reply-advances-lead: salesperson reply auto-moves a lead New → Contacted

### DIFF
--- a/lib/podiumWebhook.js
+++ b/lib/podiumWebhook.js
@@ -19,7 +19,9 @@
 //          open, else touch `last_contact_at`. Completes the funnel's first touch.
 //        • conversation-assignment → resolve `assignedUser.uid` → portal user →
 //          mirrorAssignmentToLead(). This is F1b's Podium → portal direction.
-//        • message.sent → reconcile (log only for now).
+//        • message.sent → a SALESPERSON reply advances the conversation's open
+//          lead New → Contacted (hybrid funnel automation); creates one at
+//          Contacted if none exists; AI/auto sends (Jerry, F16) are skipped.
 //        • message.failed → record status='failed' (surfaced by the inbox/F10).
 //        • contact / lead / review events → logged; richer handling lands with
 //          F4/F5/F8 which own those tables.
@@ -107,7 +109,8 @@ export function verifySignature({ rawBody, signature, timestamp, secret, toleran
  * stable `conversation.uid` + the Users/Contacts APIs (resolved later, F4).
  * @returns {{eventUid:?string, eventType:?string, version:?string,
  *   conversationUid:?string, channelType:?string, channelIdentifier:?string,
- *   assignedUserUid:?string, contactUid:?string, locationUid:?string,
+ *   assignedUserUid:?string, senderUserUid:?string, automated:boolean,
+ *   contactUid:?string, locationUid:?string,
  *   orgUid:?string, occurredAt:?string, failureReason:?string}}
  */
 export function parseEnvelope(payload) {
@@ -128,6 +131,15 @@ export function parseEnvelope(payload) {
     channelType: channel.type ?? null,
     channelIdentifier: channel.identifier ?? null,
     assignedUserUid: conv.assignedUser?.uid ?? null,
+    // Who sent this message (an outbound reply's author = the rep). Best-effort id
+    // only, never the body (P1). VERIFY the concrete field on message.sent against
+    // docs.podium.com at live wiring — Podium's exact sender path isn't pinned yet.
+    senderUserUid: data.sender?.uid ?? data.user?.uid ?? data.author?.uid ?? null,
+    // True when the message was sent by an automation/AI (e.g. Podium's "Jerry"),
+    // NOT a human rep. Used to skip auto-advancing the funnel on a bot reply (F16
+    // will refine the exact signal). Defaults false when Podium doesn't flag it.
+    automated: data.automated === true || data.isAutomated === true
+      || (data.author?.type != null && String(data.author.type).toLowerCase() !== 'user'),
     contactUid: contactHint.uid ?? null,
     locationUid: loc.uid ?? null,
     orgUid: loc.organizationUid ?? null,
@@ -215,6 +227,25 @@ export async function portalUserForPodiumUid(client, podiumUserUid) {
 }
 
 /**
+ * Best-effort customer link off the (deprecated) contact-hint uid — id lookup only,
+ * no API call. Full contact↔customer bridging is F4; until then customer_id may stay
+ * NULL. Tolerates a pre-F0 DB (missing column/table).
+ */
+export async function customerIdForContactUid(client, contactUid) {
+  if (!contactUid) return null;
+  try {
+    const cr = await client.query(
+      `SELECT id FROM customers WHERE podium_contact_id = $1 LIMIT 1`,
+      [contactUid]
+    );
+    return cr.rows[0]?.id ?? null;
+  } catch (err) {
+    if (err?.code !== '42703' && err?.code !== '42P01') throw err;
+    return null;
+  }
+}
+
+/**
  * P12 — auto-create a lead on the first inbound with no open lead for the
  * conversation, else touch last_contact_at. Idempotent per conversation: a
  * just-created lead is open, so subsequent inbounds only touch it.
@@ -244,19 +275,7 @@ export async function handleMessageReceived(client, env) {
   const assignedTo = await portalUserForPodiumUid(client, env.assignedUserUid);
 
   // Best-effort customer link off the (deprecated) contact hint — no API call, id only.
-  // Full contact↔customer bridging is F4; until then customer_id may stay NULL.
-  let customerId = null;
-  if (env.contactUid) {
-    try {
-      const cr = await client.query(
-        `SELECT id FROM customers WHERE podium_contact_id = $1 LIMIT 1`,
-        [env.contactUid]
-      );
-      customerId = cr.rows[0]?.id ?? null;
-    } catch (err) {
-      if (err?.code !== '42703' && err?.code !== '42P01') throw err;
-    }
-  }
+  const customerId = await customerIdForContactUid(client, env.contactUid);
 
   const ins = await client.query(
     `INSERT INTO leads
@@ -275,6 +294,79 @@ export async function handleMessageReceived(client, env) {
     [leadId, assignedTo]
   );
 
+  return { action: 'created_lead', leadId };
+}
+
+/**
+ * Reply-advances-lead (hybrid funnel automation): when a SALESPERSON replies
+ * (an outbound message.sent), advance the conversation's open lead from New →
+ * Contacted, so the rep's engagement — not just the customer's inbound — is what
+ * moves the card. Rules:
+ *   • Automated/AI replies (Podium "Jerry", F16) never advance the funnel.
+ *   • An open lead at 'New' → advance to 'Contacted' (+ a stage-log row).
+ *   • An open lead already past 'New' → just touch last_contact_at (never regress,
+ *     never duplicate).
+ *   • No open lead (a rep-initiated outbound with no prior inbound) → create one
+ *     directly at 'Contacted'.
+ * Idempotent: a second reply on an already-Contacted lead only touches it.
+ * @returns {Promise<{action:string, leadId:?number}>}
+ */
+export async function handleMessageSent(client, env) {
+  const convUid = env.conversationUid;
+  if (!convUid) return { action: 'skipped_no_conversation', leadId: null };
+  // Only a HUMAN reply marks engagement — skip AI/auto sends (Jerry, F16).
+  if (env.automated) return { action: 'skipped_automated', leadId: null };
+
+  // Who replied: prefer the message sender, fall back to the conversation assignee.
+  const actor = (await portalUserForPodiumUid(client, env.senderUserUid))
+    || (await portalUserForPodiumUid(client, env.assignedUserUid));
+
+  const existing = await client.query(
+    `SELECT lead_id, stage FROM leads
+      WHERE podium_conversation_id = $1 AND stage NOT IN ('Won','Lost')
+      ORDER BY created_at DESC LIMIT 1`,
+    [convUid]
+  );
+
+  if (existing.rowCount > 0) {
+    const { lead_id: leadId, stage } = existing.rows[0];
+    if (stage === 'New') {
+      await client.query(
+        `UPDATE leads SET stage = 'Contacted', last_contact_at = NOW(), updated_at = NOW()
+          WHERE lead_id = $1`,
+        [leadId]
+      );
+      await client.query(
+        `INSERT INTO lead_stage_log (lead_id, from_stage, to_stage, user_id, notes_log)
+         VALUES ($1, 'New', 'Contacted', $2, 'Auto-advanced: salesperson replied')`,
+        [leadId, actor]
+      );
+      return { action: 'advanced_lead', leadId };
+    }
+    // Already engaged (Contacted/Quoted/…) — record contact, don't regress/duplicate.
+    await client.query(
+      `UPDATE leads SET last_contact_at = NOW(), updated_at = NOW() WHERE lead_id = $1`,
+      [leadId]
+    );
+    return { action: 'touched_lead', leadId };
+  }
+
+  // No open lead — a rep-initiated outbound. Create one already at Contacted.
+  const customerId = await customerIdForContactUid(client, env.contactUid);
+  const ins = await client.query(
+    `INSERT INTO leads
+       (source, source_channel, podium_conversation_id, podium_contact_id,
+        customer_id, stage, assigned_to, last_contact_at)
+     VALUES ('podium', $1, $2, $3, $4, 'Contacted', $5, NOW())
+     RETURNING lead_id`,
+    [env.channelType || null, convUid, env.contactUid || null, customerId, actor]
+  );
+  const leadId = ins.rows[0].lead_id;
+  await client.query(
+    `INSERT INTO lead_stage_log (lead_id, from_stage, to_stage, user_id, notes_log)
+     VALUES ($1, NULL, 'Contacted', $2, 'Auto-created from salesperson reply (rep-initiated)')`,
+    [leadId, actor]
+  );
   return { action: 'created_lead', leadId };
 }
 
@@ -307,8 +399,11 @@ export async function routeEvent(client, env) {
     case 'message.failed':
       // §10: record the failure; the inbox/F10 surface it. No lead mutation.
       return { kind, status: 'failed', action: 'recorded_failure' };
-    case 'message.sent':
-      return { kind, status: 'processed', action: 'reconciled_send' };
+    case 'message.sent': {
+      // A salesperson reply advances the funnel (New → Contacted) — hybrid rule.
+      const r = await handleMessageSent(client, env);
+      return { kind, status: 'processed', ...r };
+    }
     default:
       // contact/lead/review/unknown — logged now; owned by F4/F5/F8 later.
       return { kind, status: 'processed', action: 'logged' };
@@ -348,7 +443,7 @@ export async function processEvent(client, env) {
 export default {
   parseTimestampMs, safeEqual, computeSignature, verifySignature,
   parseEnvelope, buildSyncPayload, classifyEvent,
-  insertSyncLog, markSyncLog, portalUserForPodiumUid,
-  handleMessageReceived, handleAssignment, routeEvent, processEvent,
+  insertSyncLog, markSyncLog, portalUserForPodiumUid, customerIdForContactUid,
+  handleMessageReceived, handleMessageSent, handleAssignment, routeEvent, processEvent,
   DEFAULT_TOLERANCE_SEC,
 };

--- a/scripts/podium-webhook-smoke.mjs
+++ b/scripts/podium-webhook-smoke.mjs
@@ -127,6 +127,13 @@ console.log('Podium webhook (F2) smoke (PODIUM_MOCK=true)\n');
   const syncPayload = wh.buildSyncPayload(env);
   check('P1: sync-log payload contains NO message body', !/SECRET MESSAGE TEXT/.test(JSON.stringify(syncPayload)) && syncPayload.body === undefined);
   check('sync payload: keeps conversation + channel + assignee', syncPayload.conversationUid === 'pod_cnv_00003' && syncPayload.channel === 'phone' && syncPayload.assignedUserUid === 'pod_usr_amELia');
+
+  // Reply-advance fields (message.sent): sender + automated flag.
+  check('envelope: senderUserUid null when absent', env.senderUserUid === null);
+  check('envelope: automated defaults false', env.automated === false);
+  const outEnv = wh.parseEnvelope({ metadata: { eventType: 'message.sent' }, data: { sender: { uid: 'pod_usr_amELia' }, author: { type: 'bot' } } });
+  check('envelope: senderUserUid extracted from data.sender', outEnv.senderUserUid === 'pod_usr_amELia');
+  check('envelope: automated true when author.type != user (Jerry/AI)', outEnv.automated === true);
 }
 
 // ============================================================================
@@ -134,6 +141,7 @@ console.log('Podium webhook (F2) smoke (PODIUM_MOCK=true)\n');
 // ============================================================================
 {
   check('classify: message.received', wh.classifyEvent('message.received') === 'message.received');
+  check('classify: message.sent', wh.classifyEvent('message.sent') === 'message.sent');
   check('classify: message.failed', wh.classifyEvent('message.failed') === 'message.failed');
   check('classify: assignment (liberal match)', wh.classifyEvent('conversation.assignee.updated') === 'assignment');
   check('classify: contact', wh.classifyEvent('contact.created') === 'contact');
@@ -208,6 +216,70 @@ console.log('Podium webhook (F2) smoke (PODIUM_MOCK=true)\n');
   const client = makeClient([{ match: has(/SELECT id FROM users/i), throws: Object.assign(new Error('col'), { code: '42703' }) }]);
   const id = await wh.portalUserForPodiumUid(client, 'pod_usr_x');
   check('resolve: null (not error) when podium_user_id column absent (42703)', id === null);
+}
+
+// 4g. Reply-advances-lead (message.sent) — hybrid funnel automation
+// A human reply on an open 'New' lead → advance to 'Contacted' (+ stage log).
+{
+  const client = makeClient([
+    { match: has(/SELECT lead_id, stage FROM leads/i), result: { rowCount: 1, rows: [{ lead_id: 810, stage: 'New' }] } },
+    { match: has(/SELECT id FROM users/i), result: { rowCount: 1, rows: [{ id: 'AM' }] } },
+    { match: has(/UPDATE leads SET stage = 'Contacted'/i), result: { rowCount: 1 } },
+    { match: has(/INSERT INTO lead_stage_log/i), result: { rowCount: 1 } },
+  ]);
+  const r = await wh.handleMessageSent(client, { conversationUid: 'pod_cnv_a', senderUserUid: 'pod_usr_amELia', channelType: 'phone' });
+  check('reply: advances an open New lead → Contacted', r.action === 'advanced_lead' && r.leadId === 810);
+  const log = client.calls.find((c) => /INSERT INTO lead_stage_log/i.test(c.sql));
+  check('reply: writes a New→Contacted stage log by the replying rep', log && /'New', 'Contacted'/.test(log.sql) && log.params[1] === 'AM');
+}
+// A reply on a lead already past New → touch only (no regress, no duplicate log).
+{
+  const client = makeClient([
+    { match: has(/SELECT lead_id, stage FROM leads/i), result: { rowCount: 1, rows: [{ lead_id: 811, stage: 'Contacted' }] } },
+    { match: has(/SELECT id FROM users/i), result: { rowCount: 1, rows: [{ id: 'AM' }] } },
+    { match: has(/UPDATE leads SET last_contact_at/i), result: { rowCount: 1 } },
+  ]);
+  const r = await wh.handleMessageSent(client, { conversationUid: 'pod_cnv_b', senderUserUid: 'pod_usr_amELia' });
+  check('reply: already-engaged lead is only touched', r.action === 'touched_lead' && r.leadId === 811);
+  check('reply: no stage log + no stage change when already past New', !client.calls.some((c) => /INSERT INTO lead_stage_log/i.test(c.sql)) && !client.calls.some((c) => /SET stage =/i.test(c.sql)));
+}
+// A reply with NO open lead (rep-initiated outreach) → create one at Contacted.
+{
+  const client = makeClient([
+    { match: has(/SELECT lead_id, stage FROM leads/i), result: { rowCount: 0, rows: [] } },
+    { match: has(/SELECT id FROM users/i), result: { rowCount: 1, rows: [{ id: 'AM' }] } },
+    { match: has(/SELECT id FROM customers/i), result: { rowCount: 0, rows: [] } },
+    { match: has(/INSERT INTO leads/i), result: { rowCount: 1, rows: [{ lead_id: 812 }] } },
+    { match: has(/INSERT INTO lead_stage_log/i), result: { rowCount: 1 } },
+  ]);
+  const r = await wh.handleMessageSent(client, { conversationUid: 'pod_cnv_c', senderUserUid: 'pod_usr_amELia', channelType: 'sms' });
+  check('reply: creates a lead at Contacted when none open (rep-initiated)', r.action === 'created_lead' && r.leadId === 812);
+  const ins = client.calls.find((c) => /INSERT INTO leads/i.test(c.sql));
+  check('reply: new lead is Contacted, on the conversation, owned by the rep', ins && /'Contacted'/.test(ins.sql) && ins.params[1] === 'pod_cnv_c' && ins.params[4] === 'AM');
+}
+// Automated/AI reply (Jerry, F16) → never advances the funnel.
+{
+  const client = makeClient();
+  const r = await wh.handleMessageSent(client, { conversationUid: 'pod_cnv_d', automated: true });
+  check('reply: automated/AI send is skipped (no funnel change)', r.action === 'skipped_automated' && client.calls.length === 0);
+}
+// No conversation uid → skipped.
+{
+  const r = await wh.handleMessageSent(makeClient(), { conversationUid: null });
+  check('reply: skipped when no conversation uid', r.action === 'skipped_no_conversation');
+}
+// Sender absent → fall back to the conversation assignee as the actor.
+{
+  const client = makeClient([
+    { match: has(/SELECT lead_id, stage FROM leads/i), result: { rowCount: 1, rows: [{ lead_id: 813, stage: 'New' }] } },
+    { match: has(/SELECT id FROM users/i), result: { rowCount: 1, rows: [{ id: 'BN' }] } },
+    { match: has(/UPDATE leads SET stage = 'Contacted'/i), result: { rowCount: 1 } },
+    { match: has(/INSERT INTO lead_stage_log/i), result: { rowCount: 1 } },
+  ]);
+  const r = await wh.handleMessageSent(client, { conversationUid: 'pod_cnv_e', senderUserUid: null, assignedUserUid: 'pod_usr_bENjin' });
+  check('reply: actor falls back to the assignee when no sender uid', r.action === 'advanced_lead');
+  const log = client.calls.find((c) => /INSERT INTO lead_stage_log/i.test(c.sql));
+  check('reply: stage log attributed to the fallback assignee', log && log.params[1] === 'BN');
 }
 
 // ============================================================================
@@ -317,6 +389,21 @@ function makeReq({ method = 'POST', headers = {}, raw = '' } = {}) {
   // Missing headers → 401 missing_headers (reached before DB)
   await webhookHandler(makeReq({ method: 'POST', raw }), res);
   check('endpoint: POST missing signature headers → 401', res.statusCode === 401 && res.body?.reason === 'missing_headers');
+}
+
+// 5e. fresh message.sent → routes to reply-advance, marks processed, COMMIT
+{
+  const client = makeClient([
+    { match: has(/INSERT INTO integration_sync_log/i), result: { rowCount: 1, rows: [{ id: 71 }] } },
+    { match: has(/SELECT lead_id, stage FROM leads/i), result: { rowCount: 1, rows: [{ lead_id: 900, stage: 'New' }] } },
+    { match: has(/SELECT id FROM users/i), result: { rowCount: 1, rows: [{ id: 'AM' }] } },
+    { match: has(/UPDATE leads SET stage = 'Contacted'/i), result: { rowCount: 1 } },
+    { match: has(/INSERT INTO lead_stage_log/i), result: { rowCount: 1 } },
+    { match: has(/UPDATE integration_sync_log/i), result: { rowCount: 1 } },
+  ]);
+  const r = await wh.processEvent(client, { eventUid: 'evt_sent', eventType: 'message.sent', conversationUid: 'pod_cnv_z', senderUserUid: 'pod_usr_amELia' });
+  check('processEvent: message.sent advances the lead (not deduped)', r.deduped === false && r.action === 'advanced_lead');
+  check('processEvent: message.sent commits', client.calls.some((c) => /^COMMIT/i.test(c.sql)));
 }
 
 console.log(`\nAll ${passed} checks passed ✅`);


### PR DESCRIPTION
Makes lead capture automatic on the **salesperson's reply** — the hybrid you approved. Builds on the existing P12 rule (inbound customer message already auto-creates a `New` lead) so **nothing is missed**, and the rep's reply is what marks real engagement by advancing the card.

### Behaviour (in `lib/podiumWebhook.js`, on the outbound `message.sent` event)
- **Open lead at `New`** → advance to **Contacted** + append a `New → Contacted` stage-log row attributed to the replying rep.
- **Open lead already past New** (Contacted/Quoted/…) → just touch `last_contact_at` — never regress, never duplicate.
- **No open lead** (a rep-initiated outbound with no prior inbound) → create one directly at **Contacted**.
- **Automated / AI replies** (Podium's "Jerry", F16) are **skipped** — only a human reply advances the funnel.

### Notes
- **Mock-first**, behind the F2 webhook: this fires on live chats only once `PODIUM_MOCK=false` and the Podium webhook subscription is registered. Until then it's exercised by the offline smoke.
- **No migration. No new serverless function. P1 held** — only identifiers/metadata are read (never the message body); `senderUserUid` is an id only.
- **VERIFY at live wiring:** Podium's concrete `message.sent` sender field and the automated/bot signal aren't pinned in our reference yet — flagged in code.
- Independent of PR #49 (writes `leads`/`lead_stage_log` directly, both already on `main`), so it can be reviewed/merged on its own.

### Tests
- `scripts/podium-webhook-smoke.mjs` → **72/72** (adds envelope sender/automated, `message.sent` classification, advance/touch/create/skip/fallback cases, and `processEvent` routing).
- `CI=true npm run build` → **Compiled successfully**.

**Do not merge without review** — draft/review gate.
