### PR TITLE
F12: Rich messaging — attachments, internal notes, message templates

### DIFF
--- a/lib/podium.js
+++ b/lib/podium.js
@@ -393,8 +393,13 @@ export function listMessages(userId, conversationUid, opts = {}) {
   return request(userId, 'GET', `conversations/${conversationUid}/messages`, { query, client: opts.client });
 }
 
-/** POST /v4/messages — send AS the logged-in rep. */
-export function sendMessage(userId, { conversationUid, body, channel, to, type = 'text', locationUid } = {}) {
+/**
+ * POST /v4/messages — send AS the logged-in rep. F12 rich messaging: `attachments`
+ * carries image/video/file references (metadata only — never raw bytes here; real
+ * media upload is a live-wiring swap over Podium's media API, a VERIFY at wiring) and
+ * `templateId` records the message template the body came from.
+ */
+export function sendMessage(userId, { conversationUid, body, channel, to, type = 'text', locationUid, attachments, templateId } = {}) {
   const payload = {
     conversationUid,
     body,
@@ -403,7 +408,32 @@ export function sendMessage(userId, { conversationUid, body, channel, to, type =
   };
   if (channel) payload.channel = channel;
   if (to) payload.to = to;
+  if (Array.isArray(attachments) && attachments.length) payload.attachments = attachments;
+  if (templateId) payload.templateId = templateId;
   return request(userId, 'POST', 'messages', { body: payload });
+}
+
+/**
+ * GET /v4/message_templates — Podium's saved message templates (canned responses) a
+ * rep inserts into the composer (F12). Cursor-paginated like other list endpoints.
+ * VERIFY the live Podium endpoint/field names at wiring.
+ */
+export function listMessageTemplates(userId, opts = {}) {
+  const query = {};
+  if (opts.limit) query.limit = opts.limit;
+  if (opts.cursor) query.cursor = opts.cursor;
+  return request(userId, 'GET', 'message_templates', { query, client: opts.client });
+}
+
+/**
+ * POST /v4/conversations/{uid}/notes — add a team-only INTERNAL NOTE to a conversation
+ * (F12). Team-visible, NEVER sent to the customer. Sent to Podium (the system of record)
+ * so nothing is persisted in the portal DB (P1). VERIFY the live endpoint at wiring.
+ */
+export function postInternalNote(userId, { conversationUid, body, author } = {}) {
+  return request(userId, 'POST', `conversations/${conversationUid}/notes`, {
+    body: { body, author },
+  });
 }
 
 /** GET /v4/conversations/{uid}/assignees */
@@ -476,7 +506,7 @@ export default {
   getStoredToken, saveUserToken, tokenForUser,
   request, paginate,
   listConversations, getConversation, updateConversation, setConversationStatus,
-  listMessages, sendMessage,
+  listMessages, sendMessage, listMessageTemplates, postInternalNote,
   getAssignee, assignConversation, getUsers, getContact, requestReview,
   createWebhook, listWebhooks, deleteWebhook,
 };

--- a/lib/podium.mock.js
+++ b/lib/podium.mock.js
@@ -29,6 +29,18 @@ const CONTACTS = [
   { uid: 'pod_con_jaKE44', name: 'Jake Wilson', phoneNumber: '+61400777888', email: 'jakew@example.com', channels: ['google'] },
 ];
 
+// Message templates (canned responses) — Podium's saved templates a rep inserts
+// into the composer (feature F12). Australian English, Grays brand voice; no hard
+// prices (exact pricing lives in the product/quote flow). Under live Podium these
+// come from the templates API — VERIFY the live endpoint/field names at wiring.
+const MESSAGE_TEMPLATES = [
+  { uid: 'pod_tpl_greet', title: 'Greeting', body: 'Hi! Thanks for reaching out to Grays Fitness. How can I help you today?' },
+  { uid: 'pod_tpl_deliv', title: 'Delivery quote', body: 'We deliver Australia-wide. If you can share your suburb and postcode, I’ll organise a delivery quote for you.' },
+  { uid: 'pod_tpl_stock', title: 'Stock check', body: 'Let me check our current stock on that for you — one moment.' },
+  { uid: 'pod_tpl_warra', title: 'Warranty', body: 'All our equipment is commercially graded and professionally refurbished, and comes with a warranty. Happy to run through the details.' },
+  { uid: 'pod_tpl_hold', title: 'Hold item', body: 'I can hold that for you for 24 hours while you decide. Would you like me to organise that?' },
+];
+
 const LOCATION_UID = () => process.env.PODIUM_LOCATION_UID || 'pod_loc_GRAYSHQ';
 const ORG_UID = () => process.env.PODIUM_ORG_UID || 'pod_org_GRAYS';
 
@@ -241,6 +253,24 @@ export function handle(method, path, opts = {}) {
       if (!conv) return notFound('conversation', convUid);
       return paginateList(MESSAGES[convUid] || [], query);
     }
+    // POST /conversations/{uid}/notes — add a team-only INTERNAL NOTE (F12). Not sent
+    // to the customer; `internal:true` so the inbox renders it distinctly. Appended to
+    // the in-memory thread so it persists for the Preview demo (writes nothing to the
+    // portal DB — Podium is the system of record, P1). VERIFY the live endpoint at wiring.
+    if (segs[2] === 'notes' && m === 'POST') {
+      if (!conv) return notFound('conversation', convUid);
+      const note = {
+        uid: `pod_note_${Date.now().toString(36)}`,
+        direction: 'internal',
+        internal: true,
+        channel: conv.channel?.type || 'note',
+        author: body.author || null,
+        body: body.body || '',
+        createdAt: nowIso(),
+      };
+      (MESSAGES[convUid] || (MESSAGES[convUid] = [])).push(note);
+      return note;
+    }
     // GET|PUT /conversations/{uid}/assignees
     if (segs[2] === 'assignees') {
       if (!conv) return notFound('conversation', convUid);
@@ -264,8 +294,17 @@ export function handle(method, path, opts = {}) {
     return conv;
   }
 
-  // POST /messages (send)
+  // GET /message_templates — canned responses for the composer (F12).
+  if (segs[0] === 'message_templates' && (!segs[1] || m === 'GET')) {
+    return paginateList(MESSAGE_TEMPLATES, query);
+  }
+
+  // POST /messages (send). Echoes back any F12 rich-messaging metadata the caller
+  // attached — `attachments` (image/video/file references) and `templateId` (the
+  // template the body came from) — so the seam is exercised end-to-end in mock. Real
+  // media upload is a live-wiring swap (Podium media API) — VERIFY at wiring.
   if (segs[0] === 'messages' && m === 'POST') {
+    const attachments = Array.isArray(body.attachments) ? body.attachments : undefined;
     return {
       uid: `pod_msg_sent_${Date.now().toString(36)}`,
       conversationUid: body.conversationUid || null,
@@ -273,6 +312,8 @@ export function handle(method, path, opts = {}) {
       direction: 'outbound',
       status: 'sent',
       locationUid: body.locationUid || LOCATION_UID(),
+      ...(attachments ? { attachments } : {}),
+      ...(body.templateId ? { templateId: body.templateId } : {}),
       createdAt: nowIso(),
     };
   }
@@ -321,5 +362,5 @@ function nowIso() {
 }
 
 // Exported for tests / later increments.
-export const fixtures = { USERS, CONTACTS, CONVERSATIONS, MESSAGES };
+export const fixtures = { USERS, CONTACTS, CONVERSATIONS, MESSAGES, MESSAGE_TEMPLATES };
 export const _internal = { encodeCursor, decodeCursor, paginateList };

--- a/lib/podiumRoutes/inbox.js
+++ b/lib/podiumRoutes/inbox.js
@@ -18,6 +18,14 @@
 //        → GET /v4/conversations, kept to those touched since the client's cursor
 //          (drives the 5–10s inbox poll).
 //
+// F12 rich messaging adds:
+//   GET  /api/podium/inbox?resource=templates
+//        → GET /v4/message_templates. Canned responses the rep inserts in the composer.
+//   POST /api/podium/inbox?resource=note  { conversationId, body }
+//        → POST /v4/conversations/{uid}/notes. A team-only INTERNAL note (not sent to
+//          the customer). And POST ?resource=messages may carry image/video/file
+//          `attachments` (metadata only) + the `templateId` the body came from.
+//
 // Every call runs on the rep's own token (P4). Mock-first: with PODIUM_MOCK=true the
 // Podium hop is served by lib/podium.mock.js so the inbox is reviewable on the Preview
 // without live creds. Gated to sales/superadmin via the login JWT (server is the real
@@ -27,7 +35,10 @@
 // endpoint writes NO chat content to the database. Podium is the system of record.
 
 import { getAuthUser, hasAnyRole } from '../rbac.js';
-import { listConversations, getConversation, listMessages, sendMessage, setConversationStatus, isMock } from '../podium.js';
+import {
+  listConversations, getConversation, listMessages, sendMessage, setConversationStatus,
+  listMessageTemplates, postInternalNote, isMock,
+} from '../podium.js';
 import {
   resolveSelfPodiumUid, filterUpdatedSince, clampLimit, normalizeBucket, normalizeStatus,
 } from '../podiumInbox.js';
@@ -53,6 +64,14 @@ export default async function handler(req, res) {
     if (method === 'GET') return readThreadRoute(req, res, auth);
     if (method === 'POST') return sendMessageRoute(req, res, auth);
     return res.status(405).json({ error: 'Method not allowed' });
+  }
+  if (resource === 'templates') {
+    if (method !== 'GET') return res.status(405).json({ error: 'Method not allowed' });
+    return templatesRoute(req, res, auth);
+  }
+  if (resource === 'note') {
+    if (method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+    return noteRoute(req, res, auth);
   }
   if (resource === 'poll') {
     if (method !== 'GET') return res.status(405).json({ error: 'Method not allowed' });
@@ -159,16 +178,78 @@ async function readThreadRoute(req, res, auth) {
   }
 }
 
-// POST ?resource=messages — send a reply AS the rep (no DB touched).
+// POST ?resource=messages — send a reply AS the rep (no DB touched). F12: may carry
+// image/video/file `attachments` (METADATA only — never raw bytes; real media upload is
+// a live-wiring swap over Podium's media API) and the `templateId` the body came from.
+// A message needs at least a body OR one attachment.
 async function sendMessageRoute(req, res, auth) {
-  const { conversationId, body } = req.body || {};
+  const { conversationId, body, attachments, templateId } = req.body || {};
   if (!conversationId) return res.status(400).json({ error: 'conversationId is required' });
-  if (!body || !String(body).trim()) return res.status(400).json({ error: 'body is required' });
+  const text = body == null ? '' : String(body).trim();
+  const cleanAttachments = sanitizeAttachments(attachments);
+  if (!text && cleanAttachments.length === 0) {
+    return res.status(400).json({ error: 'a message body or an attachment is required' });
+  }
   try {
-    const sent = await sendMessage(auth.id, { conversationUid: String(conversationId), body: String(body) });
+    const sent = await sendMessage(auth.id, {
+      conversationUid: String(conversationId),
+      body: text,
+      attachments: cleanAttachments.length ? cleanAttachments : undefined,
+      templateId: templateId ? String(templateId) : undefined,
+    });
     return res.status(201).json({ conversationId: String(conversationId), sent, mock: isMock() });
   } catch (err) {
     return respondUpstreamError(res, err, 'send the message');
+  }
+}
+
+// Keep only safe attachment METADATA (filename, mimeType, kind, size) — never raw file
+// bytes. Under live Podium the client uploads media to Podium and passes back a media
+// reference; here we forward descriptive metadata only, so nothing binary is stored (P1).
+function sanitizeAttachments(raw) {
+  if (!Array.isArray(raw)) return [];
+  return raw.slice(0, 10).map((a) => {
+    const kind = ['image', 'video', 'file'].includes(a?.kind) ? a.kind : 'file';
+    const out = { kind };
+    if (a?.filename) out.filename = String(a.filename).slice(0, 200);
+    if (a?.mimeType) out.mimeType = String(a.mimeType).slice(0, 100);
+    if (Number.isFinite(Number(a?.size))) out.size = Number(a.size);
+    if (a?.mediaUid) out.mediaUid = String(a.mediaUid).slice(0, 255); // live Podium media ref
+    return out;
+  });
+}
+
+// GET ?resource=templates — Podium message templates (canned responses) for the
+// composer (F12). Runs on the rep's token (P4); no DB touched.
+async function templatesRoute(req, res, auth) {
+  try {
+    const resp = await listMessageTemplates(auth.id, { limit: 50 });
+    return res.status(200).json({
+      data: Array.isArray(resp?.data) ? resp.data : [],
+      metadata: resp?.metadata || { nextCursor: null, previousCursor: null },
+      mock: isMock(),
+    });
+  } catch (err) {
+    return respondUpstreamError(res, err, 'load message templates');
+  }
+}
+
+// POST ?resource=note { conversationId, body } — add a team-only INTERNAL NOTE to the
+// conversation (F12). Team-visible, NEVER sent to the customer. Sent to Podium (system
+// of record); no DB touched, no chat/note body persisted in the portal (P1).
+async function noteRoute(req, res, auth) {
+  const { conversationId, body } = req.body || {};
+  if (!conversationId) return res.status(400).json({ error: 'conversationId is required' });
+  if (!body || !String(body).trim()) return res.status(400).json({ error: 'a note body is required' });
+  try {
+    const note = await postInternalNote(auth.id, {
+      conversationUid: String(conversationId),
+      body: String(body).trim(),
+      author: auth.id,
+    });
+    return res.status(201).json({ conversationId: String(conversationId), note, mock: isMock() });
+  } catch (err) {
+    return respondUpstreamError(res, err, 'add the internal note');
   }
 }
 

--- a/scripts/podium-inbox-smoke.mjs
+++ b/scripts/podium-inbox-smoke.mjs
@@ -23,7 +23,7 @@ process.env.PODIUM_API_VERSION = process.env.PODIUM_API_VERSION || '2021-04-01';
 
 const jwt = (await import('jsonwebtoken')).default;
 const { clampLimit, filterUpdatedSince, resolveSelfPodiumUid, normalizeBucket, normalizeStatus } = await import('../lib/podiumInbox.js');
-const { listConversations, listMessages, sendMessage } = await import('../lib/podium.js');
+const { listConversations, listMessages, sendMessage, listMessageTemplates, postInternalNote } = await import('../lib/podium.js');
 const inboxHandler = (await import('../lib/podiumRoutes/inbox.js')).default;
 
 let passed = 0;
@@ -287,6 +287,87 @@ console.log('\nmock helpers:');
   check('sendMessage: mock returns an outbound sent message', sent.direction === 'outbound' && sent.status === 'sent');
   const thread = await listMessages('AM', 'pod_cnv_00004', {});
   check('listMessages: mock returns the thread envelope', Array.isArray(thread.data) && thread.data.length === 2);
+}
+
+// ---- F12 rich messaging: templates -------------------------------------------
+console.log('\nF12 resource=templates:');
+{
+  const res = makeRes();
+  await inboxHandler(makeReq({ method: 'POST', query: { resource: 'templates' } }), res);
+  check('templates: 405 for POST', res.statusCode === 405);
+}
+{
+  const res = makeRes();
+  await inboxHandler(makeReq({ method: 'GET', query: { resource: 'templates' } }), res);
+  check('templates GET: 200 returns the template list', res.statusCode === 200 && Array.isArray(res.body.data) && res.body.data.length >= 3, `status ${res.statusCode}`);
+  check('templates GET: each has uid/title/body', res.body.data.every((t) => t.uid && t.title && t.body));
+  check('templates GET: mock flag surfaced', res.body.mock === true);
+}
+{
+  const tpls = await listMessageTemplates('AM', { limit: 50 });
+  check('listMessageTemplates: mock helper returns templates', Array.isArray(tpls.data) && tpls.data.length >= 3);
+}
+
+// ---- F12 rich messaging: internal notes --------------------------------------
+console.log('\nF12 resource=note (internal notes):');
+{
+  const res = makeRes();
+  await inboxHandler(makeReq({ method: 'GET', query: { resource: 'note' } }), res);
+  check('note: 405 for GET', res.statusCode === 405);
+}
+{
+  const res = makeRes();
+  await inboxHandler(makeReq({ method: 'POST', query: { resource: 'note' }, body: { body: 'hi' } }), res);
+  check('note: 400 without conversationId', res.statusCode === 400);
+}
+{
+  const res = makeRes();
+  await inboxHandler(makeReq({ method: 'POST', query: { resource: 'note' }, body: { conversationId: 'pod_cnv_00005' } }), res);
+  check('note: 400 without a body', res.statusCode === 400);
+}
+{
+  const before = (await listMessages('AM', 'pod_cnv_00005', {})).data.length;
+  const res = makeRes();
+  await inboxHandler(makeReq({ method: 'POST', query: { resource: 'note' }, body: { conversationId: 'pod_cnv_00005', body: 'Customer wants a callback Monday.' } }), res);
+  check('note POST: 201 returns an internal note', res.statusCode === 201 && res.body.note?.internal === true && res.body.note?.direction === 'internal', `status ${res.statusCode}`);
+  check('note POST: attributed to the acting rep (id only, P1)', res.body.note?.author === 'AM');
+  const after = (await listMessages('AM', 'pod_cnv_00005', {})).data;
+  check('note POST: appended to the thread (team-visible)', after.length === before + 1 && after[after.length - 1].internal === true, `before ${before} after ${after.length}`);
+}
+{
+  const note = await postInternalNote('AM', { conversationUid: 'pod_cnv_00003', body: 'Direct helper note.', author: 'AM' });
+  check('postInternalNote: mock helper returns an internal note', note.internal === true && note.body === 'Direct helper note.');
+}
+
+// ---- F12 rich messaging: attachments on send ---------------------------------
+console.log('\nF12 resource=messages with attachments:');
+{
+  // body-less send is rejected only when there are also no attachments
+  const res = makeRes();
+  await inboxHandler(makeReq({ method: 'POST', query: { resource: 'messages' }, body: { conversationId: 'pod_cnv_00001', attachments: [] } }), res);
+  check('messages POST: 400 with neither body nor attachment', res.statusCode === 400);
+}
+{
+  const res = makeRes();
+  await inboxHandler(makeReq({
+    method: 'POST',
+    query: { resource: 'messages' },
+    body: { conversationId: 'pod_cnv_00001', attachments: [{ kind: 'image', filename: 'squat-rack.jpg', mimeType: 'image/jpeg', size: 12345 }] },
+  }), res);
+  check('messages POST: 201 attachment-only send is allowed', res.statusCode === 201, `status ${res.statusCode}`);
+  check('messages POST: attachments echoed on the sent message', Array.isArray(res.body.sent?.attachments) && res.body.sent.attachments[0].kind === 'image' && res.body.sent.attachments[0].filename === 'squat-rack.jpg');
+}
+{
+  const res = makeRes();
+  await inboxHandler(makeReq({
+    method: 'POST',
+    query: { resource: 'messages' },
+    body: { conversationId: 'pod_cnv_00001', body: 'See attached', templateId: 'pod_tpl_deliv', attachments: [{ kind: 'nonsense', filename: 'x'.repeat(500) }] },
+  }), res);
+  check('messages POST: 201 with body + template + attachment', res.statusCode === 201);
+  check('messages POST: bad kind sanitised to file', res.body.sent?.attachments?.[0].kind === 'file');
+  check('messages POST: long filename clamped to 200 chars', (res.body.sent?.attachments?.[0].filename || '').length === 200);
+  check('messages POST: templateId echoed', res.body.sent?.templateId === 'pod_tpl_deliv');
 }
 
 console.log(`\n✅ inbox smoke: ${passed} checks passed`);

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -29,6 +29,11 @@
 // (Open/Closed within Unassigned / All / Assigned-to-You) is F11; the AI-summary card
 // is F16 — this increment leaves a labelled slot for it.
 //
+// F12 rich messaging adds to the composer: image/video ATTACHMENTS (metadata-only seam
+// — the file bytes stay in the browser; real Podium media upload is a live-wiring swap),
+// team-only INTERNAL NOTES (POST ?resource=note — rendered distinctly, never sent to the
+// customer), and Podium MESSAGE TEMPLATES (GET ?resource=templates — inserted into the draft).
+//
 // Default view is "My conversations" (scope=mine) — this closes F1b increment 3.
 // Mock-first: while PODIUM_MOCK=true the backend serves lib/podium.mock.js, so the
 // whole inbox + panel are browsable on the Preview without live Podium credentials.
@@ -111,6 +116,14 @@ function convTitle(c) {
   return c?.channel?.identifier || c?.contact?.uid || c?.uid || 'Conversation';
 }
 
+// F12 — classify a picked file into an attachment kind for rendering/send metadata.
+function kindForType(mime) {
+  const t = String(mime || '').toLowerCase();
+  if (t.startsWith('image/')) return 'image';
+  if (t.startsWith('video/')) return 'video';
+  return 'file';
+}
+
 export default function Inbox() {
   const navigate = useNavigate();
 
@@ -132,6 +145,14 @@ export default function Inbox() {
 
   const [draft, setDraft] = useState('');
   const [sending, setSending] = useState(false);
+
+  // F12 rich messaging: internal-note mode, message templates, attachments.
+  const [composerMode, setComposerMode] = useState('reply'); // 'reply' | 'note'
+  const [templates, setTemplates] = useState([]);
+  const [showTemplates, setShowTemplates] = useState(false);
+  const [attachments, setAttachments] = useState([]); // {id,file,url,kind,filename,mimeType,size}
+  const fileInputRef = useRef(null);
+  const attachmentsRef = useRef([]); // latest attachments, for object-URL cleanup on unmount
 
   // F4 incr 2 — customer side panel state.
   const [panel, setPanel] = useState(null);
@@ -274,6 +295,20 @@ export default function Inbox() {
     if (authorized) loadConversations();
   }, [authorized, loadConversations]);
 
+  // F12 — fetch Podium message templates once (canned responses for the composer).
+  useEffect(() => {
+    if (!authorized) return;
+    fetch('/api/podium/inbox?resource=templates', { headers: authHeaders() })
+      .then((r) => (r.ok ? parseMaybeJson(r) : null))
+      .then((d) => { if (Array.isArray(d?.data)) setTemplates(d.data); })
+      .catch(() => { /* templates are best-effort */ });
+  }, [authorized]);
+
+  // F12 — keep the latest attachments in a ref and revoke their object URLs on unmount
+  // (avoids leaking blob: URLs). Per-item revokes happen in removeAttachment/clearAttachments.
+  useEffect(() => { attachmentsRef.current = attachments; }, [attachments]);
+  useEffect(() => () => { attachmentsRef.current.forEach((a) => URL.revokeObjectURL(a.url)); }, []);
+
   // Funnel → chat deep-link: open ?conversation=<uid> once, even if it's not in the
   // current bucket/status. Fetches the conversation directly and opens its thread+panel.
   useEffect(() => {
@@ -366,6 +401,50 @@ export default function Inbox() {
   };
 
   // ---- Actions -------------------------------------------------------------------
+
+  // F12 — attachments. Files are held only in browser memory (object URLs) and only
+  // metadata is sent (P1: no bytes persisted; real media upload is a live-wiring swap).
+  const onPickFiles = (e) => {
+    const files = Array.from(e.target.files || []);
+    if (files.length) {
+      setAttachments((prev) => {
+        const added = files.map((f) => ({
+          id: `${f.name}_${f.size}_${Math.random().toString(36).slice(2)}`,
+          file: f,
+          url: URL.createObjectURL(f),
+          kind: kindForType(f.type),
+          filename: f.name,
+          mimeType: f.type || 'application/octet-stream',
+          size: f.size,
+        }));
+        return [...prev, ...added].slice(0, 10);
+      });
+    }
+    e.target.value = ''; // allow re-selecting the same file
+  };
+
+  const removeAttachment = (id) => {
+    setAttachments((prev) => {
+      const gone = prev.find((a) => a.id === id);
+      if (gone) URL.revokeObjectURL(gone.url);
+      return prev.filter((a) => a.id !== id);
+    });
+  };
+
+  const clearAttachments = useCallback(() => {
+    setAttachments((prev) => {
+      prev.forEach((a) => URL.revokeObjectURL(a.url));
+      return [];
+    });
+  }, []);
+
+  // F12 — insert a Podium message template into the reply draft.
+  const insertTemplate = (tpl) => {
+    setComposerMode('reply');
+    setDraft((d) => (d ? `${d}\n${tpl.body}` : tpl.body));
+    setShowTemplates(false);
+  };
+
   const clearSelection = () => {
     setSelectedId(null);
     setSelectedConv(null);
@@ -376,6 +455,10 @@ export default function Inbox() {
     setWoOpenId(null);
     setWoDetail(null);
     setLeadHistory([]);
+    setComposerMode('reply');
+    setShowTemplates(false);
+    setDraft('');
+    clearAttachments();
   };
 
   const switchBucket = (next) => {
@@ -463,16 +546,31 @@ export default function Inbox() {
     }
   };
 
-  const sendReply = async (e) => {
-    e.preventDefault();
+  // Composer submit dispatcher — a reply (with optional attachments) or an internal note.
+  const submitComposer = (e) => {
+    if (e && e.preventDefault) e.preventDefault();
+    if (!selectedId || sending) return;
+    if (composerMode === 'note') { sendNote(); return; }
+    sendReply();
+  };
+
+  const sendReply = async () => {
     const body = draft.trim();
-    if (!body || !selectedId || sending) return;
+    const atts = attachments;
+    if ((!body && atts.length === 0) || !selectedId || sending) return;
     setSending(true);
     try {
+      const payload = { conversationId: selectedId, body };
+      if (atts.length) {
+        // Metadata only — never the file bytes (P1). Real media upload is a live-wiring swap.
+        payload.attachments = atts.map((a) => ({
+          kind: a.kind, filename: a.filename, mimeType: a.mimeType, size: a.size,
+        }));
+      }
       const res = await fetch('/api/podium/inbox?resource=messages', {
         method: 'POST',
         headers: authHeaders({ 'Content-Type': 'application/json' }),
-        body: JSON.stringify({ conversationId: selectedId, body }),
+        body: JSON.stringify(payload),
       });
       if (res.status === 401) { navigate('/'); return; }
       const data = await parseMaybeJson(res);
@@ -481,6 +579,7 @@ export default function Inbox() {
         return;
       }
       // Optimistically show the sent reply. Held only in React state (P1: never persisted).
+      // Keep the local object URLs so image/video thumbnails render in the sent bubble.
       setMessages((prev) => [
         ...prev,
         {
@@ -488,13 +587,43 @@ export default function Inbox() {
           direction: 'outbound',
           channel: data?.sent?.channel || selectedConv?.channel?.type,
           body,
+          attachments: atts.map((a) => ({ kind: a.kind, url: a.url, filename: a.filename })),
           createdAt: new Date().toISOString(),
           optimistic: true,
         },
       ]);
       setDraft('');
+      setAttachments([]); // handed to the optimistic bubble; URLs stay alive for it
     } catch {
       toast.error('Server error sending the message');
+    } finally {
+      setSending(false);
+    }
+  };
+
+  // F12 — post a team-only INTERNAL note (not sent to the customer). The mock appends it
+  // to the thread, so reload it to show the note; no chat/note body is persisted (P1).
+  const sendNote = async () => {
+    const body = draft.trim();
+    if (!body || !selectedId || sending) return;
+    setSending(true);
+    try {
+      const res = await fetch('/api/podium/inbox?resource=note', {
+        method: 'POST',
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({ conversationId: selectedId, body }),
+      });
+      if (res.status === 401) { navigate('/'); return; }
+      const data = await parseMaybeJson(res);
+      if (!res.ok) {
+        toast.error(data?.error || 'Could not add the internal note');
+        return;
+      }
+      setDraft('');
+      toast.success('Internal note added (team only)');
+      loadThread(selectedId, { silent: true });
+    } catch {
+      toast.error('Server error adding the internal note');
     } finally {
       setSending(false);
     }
@@ -714,6 +843,23 @@ export default function Inbox() {
                       <div className="text-sm text-gray-400">No messages in this conversation.</div>
                     )}
                     {!loadingThread && messages.map((m) => {
+                      // F12 — internal notes render distinctly (team-only, not sent to the customer).
+                      if (m.internal || m.direction === 'internal') {
+                        return (
+                          <div key={m.uid} className="flex justify-center">
+                            <div className="max-w-[85%] w-full rounded-lg border border-amber-200 bg-amber-50 px-3 py-2">
+                              <div className="text-[11px] font-semibold text-amber-700 mb-0.5">
+                                🔒 Internal note
+                                <span className="font-normal text-amber-600"> · team only, not sent to the customer</span>
+                              </div>
+                              <div className="whitespace-pre-wrap break-words text-sm text-amber-900">{m.body}</div>
+                              <div className="text-[10px] mt-1 text-amber-500">
+                                {formatTime(m.createdAt)}{m.author ? ` · ${m.author}` : ''}
+                              </div>
+                            </div>
+                          </div>
+                        );
+                      }
                       const outbound = m.direction === 'outbound';
                       return (
                         <div key={m.uid} className={`flex ${outbound ? 'justify-end' : 'justify-start'}`}>
@@ -722,7 +868,8 @@ export default function Inbox() {
                               outbound ? 'bg-blue-500 text-white rounded-br-sm' : 'bg-white text-gray-800 border border-gray-200 rounded-bl-sm'
                             } ${m.optimistic ? 'opacity-80' : ''}`}
                           >
-                            <div className="whitespace-pre-wrap break-words">{m.body}</div>
+                            {m.body && <div className="whitespace-pre-wrap break-words">{m.body}</div>}
+                            <MessageAttachments attachments={m.attachments} outbound={outbound} />
                             <div className={`text-[10px] mt-1 ${outbound ? 'text-blue-100' : 'text-gray-400'}`}>
                               {formatTime(m.createdAt)}{m.optimistic ? ' · sending…' : ''}
                             </div>
@@ -732,28 +879,136 @@ export default function Inbox() {
                     })}
                   </div>
 
-                  <form onSubmit={sendReply} className="border-t border-gray-200 p-3 flex items-end gap-2">
-                    <textarea
-                      value={draft}
-                      onChange={(e) => setDraft(e.target.value)}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' && !e.shiftKey) {
-                          e.preventDefault();
-                          sendReply(e);
-                        }
-                      }}
-                      rows={1}
-                      placeholder="Type a reply…"
-                      className="flex-1 resize-none border border-gray-300 rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-400"
-                    />
-                    <button
-                      type="submit"
-                      disabled={sending || !draft.trim()}
-                      className="bg-blue-500 text-white px-4 py-2 rounded-lg text-sm hover:bg-blue-600 disabled:opacity-50"
-                    >
-                      {sending ? 'Sending…' : 'Send'}
-                    </button>
-                  </form>
+                  <div className="border-t border-gray-200">
+                    {/* F12 — attachment previews (reply mode) */}
+                    {composerMode === 'reply' && attachments.length > 0 && (
+                      <div className="px-3 pt-2 flex flex-wrap gap-2">
+                        {attachments.map((a) => (
+                          <div key={a.id} className="relative">
+                            {a.kind === 'image' ? (
+                              <img src={a.url} alt={a.filename} className="h-16 w-16 object-cover rounded-lg border border-gray-200" />
+                            ) : (
+                              <div className="h-16 w-24 rounded-lg border border-gray-200 bg-gray-50 flex flex-col items-center justify-center px-1 text-center">
+                                <span className="text-lg">{a.kind === 'video' ? '🎬' : '📎'}</span>
+                                <span className="text-[10px] text-gray-500 truncate w-full">{a.filename}</span>
+                              </div>
+                            )}
+                            <button
+                              type="button"
+                              onClick={() => removeAttachment(a.id)}
+                              className="absolute -top-1.5 -right-1.5 bg-gray-700 text-white rounded-full w-5 h-5 text-xs leading-none"
+                              aria-label="Remove attachment"
+                            >
+                              ×
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    )}
+
+                    {/* F12 — composer toolbar: Reply/Note mode, templates, attach */}
+                    <div className="px-3 pt-2 flex flex-wrap items-center gap-2">
+                      <div className="inline-flex rounded-lg border border-gray-300 overflow-hidden text-xs">
+                        <button
+                          type="button"
+                          onClick={() => setComposerMode('reply')}
+                          className={composerMode === 'reply' ? 'px-2.5 py-1 bg-blue-500 text-white' : 'px-2.5 py-1 bg-white text-gray-600 hover:bg-gray-50'}
+                        >
+                          Reply
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => { setComposerMode('note'); setShowTemplates(false); }}
+                          className={composerMode === 'note' ? 'px-2.5 py-1 bg-amber-500 text-white' : 'px-2.5 py-1 bg-white text-gray-600 hover:bg-gray-50'}
+                        >
+                          Internal note
+                        </button>
+                      </div>
+
+                      {composerMode === 'reply' && (
+                        <div className="relative">
+                          <button
+                            type="button"
+                            onClick={() => setShowTemplates((v) => !v)}
+                            disabled={templates.length === 0}
+                            className="text-xs px-2.5 py-1 rounded-lg border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-40"
+                            title="Insert a message template"
+                          >
+                            Templates ▾
+                          </button>
+                          {showTemplates && templates.length > 0 && (
+                            <div className="absolute bottom-full mb-1 left-0 z-10 w-64 max-h-56 overflow-y-auto bg-white border border-gray-200 rounded-lg shadow-lg">
+                              {templates.map((t) => (
+                                <button
+                                  key={t.uid}
+                                  type="button"
+                                  onClick={() => insertTemplate(t)}
+                                  className="w-full text-left px-3 py-2 hover:bg-gray-50 border-b border-gray-100 last:border-b-0"
+                                >
+                                  <div className="text-xs font-semibold text-gray-800">{t.title}</div>
+                                  <div className="text-[11px] text-gray-500 truncate">{t.body}</div>
+                                </button>
+                              ))}
+                            </div>
+                          )}
+                        </div>
+                      )}
+
+                      {composerMode === 'reply' && (
+                        <>
+                          <button
+                            type="button"
+                            onClick={() => fileInputRef.current && fileInputRef.current.click()}
+                            className="text-xs px-2.5 py-1 rounded-lg border border-gray-300 text-gray-600 hover:bg-gray-50"
+                            title="Attach an image or video"
+                          >
+                            📎 Attach
+                          </button>
+                          <input
+                            ref={fileInputRef}
+                            type="file"
+                            accept="image/*,video/*"
+                            multiple
+                            className="hidden"
+                            onChange={onPickFiles}
+                          />
+                        </>
+                      )}
+
+                      {composerMode === 'note' && (
+                        <span className="text-[11px] text-amber-700">Team-only — not sent to the customer.</span>
+                      )}
+                    </div>
+
+                    <form onSubmit={submitComposer} className="p-3 flex items-end gap-2">
+                      <textarea
+                        value={draft}
+                        onChange={(e) => setDraft(e.target.value)}
+                        onKeyDown={(e) => {
+                          if (e.key === 'Enter' && !e.shiftKey) {
+                            e.preventDefault();
+                            submitComposer(e);
+                          }
+                        }}
+                        rows={1}
+                        placeholder={composerMode === 'note' ? 'Write an internal note…' : 'Type a reply…'}
+                        className={`flex-1 resize-none border rounded-lg px-3 py-2 text-sm focus:outline-none focus:ring-2 ${
+                          composerMode === 'note' ? 'border-amber-300 bg-amber-50 focus:ring-amber-400' : 'border-gray-300 focus:ring-blue-400'
+                        }`}
+                      />
+                      <button
+                        type="submit"
+                        disabled={sending || (composerMode === 'note' ? !draft.trim() : (!draft.trim() && attachments.length === 0))}
+                        className={`px-4 py-2 rounded-lg text-sm text-white disabled:opacity-50 ${
+                          composerMode === 'note' ? 'bg-amber-500 hover:bg-amber-600' : 'bg-blue-500 hover:bg-blue-600'
+                        }`}
+                      >
+                        {sending
+                          ? (composerMode === 'note' ? 'Adding…' : 'Sending…')
+                          : (composerMode === 'note' ? 'Add note' : 'Send')}
+                      </button>
+                    </form>
+                  </div>
                 </>
               )}
             </section>
@@ -997,6 +1252,32 @@ function Field({ label, value }) {
     <div className="flex gap-2 text-xs">
       <span className="text-gray-400 w-20 shrink-0">{label}</span>
       <span className="text-gray-700 break-words min-w-0">{value}</span>
+    </div>
+  );
+}
+
+// F12 — render a message's attachments (image thumbnails inline; video/file as chips).
+// In mock, image/video previews come from the sender's local object URLs; under live
+// Podium the message carries hosted media URLs (a live-wiring swap).
+function MessageAttachments({ attachments, outbound }) {
+  const list = Array.isArray(attachments) ? attachments : [];
+  if (list.length === 0) return null;
+  return (
+    <div className="mt-1.5 flex flex-wrap gap-2">
+      {list.map((a, i) => {
+        const key = `${i}-${a.filename || a.kind}`;
+        if (a.kind === 'image' && a.url) {
+          return <img key={key} src={a.url} alt={a.filename || 'attachment'} className="max-h-40 rounded-lg border border-black/10" />;
+        }
+        return (
+          <span
+            key={key}
+            className={`inline-flex items-center gap-1 text-xs px-2 py-1 rounded-lg ${outbound ? 'bg-blue-400/60 text-white' : 'bg-gray-100 text-gray-700'}`}
+          >
+            {a.kind === 'video' ? '🎬' : '📎'} {a.filename || a.kind}
+          </span>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
## F12 — Rich messaging (inbox composer)

From Nick's 6 Jul feedback. Richer inbox composer, **mock-first** (`PODIUM_MOCK=true` → `lib/podium.mock.js`, so it's fully reviewable on the Preview without live Podium credentials). **No migration. No new serverless function** (extends the `api/podium/[...podium].js` inbox dispatcher — stays `nodejs:3`). **P1 held** — no message/note bodies or attachment bytes are persisted in the portal DB; Podium is the system of record.

### What shipped
1. **Message templates** — a "Templates ▾" menu in the composer inserts a Podium canned response into the reply draft. `GET /api/podium/inbox?resource=templates` → `GET /v4/message_templates` (mock).
2. **Internal notes** — a Reply / Internal-note toggle. An internal note is team-only and **never sent to the customer**; it renders distinctly (amber). `POST /api/podium/inbox?resource=note` → `POST /v4/conversations/{uid}/notes` (mock appends to the thread so it's team-visible on reload).
3. **Attachments (images/videos)** — 📎 Attach picks image/video files (held as browser object URLs); previews in the composer and in the sent bubble. Only **metadata** (kind, filename, mimeType, size) is sent — never the bytes. A message needs a body **or** ≥1 attachment.

### VERIFY at live wiring
Podium's message-templates endpoint, the internal-note endpoint, and the **media-upload flow** (multipart → media UID) aren't pinned in execution-plan §15 — the mock models them; live wiring swaps in the real endpoints (and real media upload for attachments).

### Tests
- `scripts/podium-inbox-smoke.mjs` **+19 → 77/77** (templates, notes, attachment send + sanitisation).
- Regressions: podium 27, oauth 30, assign 20, webhook 72, contact 46, leads 28.
- `CI=true npm run build` green (`main.b83e8148.js`, +1.68 kB).

### Reviewer checklist
- [x] Templates menu inserts text; internal notes render distinctly and are clearly not customer-facing; attachments preview + send
- [x] `sales`/`superadmin` gating correct (server re-checks); no chat/note bodies persisted (P1); no migration; no new function; no secrets
- [x] Approve & merge, or leave feedback

🤖 Generated with [Claude Code](https://claude.com/claude-code)