### PR TITLE
F13: Multi-assignee + sender attribution

### DIFF
--- a/lib/podium.js
+++ b/lib/podium.js
@@ -436,15 +436,29 @@ export function postInternalNote(userId, { conversationUid, body, author } = {})
   });
 }
 
-/** GET /v4/conversations/{uid}/assignees */
+/**
+ * GET /v4/conversations/{uid}/assignees — the conversation's assignee(s). Returns
+ * `{ conversationUid, assignees:[{uid}], assignedUser }` (F13 multi-assignee; the
+ * endpoint is plural). `assignedUser` is the primary (first) assignee.
+ */
 export function getAssignee(userId, conversationUid, opts = {}) {
   return request(userId, 'GET', `conversations/${conversationUid}/assignees`, { client: opts.client });
 }
+export { getAssignee as getAssignees };
 
-/** PUT /v4/conversations/{uid}/assignees — drives native assignment (F1b). */
-export function assignConversation(userId, conversationUid, assigneeUid) {
+/**
+ * PUT /v4/conversations/{uid}/assignees — set the conversation's assignee(s). Drives
+ * native assignment (F1b single owner, F13 one-or-more). Accepts a single Podium member
+ * uid (string) or an array of uids; an empty array clears all assignees. Sends the array
+ * as `userUids` plus `userUid`=the primary for single-owner backward-compat.
+ * VERIFY the exact live Podium request body shape for multiple assignees at wiring.
+ */
+export function assignConversation(userId, conversationUid, assignees) {
+  const uids = (Array.isArray(assignees) ? assignees : [assignees])
+    .filter(Boolean)
+    .map(String);
   return request(userId, 'PUT', `conversations/${conversationUid}/assignees`, {
-    body: { userUid: assigneeUid },
+    body: { userUids: uids, userUid: uids[0] || null },
   });
 }
 

--- a/lib/podium.mock.js
+++ b/lib/podium.mock.js
@@ -50,15 +50,23 @@ const ORG_UID = () => process.env.PODIUM_ORG_UID || 'pod_org_GRAYS';
 //   Assigned-to-amELia: 00001 open, 00004 closed
 //   Unassigned:         00003 open, 00006 closed
 //   (00002/00005 belong to bENjin, and round out "All").
+//
+// F13 multi-assignee: a conversation may be assigned to ONE OR MORE reps via the
+// `assignees` array (Podium's `PUT /conversations/{uid}/assignees` is plural). When
+// present it is authoritative; `assignedUser` is kept as the PRIMARY (first) assignee
+// for backward-compat with the single-owner mirror (leads.assigned_to). Conversation
+// 00001 is assigned to two reps (Amelia + Ben) so the multi-assignee UI + the
+// who-sent-what attribution in its thread are reviewable out of the box.
 const CONVERSATIONS = [
   {
     uid: 'pod_cnv_00001',
     channel: { type: 'phone', identifier: '+61400111222' },
     contact: { uid: 'pod_con_maRIA1' }, // deprecated hint (see §15.6) — resolve via Contacts API
-    assignedUser: { uid: 'pod_usr_amELia' },
+    assignedUser: { uid: 'pod_usr_amELia' }, // primary (first) assignee
+    assignees: [{ uid: 'pod_usr_amELia' }, { uid: 'pod_usr_bENjin' }], // F13: two reps
     status: 'open',
     location: { uid: LOCATION_UID(), organizationUid: ORG_UID() },
-    lastMessageAt: '2026-07-03T09:15:00+10:00',
+    lastMessageAt: '2026-07-03T09:18:00+10:00',
   },
   {
     uid: 'pod_cnv_00002',
@@ -108,22 +116,28 @@ const CONVERSATIONS = [
 ];
 
 // Messages keyed by conversation uid (oldest → newest). `body` present (see P1 note).
+// F13 sender attribution: OUTBOUND messages carry a `senderUser` ({uid,name}) = the rep
+// who sent them, so a multi-rep thread can label who-sent-what. `name` is denormalised
+// here for the mock; under live Podium the message carries the sender's user uid and the
+// UI resolves the name via GET /v4/users (a live-wiring detail — VERIFY the exact field).
+// Conversation 00001 is a genuine two-rep thread (Amelia + Ben both reply).
 const MESSAGES = {
   pod_cnv_00001: [
     { uid: 'pod_msg_0001a', direction: 'inbound', channel: 'phone', body: 'Hi, is the 20kg adjustable dumbbell set back in stock?', createdAt: '2026-07-03T09:10:00+10:00' },
-    { uid: 'pod_msg_0001b', direction: 'outbound', channel: 'phone', body: 'Hi Maria! Yes, we just restocked — want me to hold a set for you?', createdAt: '2026-07-03T09:12:00+10:00' },
+    { uid: 'pod_msg_0001b', direction: 'outbound', channel: 'phone', senderUser: { uid: 'pod_usr_amELia', name: 'Amelia Reid' }, body: 'Hi Maria! Yes, we just restocked — want me to hold a set for you?', createdAt: '2026-07-03T09:12:00+10:00' },
     { uid: 'pod_msg_0001c', direction: 'inbound', channel: 'phone', body: 'Yes please, and can you do delivery to Brunswick?', createdAt: '2026-07-03T09:15:00+10:00' },
+    { uid: 'pod_msg_0001d', direction: 'outbound', channel: 'phone', senderUser: { uid: 'pod_usr_bENjin', name: 'Ben Jindra' }, body: 'Hi Maria, Ben here — I can confirm a Brunswick delivery slot for Thursday. Amelia has your dumbbells on hold.', createdAt: '2026-07-03T09:18:00+10:00' },
   ],
   pod_cnv_00002: [
     { uid: 'pod_msg_0002a', direction: 'inbound', channel: 'facebook', body: 'Do you price match on the rowing machine?', createdAt: '2026-07-02T16:38:00+10:00' },
-    { uid: 'pod_msg_0002b', direction: 'outbound', channel: 'facebook', body: 'We can usually get close — send me the competitor link?', createdAt: '2026-07-02T16:40:00+10:00' },
+    { uid: 'pod_msg_0002b', direction: 'outbound', channel: 'facebook', senderUser: { uid: 'pod_usr_bENjin', name: 'Ben Jindra' }, body: 'We can usually get close — send me the competitor link?', createdAt: '2026-07-02T16:40:00+10:00' },
   ],
   pod_cnv_00003: [
     { uid: 'pod_msg_0003a', direction: 'inbound', channel: 'phone', body: 'What are your warehouse pickup hours on Saturday?', createdAt: '2026-07-03T08:02:00+10:00' },
   ],
   pod_cnv_00004: [
     { uid: 'pod_msg_0004a', direction: 'inbound', channel: 'instagram', body: 'Love the new squat racks 😍 do they come assembled?', createdAt: '2026-07-01T11:18:00+10:00' },
-    { uid: 'pod_msg_0004b', direction: 'outbound', channel: 'instagram', body: 'Thank you! They ship flat-packed but assembly is straightforward.', createdAt: '2026-07-01T11:20:00+10:00' },
+    { uid: 'pod_msg_0004b', direction: 'outbound', channel: 'instagram', senderUser: { uid: 'pod_usr_amELia', name: 'Amelia Reid' }, body: 'Thank you! They ship flat-packed but assembly is straightforward.', createdAt: '2026-07-01T11:20:00+10:00' },
   ],
   pod_cnv_00005: [
     { uid: 'pod_msg_0005a', direction: 'inbound', channel: 'google', body: 'Can I get a quote for a full home gym setup?', createdAt: '2026-07-03T07:45:00+10:00' },
@@ -195,6 +209,26 @@ function stripV4(path) {
   return String(path || '').replace(/^\/?v4\//, '').replace(/^\//, '');
 }
 
+// F13: the effective assignee uid set for a conversation. Prefers the `assignees`
+// array (multi-assignee); falls back to the single `assignedUser` for fixtures that
+// carry only the legacy field. Deduped, empty when unassigned.
+function assigneeUidList(conv) {
+  const uids = Array.isArray(conv?.assignees) && conv.assignees.length
+    ? conv.assignees.map((a) => a?.uid)
+    : (conv?.assignedUser?.uid ? [conv.assignedUser.uid] : []);
+  return [...new Set(uids.filter(Boolean).map(String))];
+}
+
+// Normalise a PUT /assignees body into a deduped uid array. Accepts the F13 array form
+// (`userUids` / `assigneeUids`) and the legacy single form (`userUid` / `assigneeUid` /
+// `uid`), so both single- and multi-assignee callers work.
+function normalizeAssigneeUids(body = {}) {
+  const raw = Array.isArray(body.userUids) ? body.userUids
+    : Array.isArray(body.assigneeUids) ? body.assigneeUids
+      : [body.userUid || body.assigneeUid || body.uid].filter(Boolean);
+  return [...new Set(raw.filter(Boolean).map(String))];
+}
+
 /**
  * Route a mock request. Returns a plain object shaped like the live API.
  * @param {string} method  GET|POST|PUT|PATCH|DELETE
@@ -236,10 +270,12 @@ export function handle(method, path, opts = {}) {
       // F11 buckets: `unassigned=true` (no assignee) wins; else `assigneeUid` (mine);
       // else all. `status=open|closed` narrows either. VERIFY the live Podium param
       // names for the unassigned + status filters at live wiring (§15.5 note).
+      // F13: "mine" and "unassigned" test the full assignee SET (a conversation shared
+      // by two reps appears in BOTH reps' "Assigned to You" buckets).
       if (query.unassigned === 'true' || query.unassigned === true) {
-        items = items.filter((c) => !c.assignedUser?.uid);
+        items = items.filter((c) => assigneeUidList(c).length === 0);
       } else if (query.assigneeUid) {
-        items = items.filter((c) => c.assignedUser?.uid === query.assigneeUid);
+        items = items.filter((c) => assigneeUidList(c).includes(query.assigneeUid));
       }
       if (query.status === 'open' || query.status === 'closed') {
         items = items.filter((c) => (c.status || 'open') === query.status);
@@ -271,14 +307,25 @@ export function handle(method, path, opts = {}) {
       (MESSAGES[convUid] || (MESSAGES[convUid] = [])).push(note);
       return note;
     }
-    // GET|PUT /conversations/{uid}/assignees
+    // GET|PUT /conversations/{uid}/assignees — F13 multi-assignee (Podium's endpoint is
+    // plural). PUT replaces the whole assignee SET; `assignedUser` tracks the primary
+    // (first). The fixture is mutated so the change persists for the Preview demo (a
+    // reassignment shows up on reload/poll within this serverless instance).
     if (segs[2] === 'assignees') {
       if (!conv) return notFound('conversation', convUid);
       if (m === 'PUT') {
-        const assigneeUid = body.userUid || body.assigneeUid || body.uid || null;
-        return { conversationUid: convUid, assignedUser: assigneeUid ? { uid: assigneeUid } : null };
+        const uids = normalizeAssigneeUids(body);
+        const assignees = uids.map((uid) => ({ uid }));
+        const primary = assignees[0] || null;
+        const idx = CONVERSATIONS.findIndex((c) => c.uid === convUid);
+        if (idx !== -1) {
+          CONVERSATIONS[idx].assignees = assignees;
+          CONVERSATIONS[idx].assignedUser = primary;
+        }
+        return { conversationUid: convUid, assignees, assignedUser: primary };
       }
-      return { conversationUid: convUid, assignedUser: conv.assignedUser || null };
+      const assignees = assigneeUidList(conv).map((uid) => ({ uid }));
+      return { conversationUid: convUid, assignees, assignedUser: conv.assignedUser || assignees[0] || null };
     }
     // GET|PATCH /conversations/{uid}
     if (!conv) return notFound('conversation', convUid);

--- a/lib/podiumAssign.js
+++ b/lib/podiumAssign.js
@@ -25,6 +25,56 @@
 import { getUsers } from './podium.js';
 
 /**
+ * Resolve a set of Podium member uids into display-ready assignees for the inbox
+ * (F13 multi-assignee). For each uid: match it to a portal user (users.podium_user_id)
+ * for the portal id + name; if unmatched, fall back to the Podium member's name (via
+ * GET /v4/users AS the acting rep) so a Podium-only member still shows a name, not a uid.
+ *
+ * @param {object} client        pg client (caller owns the connection)
+ * @param {string} actingUserId  portal id whose token lists Podium members (for the name fallback)
+ * @param {string[]} podiumUids  the conversation's assignee uids
+ * @returns {Promise<Array<{podiumUserId:string, portalId:string|null, name:string|null, linked:boolean}>>}
+ */
+export async function resolveAssignees(client, actingUserId, podiumUids) {
+  const uids = [...new Set((podiumUids || []).filter(Boolean).map(String))];
+  if (uids.length === 0) return [];
+
+  // Portal users linked to these Podium members.
+  let portalRows = [];
+  try {
+    const r = await client.query(
+      'SELECT id, name, podium_user_id FROM users WHERE podium_user_id = ANY($1)',
+      [uids]
+    );
+    portalRows = r.rows || [];
+  } catch (err) {
+    if (err?.code !== '42P01') throw err; // users table always exists; be defensive anyway
+  }
+  const byPodiumUid = new Map(portalRows.map((u) => [u.podium_user_id, u]));
+
+  // Names for any uid without a matched portal user (Podium-only members).
+  const unresolved = uids.filter((u) => !byPodiumUid.has(u));
+  const memberName = new Map();
+  if (unresolved.length) {
+    try {
+      const resp = await getUsers(actingUserId, { limit: 100, client });
+      for (const m of (Array.isArray(resp?.data) ? resp.data : [])) {
+        if (m?.uid) memberName.set(m.uid, m.name || null);
+      }
+    } catch {
+      /* name fallback is best-effort — a uid with no name still returns below */
+    }
+  }
+
+  return uids.map((uid) => {
+    const u = byPodiumUid.get(uid);
+    return u
+      ? { podiumUserId: uid, portalId: u.id, name: u.name || null, linked: true }
+      : { podiumUserId: uid, portalId: null, name: memberName.get(uid) || null, linked: false };
+  });
+}
+
+/**
  * Resolve a portal user's Podium member uid (users.podium_user_id).
  *
  * Fast path: return the stored id if the user already linked their account
@@ -97,4 +147,4 @@ export async function mirrorAssignmentToLead(client, conversationUid, portalUser
   }
 }
 
-export default { resolvePodiumUserId, mirrorAssignmentToLead };
+export default { resolvePodiumUserId, mirrorAssignmentToLead, resolveAssignees };

--- a/lib/podiumRoutes/assign.js
+++ b/lib/podiumRoutes/assign.js
@@ -5,22 +5,24 @@
 // (NOT the api/[...path].js catch-all), gated to sales/superadmin via the login JWT.
 //
 //   GET  /api/podium/assign?conversationId=<uid>
-//        → read the conversation's current Podium assignee.
-//   POST /api/podium/assign  { conversationId, userId? }
-//        → assign the conversation. Omit userId to CLAIM it for yourself. The call to
-//          Podium runs on the ACTING rep's token; the assignee is the TARGET user's
-//          Podium member uid. The owner is also mirrored onto the matching lead.
+//        → read the conversation's current Podium assignee(s), resolved to portal reps.
+//   POST /api/podium/assign  { conversationId, userIds?[], userId? }
+//        → set the conversation's assignee SET (F13 one-or-more). `userIds` is the whole
+//          new set of portal ids; `userId` (single) and omitting both (CLAIM = just you)
+//          are still honoured. The call to Podium runs on the ACTING rep's token; each
+//          target is resolved to its Podium member uid. The PRIMARY (first) owner is
+//          mirrored onto the matching lead (leads.assigned_to is a single column).
 //
 // Mock-first (Golden Rule 6): with PODIUM_MOCK=true the Podium hop is served by
 // lib/podium.mock.js, so the flow is reviewable on the Preview without live creds.
 // The Podium → portal direction (assignment webhook → leads.assigned_to) lands with
 // F2's webhook receiver and reuses mirrorAssignmentToLead() from lib/podiumAssign.js.
 //
-// P1: no message bodies are read or written here — only CRM metadata (the assignee).
+// P1: no message bodies are read or written here — only CRM metadata (the assignees).
 
 import { getAuthUser, hasAnyRole } from '../rbac.js';
 import { assignConversation, getAssignee, isMock } from '../podium.js';
-import { resolvePodiumUserId, mirrorAssignmentToLead } from '../podiumAssign.js';
+import { resolvePodiumUserId, mirrorAssignmentToLead, resolveAssignees } from '../podiumAssign.js';
 import { getClientWithTimezone } from '../db.js';
 
 // P11: working the inbox / owning conversations is a `sales` action; superadmin may
@@ -42,56 +44,88 @@ export default async function handler(req, res) {
 async function handleGet(req, res, auth) {
   const conversationId = req.query?.conversationId;
   if (!conversationId) return res.status(400).json({ error: 'conversationId is required' });
+  const client = await getClientWithTimezone();
   try {
     const a = await getAssignee(auth.id, String(conversationId));
+    const podiumUids = (
+      Array.isArray(a?.assignees) && a.assignees.length
+        ? a.assignees.map((x) => x?.uid)
+        : (a?.assignedUser?.uid ? [a.assignedUser.uid] : [])
+    ).filter(Boolean);
+    // Resolve to portal reps (with a Podium-member name fallback) for the inbox chips.
+    const assignees = await resolveAssignees(client, auth.id, podiumUids);
     return res.status(200).json({
       conversationId: String(conversationId),
-      assignedPodiumUserId: a?.assignedUser?.uid || null,
+      assignees,
+      assignedPodiumUserId: a?.assignedUser?.uid || podiumUids[0] || null,
       mock: isMock(),
     });
   } catch (err) {
-    return respondUpstreamError(res, err, 'read the conversation assignee');
+    return respondUpstreamError(res, err, 'read the conversation assignees');
+  } finally {
+    client.release();
   }
 }
 
 async function handlePost(req, res, auth) {
-  const { conversationId, userId } = req.body || {};
+  const { conversationId, userId, userIds } = req.body || {};
   if (!conversationId) return res.status(400).json({ error: 'conversationId is required' });
 
-  // Default action = claim: assign the conversation to the acting rep.
-  const targetPortalId = userId ? String(userId) : auth.id;
+  // Determine the target portal-id SET (F13 one-or-more):
+  //   • userIds (array) — the whole new assignee set (may be [] to clear all)
+  //   • userId (single)  — set to just that rep
+  //   • neither          — CLAIM: assign to the acting rep
+  let targetIds;
+  let claim = false;
+  if (Array.isArray(userIds)) {
+    targetIds = [...new Set(userIds.map((x) => String(x)).filter(Boolean))];
+  } else if (userId) {
+    targetIds = [String(userId)];
+  } else {
+    targetIds = [auth.id];
+    claim = true;
+  }
 
   const client = await getClientWithTimezone();
   try {
-    const ur = await client.query(
-      'SELECT id, email, podium_user_id FROM users WHERE id = $1 LIMIT 1',
-      [targetPortalId]
-    );
-    if (!ur.rowCount) return res.status(404).json({ error: `Target user ${targetPortalId} not found` });
-    const targetUser = ur.rows[0];
-
-    // Turn the target portal user into their Podium member uid (lazily resolving via
-    // GET /v4/users if it wasn't captured at connect). Runs on the ACTING rep's token.
-    const podiumUserId = await resolvePodiumUserId(client, auth.id, targetUser);
-    if (!podiumUserId) {
-      return res.status(409).json({
-        error: `${targetPortalId === auth.id ? 'You have' : `User ${targetPortalId} has`} not linked a Podium account`,
-        code: 'TARGET_NOT_LINKED',
-      });
+    // Resolve each target portal user to their Podium member uid. Fail closed if any
+    // hasn't linked a Podium account (assignment must reflect a real Podium member).
+    const podiumUids = [];
+    const resolvedPortalIds = [];
+    for (const pid of targetIds) {
+      const ur = await client.query(
+        'SELECT id, email, podium_user_id FROM users WHERE id = $1 LIMIT 1',
+        [pid]
+      );
+      if (!ur.rowCount) return res.status(404).json({ error: `Target user ${pid} not found` });
+      const podiumUserId = await resolvePodiumUserId(client, auth.id, ur.rows[0]);
+      if (!podiumUserId) {
+        return res.status(409).json({
+          error: `${pid === auth.id ? 'You have' : `User ${pid} has`} not linked a Podium account`,
+          code: 'TARGET_NOT_LINKED',
+          userId: pid,
+        });
+      }
+      podiumUids.push(podiumUserId);
+      resolvedPortalIds.push(pid);
     }
 
-    // Drive Podium's native assignment AS the acting rep (their OAuth token).
-    await assignConversation(auth.id, String(conversationId), podiumUserId);
+    // Drive Podium's native assignment AS the acting rep (their OAuth token). An empty
+    // set clears all assignees.
+    await assignConversation(auth.id, String(conversationId), podiumUids);
 
-    // Mirror the owner onto the lead (durable portal side). 0 rows until F2/F5 create
-    // leads — the seam is wired now; the same helper serves F2's inbound webhook.
-    const leadsUpdated = await mirrorAssignmentToLead(client, String(conversationId), targetPortalId);
+    // Mirror the PRIMARY (first) owner onto the lead — leads.assigned_to is single-owner;
+    // the full multi-assignee set lives in Podium (system of record). 0 rows until
+    // F2/F5 create leads. (A durable lead_assignees mirror is a possible follow-up.)
+    const primary = resolvedPortalIds[0] || null;
+    const leadsUpdated = await mirrorAssignmentToLead(client, String(conversationId), primary);
 
     return res.status(200).json({
       conversationId: String(conversationId),
-      assignedTo: targetPortalId,
-      assignedPodiumUserId: podiumUserId,
-      claimed: targetPortalId === auth.id,
+      assignedTo: resolvedPortalIds,
+      primaryAssignedTo: primary,
+      assignedPodiumUserIds: podiumUids,
+      claimed: claim,
       leadsUpdated,
       mock: isMock(),
     });

--- a/lib/podiumRoutes/inbox.js
+++ b/lib/podiumRoutes/inbox.js
@@ -85,7 +85,51 @@ export default async function handler(req, res) {
     if (method !== 'GET') return res.status(405).json({ error: 'Method not allowed' });
     return getConversationRoute(req, res, auth);
   }
+  if (resource === 'reps') {
+    if (method !== 'GET') return res.status(405).json({ error: 'Method not allowed' });
+    return repsRoute(req, res, auth);
+  }
   return res.status(400).json({ error: 'Unknown inbox resource', resource: resource || null });
+}
+
+// GET ?resource=reps — assignable salespeople for the F13 assignment picker: portal users
+// holding the `sales` or `superadmin` role (via F0b's user_roles, falling back to
+// users.access). `linked` = has a Podium member uid, so the UI can flag reps who must
+// connect their Podium account before they can be assigned. No message data (P1).
+async function repsRoute(req, res, auth) {
+  const client = await getClientWithTimezone();
+  try {
+    let rows;
+    try {
+      const r = await client.query(
+        `SELECT DISTINCT u.id, u.name, u.podium_user_id
+           FROM users u
+           LEFT JOIN user_roles ur ON ur.user_id = u.id
+          WHERE ur.role IN ('sales', 'superadmin')
+             OR u.access::text IN ('sales', 'superadmin')
+          ORDER BY u.name`
+      );
+      rows = r.rows;
+    } catch (err) {
+      if (err?.code !== '42P01') throw err; // user_roles absent (pre-F0 DB) → access only
+      const r = await client.query(
+        `SELECT id, name, podium_user_id FROM users
+          WHERE access::text IN ('sales', 'superadmin') ORDER BY name`
+      );
+      rows = r.rows;
+    }
+    const reps = (rows || []).map((u) => ({
+      id: u.id,
+      name: u.name || u.id,
+      podiumUserId: u.podium_user_id || null,
+      linked: !!u.podium_user_id,
+    }));
+    return res.status(200).json({ reps, mock: isMock() });
+  } catch (err) {
+    return respondUpstreamError(res, err, 'list assignable reps');
+  } finally {
+    client.release();
+  }
 }
 
 // GET ?resource=conversation&conversationId=<uid> — fetch a single conversation so the

--- a/scripts/podium-assign-smoke.mjs
+++ b/scripts/podium-assign-smoke.mjs
@@ -18,7 +18,7 @@ process.env.JWT_SECRET = process.env.JWT_SECRET || 'smoke_secret';
 process.env.PODIUM_API_VERSION = process.env.PODIUM_API_VERSION || '2021-04-01';
 
 const jwt = (await import('jsonwebtoken')).default;
-const { resolvePodiumUserId, mirrorAssignmentToLead } = await import('../lib/podiumAssign.js');
+const { resolvePodiumUserId, mirrorAssignmentToLead, resolveAssignees } = await import('../lib/podiumAssign.js');
 const { assignConversation, getAssignee } = await import('../lib/podium.js');
 const assignHandler = (await import('../lib/podiumRoutes/assign.js')).default;
 
@@ -133,10 +133,32 @@ console.log('Podium assignment (F1b) smoke (PODIUM_MOCK=true)\n');
   check('assignConversation: mock echoes conversation', r?.conversationUid === 'pod_cnv_00003');
 }
 
-// 10. getAssignee (mock) — reads the fixture assignee
+// 10. getAssignee (mock) — reads the fixture assignee(s)
 {
   const r = await getAssignee('AM', 'pod_cnv_00001');
-  check('getAssignee: mock returns fixture assignee', r?.assignedUser?.uid === 'pod_usr_amELia');
+  check('getAssignee: mock returns primary assignee', r?.assignedUser?.uid === 'pod_usr_amELia');
+  // F13: 00001 is a shared conversation — the plural list carries both reps.
+  check('getAssignee: returns the full assignees list', Array.isArray(r?.assignees) && r.assignees.map((a) => a.uid).includes('pod_usr_bENjin'));
+}
+
+// 10b. F13 — assignConversation accepts an array (multi-assignee) and clears with []
+{
+  const set = await assignConversation('AM', 'pod_cnv_00002', ['pod_usr_amELia', 'pod_usr_bENjin']);
+  check('assignConversation: array sets a two-rep assignee list', Array.isArray(set.assignees) && set.assignees.length === 2);
+  check('assignConversation: primary = first of the array', set.assignedUser?.uid === 'pod_usr_amELia');
+  const cleared = await assignConversation('AM', 'pod_cnv_00002', []);
+  check('assignConversation: empty array clears all assignees', Array.isArray(cleared.assignees) && cleared.assignees.length === 0 && cleared.assignedUser === null);
+}
+
+// 10c. F13 — resolveAssignees maps podium uids → portal reps, with a member-name fallback
+{
+  const client = makeClient([{ match: (s) => /SELECT .*FROM users/i.test(s), result: { rows: [{ id: 'AM', name: 'Amelia R', podium_user_id: 'pod_usr_amELia' }] } }]);
+  const resolved = await resolveAssignees(client, 'AM', ['pod_usr_amELia', 'pod_usr_bENjin']);
+  const am = resolved.find((a) => a.podiumUserId === 'pod_usr_amELia');
+  const bn = resolved.find((a) => a.podiumUserId === 'pod_usr_bENjin');
+  check('resolveAssignees: matched uid → portal id + linked', am?.portalId === 'AM' && am?.linked === true);
+  check('resolveAssignees: unmatched uid → Podium member name, not linked', bn?.name === 'Ben Jindra' && bn?.linked === false && bn?.portalId === null);
+  check('resolveAssignees: empty input → []', (await resolveAssignees(client, 'AM', [])).length === 0);
 }
 
 // 11. endpoint gates (all reached BEFORE any DB access → offline-safe)

--- a/scripts/podium-inbox-smoke.mjs
+++ b/scripts/podium-inbox-smoke.mjs
@@ -197,8 +197,12 @@ console.log('\ninbox resource=messages:');
 {
   const res = makeRes();
   await inboxHandler(makeReq({ method: 'GET', query: { resource: 'messages', conversationId: 'pod_cnv_00001' } }), res);
-  check('messages GET: 200 returns the live thread', res.statusCode === 200 && Array.isArray(res.body.data) && res.body.data.length === 3, `status ${res.statusCode}`);
+  check('messages GET: 200 returns the live thread', res.statusCode === 200 && Array.isArray(res.body.data) && res.body.data.length === 4, `status ${res.statusCode}`);
   check('messages GET: mock flag surfaced', res.body.mock === true);
+  // F13 sender attribution: outbound messages carry senderUser; 00001 is a two-rep thread.
+  const outs = res.body.data.filter((m) => m.direction === 'outbound');
+  check('messages GET: outbound messages carry a senderUser', outs.every((m) => m.senderUser?.uid));
+  check('messages GET: two distinct outbound senders (multi-rep)', new Set(outs.map((m) => m.senderUser.uid)).size === 2);
 }
 {
   const res = makeRes();
@@ -368,6 +372,32 @@ console.log('\nF12 resource=messages with attachments:');
   check('messages POST: bad kind sanitised to file', res.body.sent?.attachments?.[0].kind === 'file');
   check('messages POST: long filename clamped to 200 chars', (res.body.sent?.attachments?.[0].filename || '').length === 200);
   check('messages POST: templateId echoed', res.body.sent?.templateId === 'pod_tpl_deliv');
+}
+
+// ---- F13 multi-assignee: mine-filter membership + reps route gates ------------
+console.log('\nF13 multi-assignee:');
+{
+  // 00001 is assigned to Amelia AND Ben → it appears in BOTH reps' "mine" buckets.
+  const amMine = await listConversations('AM', { assigneeUid: 'pod_usr_amELia' });
+  const bnMine = await listConversations('AM', { assigneeUid: 'pod_usr_bENjin' });
+  check('mine: 00001 (shared) appears for Amelia', amMine.data.some((c) => c.uid === 'pod_cnv_00001'));
+  check('mine: 00001 (shared) also appears for Ben', bnMine.data.some((c) => c.uid === 'pod_cnv_00001'));
+  check('mine: Ben also owns his own convos (00002/00005)', bnMine.data.some((c) => c.uid === 'pod_cnv_00002'));
+}
+{
+  const res = makeRes();
+  await inboxHandler(makeReq({ method: 'POST', query: { resource: 'reps' } }), res);
+  check('reps: 405 for POST', res.statusCode === 405);
+}
+{
+  const res = makeRes();
+  await inboxHandler(makeReq({ noAuth: true, query: { resource: 'reps' } }), res);
+  check('reps: 401 without auth', res.statusCode === 401);
+}
+{
+  const res = makeRes();
+  await inboxHandler(makeReq({ roles: ['technician'], query: { resource: 'reps' } }), res);
+  check('reps: 403 for a non-sales role', res.statusCode === 403);
 }
 
 console.log(`\n✅ inbox smoke: ${passed} checks passed`);

--- a/scripts/podium-smoke.mjs
+++ b/scripts/podium-smoke.mjs
@@ -72,16 +72,25 @@ check('assignee filter returns only Amelia’s convos', mine.data.length === 2 &
 
 // 8. messages (live-only; never persisted — P1)
 const msgs = await podium.listMessages(REP, 'pod_cnv_00001');
-check('listMessages returns the thread', msgs.data.length === 3);
+check('listMessages returns the thread', msgs.data.length === 4); // F13: Amelia + Ben both reply
 check('messages carry a body for live render only', typeof msgs.data[0].body === 'string');
+// F13 sender attribution: outbound messages carry a senderUser; 00001 has two distinct senders.
+const outboundSenders = new Set(msgs.data.filter((m) => m.direction === 'outbound' && m.senderUser?.uid).map((m) => m.senderUser.uid));
+check('messages: multi-rep thread has ≥2 distinct outbound senders', outboundSenders.size === 2, `got ${outboundSenders.size}`);
 
 // 9. send message
 const sent = await podium.sendMessage(REP, { conversationUid: 'pod_cnv_00001', body: 'On its way!' });
 check('sendMessage returns sent status', sent.status === 'sent' && sent.direction === 'outbound');
 
-// 10. assignment (F1b)
+// 10. assignment (F1b single + F13 multi)
 const assigned = await podium.assignConversation(REP, 'pod_cnv_00003', 'pod_usr_amELia');
 check('assignConversation sets the assignee', assigned.assignedUser?.uid === 'pod_usr_amELia');
+// F13: multi-assignee — assign a set of two, then read the plural assignees list back.
+const multi = await podium.assignConversation(REP, 'pod_cnv_00003', ['pod_usr_amELia', 'pod_usr_bENjin']);
+check('assignConversation accepts an array (multi-assignee)', Array.isArray(multi.assignees) && multi.assignees.length === 2);
+check('assignConversation primary = first of the set', multi.assignedUser?.uid === 'pod_usr_amELia');
+const readBack = await podium.getAssignee(REP, 'pod_cnv_00003');
+check('getAssignee returns the full assignees list', Array.isArray(readBack.assignees) && readBack.assignees.map((a) => a.uid).includes('pod_usr_bENjin'));
 
 // 11. users + contact + review invite
 const users = await podium.getUsers(REP);

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -166,6 +166,13 @@ export default function Inbox() {
   const [woLoading, setWoLoading] = useState(false);
   const [woOpenId, setWoOpenId] = useState(null);
 
+  // F13 — multi-assignee: assignable reps, the selected conversation's resolved
+  // assignee set, and the assignment picker.
+  const [reps, setReps] = useState([]);
+  const [assignees, setAssignees] = useState([]); // [{podiumUserId, portalId, name, linked}]
+  const [showAssign, setShowAssign] = useState(false);
+  const [assignSaving, setAssignSaving] = useState(false);
+
   // Feedback (8 Jul): open/close a conversation + add a conversation to the funnel.
   const [statusSaving, setStatusSaving] = useState(false);
   const [addingLead, setAddingLead] = useState(false);
@@ -272,6 +279,23 @@ export default function Inbox() {
     }
   }, [navigate]);
 
+  // F13 — load the selected conversation's assignee set (resolved to portal reps, with
+  // a Podium-member name fallback) for the header chips + the assignment picker.
+  const loadAssignees = useCallback(async (convId) => {
+    if (!convId) { setAssignees([]); return; }
+    try {
+      const res = await fetch(
+        `/api/podium/assign?conversationId=${encodeURIComponent(convId)}`,
+        { headers: authHeaders() },
+      );
+      if (!res.ok) { setAssignees([]); return; }
+      const data = await parseMaybeJson(res);
+      setAssignees(Array.isArray(data?.assignees) ? data.assignees : []);
+    } catch {
+      setAssignees([]);
+    }
+  }, []);
+
   // Funnel stage history (timeline) for the panel's lead — when/if there is one.
   const loadLeadHistory = useCallback(async (leadId) => {
     if (!leadId) { setLeadHistory([]); return; }
@@ -304,6 +328,15 @@ export default function Inbox() {
       .catch(() => { /* templates are best-effort */ });
   }, [authorized]);
 
+  // F13 — fetch the assignable reps once (sales/superadmin portal users) for the picker.
+  useEffect(() => {
+    if (!authorized) return;
+    fetch('/api/podium/inbox?resource=reps', { headers: authHeaders() })
+      .then((r) => (r.ok ? parseMaybeJson(r) : null))
+      .then((d) => { if (Array.isArray(d?.reps)) setReps(d.reps); })
+      .catch(() => { /* reps list is best-effort */ });
+  }, [authorized]);
+
   // F12 — keep the latest attachments in a ref and revoke their object URLs on unmount
   // (avoids leaking blob: URLs). Per-item revokes happen in removeAttachment/clearAttachments.
   useEffect(() => { attachmentsRef.current = attachments; }, [attachments]);
@@ -330,10 +363,11 @@ export default function Inbox() {
           setSelectedConv(data.conversation);
           loadThread(convId);
           loadPanel(convId);
+          loadAssignees(convId);
         }
       } catch { /* deep-link is best-effort */ }
     })();
-  }, [authorized, navigate, loadThread, loadPanel]);
+  }, [authorized, navigate, loadThread, loadPanel, loadAssignees]);
 
   // ---- Poll: refresh the list (and the open thread) for new activity -------------
   const pollNow = useCallback(async () => {
@@ -455,6 +489,8 @@ export default function Inbox() {
     setWoOpenId(null);
     setWoDetail(null);
     setLeadHistory([]);
+    setAssignees([]);
+    setShowAssign(false);
     setComposerMode('reply');
     setShowTemplates(false);
     setDraft('');
@@ -480,6 +516,7 @@ export default function Inbox() {
     setSelectedConv(c);
     loadThread(c.uid);
     loadPanel(c.uid);
+    loadAssignees(c.uid);
   };
 
   // Feedback (8 Jul): a salesperson opens/closes the selected conversation. It then
@@ -543,6 +580,42 @@ export default function Inbox() {
       toast.error('Server error adding to the funnel');
     } finally {
       setAddingLead(false);
+    }
+  };
+
+  // F13 — add or remove a rep from the conversation's assignee set. The picker works in
+  // portal-user space: it sends the whole new set of portal ids to POST /api/podium/assign,
+  // which resolves each to a Podium member and replaces the assignees (Podium is the
+  // system of record). Reps who haven't linked their Podium account come back as a 409.
+  const toggleAssignee = async (rep) => {
+    if (!selectedId || assignSaving || !rep?.id) return;
+    const has = assignees.some((a) => a.portalId === rep.id);
+    // Rebuild the set from the currently-resolved portal ids (Podium-only members that
+    // don't map to a portal user can't be re-sent through the portal picker).
+    const currentPortalIds = assignees.map((a) => a.portalId).filter(Boolean);
+    const nextIds = has
+      ? currentPortalIds.filter((id) => id !== rep.id)
+      : [...new Set([...currentPortalIds, rep.id])];
+    setAssignSaving(true);
+    try {
+      const res = await fetch('/api/podium/assign', {
+        method: 'POST',
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({ conversationId: selectedId, userIds: nextIds }),
+      });
+      if (res.status === 401) { navigate('/'); return; }
+      const data = await parseMaybeJson(res);
+      if (!res.ok) {
+        toast.error(data?.error || 'Could not update the assignees');
+        return;
+      }
+      toast.success(has ? `Removed ${rep.name}` : `Assigned ${rep.name}`);
+      loadAssignees(selectedId);
+      loadConversations({ silent: true }); // the row may move in/out of "Assigned to You"
+    } catch {
+      toast.error('Server error updating the assignees');
+    } finally {
+      setAssignSaving(false);
     }
   };
 
@@ -672,16 +745,46 @@ export default function Inbox() {
   // ---- Render --------------------------------------------------------------------
   if (!authorized) return null;
 
+  // F13: a conversation may have one OR MORE assignees. Prefer the `assignees` set, fall
+  // back to the single `assignedUser`. Show "You" when the logged-in rep is one of them.
+  const conversationAssigneeUids = (c) => (
+    Array.isArray(c?.assignees) && c.assignees.length
+      ? c.assignees.map((a) => a?.uid)
+      : (c?.assignedUser?.uid ? [c.assignedUser.uid] : [])
+  ).filter(Boolean);
+
   const assigneeLabel = (c) => {
-    const uid = c?.assignedUser?.uid;
-    if (!uid) return { text: 'Unassigned', cls: 'text-gray-400' };
-    if (myPodiumUid && uid === myPodiumUid) return { text: 'You', cls: 'text-green-700' };
-    return { text: 'Assigned', cls: 'text-gray-500' };
+    const uids = conversationAssigneeUids(c);
+    if (uids.length === 0) return { text: 'Unassigned', cls: 'text-gray-400' };
+    const mine = myPodiumUid && uids.includes(myPodiumUid);
+    if (uids.length === 1) {
+      return mine ? { text: 'You', cls: 'text-green-700' } : { text: 'Assigned', cls: 'text-gray-500' };
+    }
+    return mine
+      ? { text: `You +${uids.length - 1}`, cls: 'text-green-700' }
+      : { text: `${uids.length} assignees`, cls: 'text-gray-500' };
   };
 
   // Prefer the resolved customer/contact name in the thread header once the panel loads.
   const headerTitle =
     panel?.customer?.name || panel?.contact?.name || convTitle(selectedConv);
+
+  // F13 sender attribution — in a MULTI-REP thread (≥2 distinct outbound senders), label
+  // who sent each outbound message. Names come from the message's senderUser (mock) or,
+  // as a fallback, the reps/assignees maps keyed by Podium member uid.
+  const nameByPodiumUid = new Map();
+  reps.forEach((r) => { if (r.podiumUserId) nameByPodiumUid.set(r.podiumUserId, r.name); });
+  assignees.forEach((a) => { if (a.podiumUserId && a.name) nameByPodiumUid.set(a.podiumUserId, a.name); });
+  const outboundSenderUids = new Set(
+    messages.filter((m) => m.direction === 'outbound' && m.senderUser?.uid).map((m) => m.senderUser.uid),
+  );
+  const showSenders = outboundSenderUids.size >= 2;
+  const senderDisplay = (m) => {
+    const s = m.senderUser;
+    if (!s?.uid) return null;
+    if (myPodiumUid && s.uid === myPodiumUid) return 'You';
+    return s.name || nameByPodiumUid.get(s.uid) || 'Team';
+  };
 
   return (
     <>
@@ -822,7 +925,16 @@ export default function Inbox() {
                           <span className="text-[11px] font-semibold px-2 py-0.5 rounded-full bg-gray-200 text-gray-700">Closed</span>
                         )}
                       </div>
-                      <div className="text-xs text-gray-400">{assigneeLabel(selectedConv).text}</div>
+                      {/* F13 — assignee chips + assignment picker (one or more reps). */}
+                      <AssigneeBar
+                        assignees={assignees}
+                        reps={reps}
+                        myPodiumUid={myPodiumUid}
+                        show={showAssign}
+                        setShow={setShowAssign}
+                        onToggle={toggleAssignee}
+                        saving={assignSaving}
+                      />
                     </div>
                     {/* Open/close the conversation (feedback 8 Jul) */}
                     <button
@@ -868,6 +980,9 @@ export default function Inbox() {
                               outbound ? 'bg-blue-500 text-white rounded-br-sm' : 'bg-white text-gray-800 border border-gray-200 rounded-bl-sm'
                             } ${m.optimistic ? 'opacity-80' : ''}`}
                           >
+                            {showSenders && outbound && senderDisplay(m) && (
+                              <div className="text-[11px] font-semibold text-blue-100 mb-0.5">{senderDisplay(m)}</div>
+                            )}
                             {m.body && <div className="whitespace-pre-wrap break-words">{m.body}</div>}
                             <MessageAttachments attachments={m.attachments} outbound={outbound} />
                             <div className={`text-[10px] mt-1 ${outbound ? 'text-blue-100' : 'text-gray-400'}`}>
@@ -1242,6 +1357,66 @@ function CustomerPanel({
           </section>
         </>
       )}
+    </div>
+  );
+}
+
+// F13 — assignee chips + the assignment picker for the thread header. Shows every
+// assignee (resolved to a portal rep, or a Podium-member name), highlights the logged-in
+// rep as "You", and lets a salesperson add/remove reps (the picker manages portal reps;
+// reps who haven't linked their Podium account are shown disabled). A conversation can be
+// assigned to one OR MORE reps — Podium's assignees endpoint is plural.
+function AssigneeBar({ assignees, reps, myPodiumUid, show, setShow, onToggle, saving }) {
+  const assignedPortalIds = new Set(assignees.map((a) => a.portalId).filter(Boolean));
+  return (
+    <div className="mt-1 flex items-center gap-1.5 flex-wrap">
+      <span className="text-[11px] text-gray-400">Assigned:</span>
+      {assignees.length === 0 && <span className="text-xs text-gray-400">Unassigned</span>}
+      {assignees.map((a) => {
+        const you = myPodiumUid && a.podiumUserId === myPodiumUid;
+        return (
+          <span
+            key={a.podiumUserId}
+            className={`inline-flex items-center text-[11px] font-medium px-2 py-0.5 rounded-full ${you ? 'bg-green-100 text-green-800' : 'bg-blue-100 text-blue-800'}`}
+          >
+            {a.name || a.podiumUserId}{you ? ' (You)' : ''}
+          </span>
+        );
+      })}
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => setShow(!show)}
+          disabled={saving || reps.length === 0}
+          className="text-[11px] px-2 py-0.5 rounded-full border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-40"
+          title="Assign salespeople to this conversation"
+        >
+          {saving ? 'Saving…' : 'Assign ▾'}
+        </button>
+        {show && reps.length > 0 && (
+          <div className="absolute top-full mt-1 left-0 z-20 w-60 max-h-64 overflow-y-auto bg-white border border-gray-200 rounded-lg shadow-lg py-1">
+            {reps.map((r) => {
+              const checked = assignedPortalIds.has(r.id);
+              return (
+                <button
+                  key={r.id}
+                  type="button"
+                  onClick={() => onToggle(r)}
+                  disabled={saving || !r.linked}
+                  className="w-full flex items-center gap-2 text-left px-3 py-1.5 hover:bg-gray-50 disabled:opacity-50"
+                  title={r.linked ? '' : 'This rep has not linked their Podium account'}
+                >
+                  <span className={`w-4 h-4 shrink-0 rounded border flex items-center justify-center text-[10px] ${checked ? 'bg-blue-500 border-blue-500 text-white' : 'border-gray-300 text-transparent'}`}>✓</span>
+                  <span className="min-w-0 flex-1">
+                    <span className="block text-xs text-gray-800 truncate">{r.name}</span>
+                    {!r.linked && <span className="block text-[10px] text-gray-400">Not linked to Podium</span>}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        )}
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
## F13 — Multi-assignee + sender attribution (from Nick's 6 Jul feedback)

A conversation can be assigned to **one or more** salespeople, and in a multi-rep thread each message is labelled with **who sent it**. Mock-first (`PODIUM_MOCK=true`) — **no migration, no new serverless function** (stays `nodejs:3`). F13 → **IN_REVIEW**.

### What's built
- **Multi-assignee (Podium's `PUT /conversations/{uid}/assignees` is plural):** conversation `00001` is shared by **Amelia + Ben**. The thread header shows assignee **chips** (with a "You" highlight) and an **Assign ▾** picker to add/remove salespeople. A shared conversation appears in **every** assignee's "Assigned to You" bucket.
- **Sender attribution:** in a thread with ≥2 distinct outbound senders, each rep's messages are labelled with the sender's name (Amelia vs Ben on `00001`).
- **Reps picker:** `GET /api/podium/inbox?resource=reps` lists assignable `sales`/`superadmin` portal users; reps who haven't linked their Podium account are shown disabled.
- **Assign API:** `POST /api/podium/assign` now accepts `userIds[]` (whole new set), a single `userId`, or a claim; the primary owner is mirrored to `leads.assigned_to`.

### Scope / guards
- **No migration.** **No new function** — `reps` is a new case on the existing inbox dispatcher; assignment reuses the existing `assign` route.
- **P1 held** — no message bodies/notes persisted; only assignee metadata + live sender identity (names).
- `sales`/`superadmin` gated (server re-checks the login JWT).

### Migration
None.

### Preview
https://grays-internal-git-feat-podium-f-ba9784-grays-supports-projects.vercel.app (Vercel SSO — open while signed into the Grays Support team)

### How to test
1. Open the Preview signed into the Grays Support Vercel team, as a `sales`/`superadmin` user. Go to **/inbox** → **All** (or **Assigned to You**) → **Open** and open **Maria's** SMS thread (`00001`).
2. **Multi-assignee:** the header shows two assignee chips — **Nick Enrique Wijaya** (Amelia, linked) + **Ben Jindra**. Click **Assign ▾** to see the reps picker; tick/untick a linked rep to reassign (unlinked reps are disabled — they must connect Podium first).
3. **Sender attribution:** the thread has two outbound replies — one labelled **Amelia Reid**, one **Ben Jindra** — so who-sent-what is clear.
4. Confirm a single-rep thread (e.g. `00004`) shows **no** sender labels (attribution only kicks in for multi-rep threads).

### Reviewer checklist
- [x] `00001` shows two assignee chips + who-sent-what in the thread
- [x] Assign picker lists sales/superadmin reps; unlinked reps disabled; assign/remove works for a linked rep
- [x] No chat bodies persisted (P1); no migration; no new function; no secrets
- [x] Approve & merge, or leave feedback

**VERIFY at live wiring:** Podium's real `PUT /assignees` body shape for multiple assignees, and the message `senderUser` field name (§15 doesn't pin either).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
