### PR TITLE
G2 — Delivery type, free/cash flags, installation cost

### DIFF
--- a/db/migrations/0004_delivery_type.sql
+++ b/db/migrations/0004_delivery_type.sql
@@ -1,0 +1,33 @@
+-- 0004_delivery_type.sql — Delivery type, free-delivery / cash-direct flags,
+-- installation cost (G2, 10 Jul 2026).
+--
+-- ADDITIVE + IDEMPOTENT. Apply ONLY to the Neon dev/preview branch — never prod.
+-- Paired rollback: 0004_delivery_type_down.sql. Independent of Podium tables.
+--
+-- delivery_type: the service. 'Customer Collect' = customer picks up, no removalist,
+--   $0 fee is correct (distinct from free_delivery — a Standard delivery given away).
+-- free_delivery: pricing flag, delivery included in the sale to win the deal.
+-- cash_to_removalist: payment flag, customer pays the removalist directly in cash.
+-- installation_cost: what the technician callout costs US (installation is always
+--   billed to the customer inside delivery_charged — D2 — so there is no separate
+--   installation_charged column).
+--
+-- delivery_type is NULLABLE with NO default (existing rows stay untagged per D3;
+-- the app defaults new rows to 'Standard'). Flags default FALSE = untagged.
+-- Both workorder (captured at create/update) and delivery (copied when the delivery
+-- is auto-created + editable in To-Be-Booked) carry the fields.
+
+DO $$ BEGIN
+  CREATE TYPE delivery_type_enum AS ENUM ('Standard', 'Standard + Installation', 'Customer Collect');
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+ALTER TABLE workorder ADD COLUMN IF NOT EXISTS delivery_type        delivery_type_enum;
+ALTER TABLE workorder ADD COLUMN IF NOT EXISTS free_delivery         BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE workorder ADD COLUMN IF NOT EXISTS cash_to_removalist    BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE workorder ADD COLUMN IF NOT EXISTS installation_cost     NUMERIC;
+
+ALTER TABLE delivery  ADD COLUMN IF NOT EXISTS delivery_type         delivery_type_enum;
+ALTER TABLE delivery  ADD COLUMN IF NOT EXISTS free_delivery         BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE delivery  ADD COLUMN IF NOT EXISTS cash_to_removalist    BOOLEAN NOT NULL DEFAULT FALSE;
+ALTER TABLE delivery  ADD COLUMN IF NOT EXISTS installation_cost     NUMERIC;

--- a/db/migrations/0004_delivery_type_down.sql
+++ b/db/migrations/0004_delivery_type_down.sql
@@ -1,0 +1,13 @@
+-- 0004_delivery_type_down.sql — rollback of G2 delivery type + flags. Reversible.
+
+ALTER TABLE delivery  DROP COLUMN IF EXISTS installation_cost;
+ALTER TABLE delivery  DROP COLUMN IF EXISTS cash_to_removalist;
+ALTER TABLE delivery  DROP COLUMN IF EXISTS free_delivery;
+ALTER TABLE delivery  DROP COLUMN IF EXISTS delivery_type;
+
+ALTER TABLE workorder DROP COLUMN IF EXISTS installation_cost;
+ALTER TABLE workorder DROP COLUMN IF EXISTS cash_to_removalist;
+ALTER TABLE workorder DROP COLUMN IF EXISTS free_delivery;
+ALTER TABLE workorder DROP COLUMN IF EXISTS delivery_type;
+
+DROP TYPE IF EXISTS delivery_type_enum;

--- a/lib/handlers/delivery.js
+++ b/lib/handlers/delivery.js
@@ -63,6 +63,10 @@ export default async function handler(req, res) {
             d.notes,
             d.workorder_id,
             d.date_created,
+            d.delivery_type,
+            d.free_delivery,
+            d.cash_to_removalist,
+            d.installation_cost,
             c.name  AS customer_name,
             c.email AS customer_email,
             c.phone AS customer_phone,
@@ -128,6 +132,10 @@ export default async function handler(req, res) {
           d.notes,
           d.workorder_id,
           d.date_created,
+          d.delivery_type,
+          d.free_delivery,
+          d.cash_to_removalist,
+          d.installation_cost,
           c.name AS customer_name,
           r.name AS removalist_name,
           w.outstanding_balance,
@@ -170,12 +178,20 @@ export default async function handler(req, res) {
         delivery_date,
         delivery_status,
         notes,
-        workorder_id
+        workorder_id,
+        delivery_type,        // G2
+        free_delivery,        // G2
+        cash_to_removalist,   // G2
+        installation_cost,    // G2
       } = body || {};
 
       if (!invoice_id || !customer_id || !delivery_state) {
         return res.status(400).json({ error: 'Missing required fields' });
       }
+
+      const dType = ['Standard', 'Standard + Installation', 'Customer Collect'].includes(delivery_type)
+        ? delivery_type
+        : 'Standard';
 
       // If creating directly as "Booked for Delivery", require date+carrier unless customer collect
       if (delivery_status === 'Booked for Delivery') {
@@ -203,10 +219,12 @@ export default async function handler(req, res) {
         INSERT INTO delivery (
           invoice_id, customer_id, delivery_suburb, delivery_state,
           delivery_charged, delivery_quoted, removalist_id, delivery_date,
-          delivery_status, notes, workorder_id, date_created
+          delivery_status, notes, workorder_id, date_created,
+          delivery_type, free_delivery, cash_to_removalist, installation_cost
         ) VALUES (
           $1,$2,$3,$4,$5,$6,$7,$8,
-          COALESCE($9, 'To Be Booked'::delivery_status_enum), $10,$11, NOW()
+          COALESCE($9, 'To Be Booked'::delivery_status_enum), $10,$11, NOW(),
+          $12,$13,$14,$15
         )
         RETURNING delivery_id, workorder_id, delivery_status
         `,
@@ -222,6 +240,10 @@ export default async function handler(req, res) {
           delivery_status || null,
           notes || null,
           workorder_id == null || workorder_id === '' ? null : Number(workorder_id),
+          dType,
+          !!free_delivery,
+          !!cash_to_removalist,
+          installation_cost == null || installation_cost === '' ? null : Number(installation_cost),
         ]
       );
 
@@ -255,6 +277,10 @@ export default async function handler(req, res) {
         notes,
         workorder_id,
         user_id, // optional from body
+        delivery_type,        // G2
+        free_delivery,        // G2
+        cash_to_removalist,   // G2
+        installation_cost,    // G2
       } = body || {};
 
       const actorId = twoCharId(req.headers['x-user-id'] || user_id);
@@ -322,6 +348,11 @@ export default async function handler(req, res) {
       if (delivery_status !== undefined)  { sets.push(`delivery_status = $${i++}`);  vals.push(delivery_status); }
       if (notes !== undefined)            { sets.push(`notes = $${i++}`);            vals.push(notes || null); }
       if (workorder_id !== undefined)     { sets.push(`workorder_id = $${i++}`);     vals.push(workorder_id === '' || workorder_id == null ? null : Number(workorder_id)); }
+      // G2 delivery type + flags + installation cost
+      if (delivery_type !== undefined)    { sets.push(`delivery_type = $${i++}`);    vals.push(['Standard','Standard + Installation','Customer Collect'].includes(delivery_type) ? delivery_type : null); }
+      if (free_delivery !== undefined)    { sets.push(`free_delivery = $${i++}`);    vals.push(!!free_delivery); }
+      if (cash_to_removalist !== undefined) { sets.push(`cash_to_removalist = $${i++}`); vals.push(!!cash_to_removalist); }
+      if (installation_cost !== undefined){ sets.push(`installation_cost = $${i++}`); vals.push(installation_cost === '' || installation_cost == null ? null : Number(installation_cost)); }
 
       if (!sets.length) {
         await client.query('ROLLBACK');

--- a/lib/handlers/workorder.js
+++ b/lib/handlers/workorder.js
@@ -282,7 +282,20 @@ export default async function handler(req, res) {
         outstanding_balance,
         items,
         important_flag,
+        delivery_type,          // G2: Standard | Standard + Installation | Customer Collect
+        free_delivery,          // G2: included-in-sale flag
+        cash_to_removalist,     // G2: customer pays removalist cash direct
+        installation_cost,      // G2: our technician callout cost
       } = body || {};
+
+      // G2 delivery service type — default Standard on create; flags default false.
+      const woDeliveryType = ['Standard', 'Standard + Installation', 'Customer Collect'].includes(delivery_type)
+        ? delivery_type
+        : 'Standard';
+      const woInstallCost =
+        installation_cost === null || installation_cost === undefined || installation_cost === ''
+          ? null
+          : Number(installation_cost);
 
       if (
         !invoice_id ||
@@ -318,9 +331,10 @@ export default async function handler(req, res) {
         `
         INSERT INTO workorder (
           invoice_id, customer_id, salesperson, delivery_suburb, delivery_state,
-          delivery_charged, lead_time, estimated_completion, notes, status, date_created, outstanding_balance, important_flag
+          delivery_charged, lead_time, estimated_completion, notes, status, date_created, outstanding_balance, important_flag,
+          delivery_type, free_delivery, cash_to_removalist, installation_cost
         )
-        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,NOW(),$11,$12)
+        VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,NOW(),$11,$12,$13,$14,$15,$16)
         RETURNING workorder_id
         `,
         [
@@ -336,6 +350,10 @@ export default async function handler(req, res) {
           status || 'Work Ordered',
           Number(outstanding_balance),
           important_flag == null ? false : !!important_flag,
+          woDeliveryType,
+          !!free_delivery,
+          !!cash_to_removalist,
+          woInstallCost,
         ]
       );
       const workorderId = woRes.rows[0].workorder_id;
@@ -430,6 +448,10 @@ export default async function handler(req, res) {
         delete_item_ids,
         status,
         salesperson,
+        delivery_type,          // G2
+        free_delivery,          // G2
+        cash_to_removalist,     // G2
+        installation_cost,      // G2
       } = body || {};
 
       await client.query('BEGIN');
@@ -491,6 +513,26 @@ export default async function handler(req, res) {
       if (salesperson !== undefined) {
         updates.push(`salesperson = $${p++}`);
         params.push(twoCharId(salesperson));
+      }
+      // G2 delivery service type + flags + installation cost
+      if (delivery_type !== undefined) {
+        const dt = ['Standard', 'Standard + Installation', 'Customer Collect'].includes(delivery_type)
+          ? delivery_type
+          : null;
+        updates.push(`delivery_type = $${p++}`);
+        params.push(dt);
+      }
+      if (free_delivery !== undefined) {
+        updates.push(`free_delivery = $${p++}`);
+        params.push(!!free_delivery);
+      }
+      if (cash_to_removalist !== undefined) {
+        updates.push(`cash_to_removalist = $${p++}`);
+        params.push(!!cash_to_removalist);
+      }
+      if (installation_cost !== undefined) {
+        updates.push(`installation_cost = $${p++}`);
+        params.push(installation_cost === null || installation_cost === '' ? null : Number(installation_cost));
       }
 
       // ✅ GS-only ecommerce flag (no logging)
@@ -754,9 +796,11 @@ export default async function handler(req, res) {
             INSERT INTO delivery (
               invoice_id, customer_id, delivery_suburb, delivery_state,
               delivery_charged, delivery_quoted, removalist_id, delivery_date,
-              delivery_status, notes, workorder_id, date_created
+              delivery_status, notes, workorder_id, date_created,
+              delivery_type, free_delivery, cash_to_removalist, installation_cost
             ) VALUES (
-              $1,$2,$3,$4,$5,NULL,NULL,NULL,'To Be Booked',$6,$7,NOW()
+              $1,$2,$3,$4,$5,NULL,NULL,NULL,'To Be Booked',$6,$7,NOW(),
+              $8,$9,$10,$11
             )
             `,
             [
@@ -767,6 +811,10 @@ export default async function handler(req, res) {
               d.delivery_charged == null ? null : Number(d.delivery_charged),
               d.notes ? `${d.notes}\n\n` : '',
               Number(id),
+              d.delivery_type ?? null,           // G2: carry the WO's service type
+              !!d.free_delivery,
+              !!d.cash_to_removalist,
+              d.installation_cost == null ? null : Number(d.installation_cost),
             ]
           );
 

--- a/src/pages/create_workorder.js
+++ b/src/pages/create_workorder.js
@@ -30,6 +30,10 @@ export default function CreateWorkorderPage() {
     delivery_suburb: '',
     delivery_state: '',
     delivery_charged: '',
+    delivery_type: 'Standard',
+    free_delivery: false,
+    cash_to_removalist: false,
+    installation_cost: '',
     lead_time: '',
     estimated_completion: '',
     notes: '',
@@ -409,6 +413,49 @@ export default function CreateWorkorderPage() {
                   value={form.delivery_charged}
                   onChange={(e) => setForm((f) => ({ ...f, delivery_charged: e.target.value }))}
                 />
+
+                {/* Delivery Type (G2) */}
+                <select
+                  className="border p-2 rounded w-full"
+                  value={form.delivery_type}
+                  onChange={(e) => setForm((f) => ({ ...f, delivery_type: e.target.value }))}
+                >
+                  <option value="Standard">Standard delivery</option>
+                  <option value="Standard + Installation">Standard + Installation</option>
+                  <option value="Customer Collect">Customer Collect (no delivery fee)</option>
+                </select>
+
+                {/* Installation cost (our cost) — only relevant when installing */}
+                {form.delivery_type === 'Standard + Installation' && (
+                  <input
+                    type="number"
+                    step="0.01"
+                    placeholder="Installation cost to us ($)"
+                    className="border p-2 rounded w-full"
+                    value={form.installation_cost}
+                    onChange={(e) => setForm((f) => ({ ...f, installation_cost: e.target.value }))}
+                  />
+                )}
+
+                {/* Delivery pricing/payment flags (G2) */}
+                <div className="flex flex-col gap-1 text-sm text-gray-700">
+                  <label className="inline-flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={form.free_delivery}
+                      onChange={(e) => setForm((f) => ({ ...f, free_delivery: e.target.checked }))}
+                    />
+                    Free delivery (included in sale to win the deal)
+                  </label>
+                  <label className="inline-flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={form.cash_to_removalist}
+                      onChange={(e) => setForm((f) => ({ ...f, cash_to_removalist: e.target.checked }))}
+                    />
+                    Customer pays removalist cash direct
+                  </label>
+                </div>
 
                 {/* Lead Time */}
                 <select

--- a/src/pages/delivery_operations/completed-deliveries.js
+++ b/src/pages/delivery_operations/completed-deliveries.js
@@ -479,6 +479,7 @@ export default function CompletedDeliveriesPage() {
                       <th className="px-3 py-2 w-20 text-center">Payment</th>
                       <th className="px-3 py-2 w-36">Delivery Date</th>{/* read-only */}
                       <th className="px-3 py-2 w-72">Notes</th>
+                      <th className="px-3 py-2 w-44">Type / Flags</th>
                       <th className="px-3 py-2 w-24">Delivery Charged</th>
                       <th className="px-3 py-2 w-24">Delivery Quoted</th>
                       <th className="px-3 py-2 w-24">Margin</th>
@@ -488,16 +489,17 @@ export default function CompletedDeliveriesPage() {
 
                   <tbody className="divide-y divide-gray-100">
                     {loading && (
-                      <tr><td colSpan={13} className="px-3 py-6 text-center text-sm">Loading…</td></tr>
+                      <tr><td colSpan={14} className="px-3 py-6 text-center text-sm">Loading…</td></tr>
                     )}
                     {!loading && paged.length === 0 && (
-                      <tr><td colSpan={13} className="px-3 py-6 text-center text-sm">No deliveries.</td></tr>
+                      <tr><td colSpan={14} className="px-3 py-6 text-center text-sm">No deliveries.</td></tr>
                     )}
 
                     {paged.map((row, idx) => {
                       const margin =
                         (row.delivery_charged == null ? 0 : Number(row.delivery_charged)) -
-                        (row.delivery_quoted == null ? 0 : Number(row.delivery_quoted));
+                        (row.delivery_quoted == null ? 0 : Number(row.delivery_quoted)) -
+                        (row.installation_cost == null ? 0 : Number(row.installation_cost));
                       const rowCls = idx % 2 ? 'bg-gray-50' : 'bg-white';
                       return (
                         <tr
@@ -535,6 +537,26 @@ export default function CompletedDeliveriesPage() {
                           <td className="px-3 py-2 text-sm text-center"><PaymentBadge outstanding={row.outstanding_balance} /></td>
                           <td className="px-3 py-2 text-sm">{formatDate(row.delivery_date) || '—'}</td>
                           <td className="px-3 py-2 text-sm" {...stopRowNav}><NotesCell row={row} /></td>
+
+                          {/* G2: delivery type + flags (read-only here) */}
+                          <td className="px-3 py-2 text-sm">
+                            <div className="flex flex-col gap-1">
+                              <span>{row.delivery_type || '—'}</span>
+                              <div className="flex flex-wrap gap-1">
+                                {row.free_delivery && (
+                                  <span className="inline-block rounded bg-green-100 text-green-800 px-1.5 py-0.5 text-[10px] font-medium">FREE</span>
+                                )}
+                                {row.cash_to_removalist && (
+                                  <span className="inline-block rounded bg-amber-100 text-amber-800 px-1.5 py-0.5 text-[10px] font-medium">CASH</span>
+                                )}
+                                {row.installation_cost != null && (
+                                  <span className="inline-block rounded bg-blue-100 text-blue-800 px-1.5 py-0.5 text-[10px] font-medium">
+                                    install {fmtMoney(Number(row.installation_cost))}
+                                  </span>
+                                )}
+                              </div>
+                            </div>
+                          </td>
 
                           {/* ✅ EDITABLE: Delivery Charged */}
                           <td className="px-3 py-2 text-sm" {...stopRowNav}>

--- a/src/pages/delivery_operations/to-be-booked.js
+++ b/src/pages/delivery_operations/to-be-booked.js
@@ -597,6 +597,64 @@ export default function ToBeBookedDeliveriesPage() {
     );
   };
 
+  // G2: delivery type + free/cash flags + installation cost (our cost)
+  const TypeCell = ({ row }) => {
+    const busy = savingIds.has(row.delivery_id);
+    const [inst, setInst] = useState(row.installation_cost ?? '');
+    useEffect(() => { setInst(row.installation_cost ?? ''); }, [row]);
+    return (
+      <div className="flex flex-col gap-1" {...stopRowNav}>
+        <select
+          className="w-full rounded border px-2 py-1 text-sm disabled:opacity-60"
+          value={row.delivery_type || 'Standard'}
+          onChange={(e) => {
+            if (e.target.value !== (row.delivery_type || 'Standard')) {
+              saveDelivery(row.delivery_id, { delivery_type: e.target.value });
+            }
+          }}
+          disabled={busy}
+        >
+          {['Standard', 'Standard + Installation', 'Customer Collect'].map((t) => (
+            <option key={t} value={t}>{t}</option>
+          ))}
+        </select>
+        {row.delivery_type === 'Standard + Installation' && (
+          <CompactMoneyInput
+            widthClass="w-24"
+            value={inst ?? ''}
+            onChange={(e) => setInst(e.target.value)}
+            onBlur={() => {
+              const num = inst === '' ? null : Number(inst);
+              const orig = row.installation_cost == null ? null : Number(row.installation_cost);
+              if (num !== orig) saveDelivery(row.delivery_id, { installation_cost: num });
+            }}
+            disabled={busy}
+          />
+        )}
+        <div className="flex flex-wrap gap-2">
+          <label className="inline-flex items-center gap-1 text-[11px] text-gray-600">
+            <input
+              type="checkbox"
+              checked={!!row.free_delivery}
+              disabled={busy}
+              onChange={(e) => saveDelivery(row.delivery_id, { free_delivery: e.target.checked })}
+            />
+            Free
+          </label>
+          <label className="inline-flex items-center gap-1 text-[11px] text-gray-600">
+            <input
+              type="checkbox"
+              checked={!!row.cash_to_removalist}
+              disabled={busy}
+              onChange={(e) => saveDelivery(row.delivery_id, { cash_to_removalist: e.target.checked })}
+            />
+            Cash direct
+          </label>
+        </div>
+      </div>
+    );
+  };
+
   // Section renderer
   const renderSection = (code) => {
     const rows = (groupByState.get(code) || []).map(r => ({ ...r, delivery_date: asYMD(r.delivery_date) }));
@@ -618,6 +676,7 @@ export default function ToBeBookedDeliveriesPage() {
                 <th className="px-3 py-2 w-16 text-center">Payment</th>
                 <th className="px-3 py-2 w-40">Delivery Date</th>
                 <th className="px-3 py-2 w-72">Notes</th>
+                <th className="px-3 py-2 w-52">Type / Flags</th>
                 <th className="px-3 py-2 w-20">Delivery Charged</th>
                 <th className="px-3 py-2 w-20">Delivery Quoted</th>
                 <th className="px-3 py-2 w-24">Margin</th>
@@ -625,12 +684,13 @@ export default function ToBeBookedDeliveriesPage() {
               </tr>
             </thead>
             <tbody className="divide-y divide-gray-100">
-              {loading && <tr><td colSpan={12} className="px-3 py-6 text-center text-sm">Loading…</td></tr>}
-              {!loading && rows.length === 0 && <tr><td colSpan={12} className="px-3 py-6 text-center text-sm">No deliveries.</td></tr>}
+              {loading && <tr><td colSpan={13} className="px-3 py-6 text-center text-sm">Loading…</td></tr>}
+              {!loading && rows.length === 0 && <tr><td colSpan={13} className="px-3 py-6 text-center text-sm">No deliveries.</td></tr>}
               {rows.map((row, idx) => {
                 const margin =
                   (row.delivery_charged == null ? 0 : Number(row.delivery_charged)) -
-                  (row.delivery_quoted == null ? 0 : Number(row.delivery_quoted));
+                  (row.delivery_quoted == null ? 0 : Number(row.delivery_quoted)) -
+                  (row.installation_cost == null ? 0 : Number(row.installation_cost));
                 const rowCls = idx % 2 ? 'bg-gray-50' : 'bg-white';
                 return (
                   <tr
@@ -650,6 +710,7 @@ export default function ToBeBookedDeliveriesPage() {
                     <td className="px-3 py-2 text-sm text-center"><PaymentCell row={row} /></td>
                     <td className="px-3 py-2 text-sm"><DateCell row={row} /></td>
                     <td className="px-3 py-2 text-sm"><NotesCell row={row} /></td>
+                    <td className="px-3 py-2 text-sm"><TypeCell row={row} /></td>
                     <td className="px-3 py-2 text-sm"><MoneyCell row={row} field="delivery_charged" /></td>
                     <td className="px-3 py-2 text-sm"><MoneyCell row={row} field="delivery_quoted" /></td>
                     <td className="px-3 py-2 text-sm">{fmtMoney(margin)}</td>

--- a/src/pages/delivery_operations/workorder/[id].js
+++ b/src/pages/delivery_operations/workorder/[id].js
@@ -177,6 +177,10 @@ export default function WorkorderDetailPage() {
 
   const [notes, setNotes] = useState('');
   const [deliveryCharged, setDeliveryCharged] = useState('');
+  const [deliveryType, setDeliveryType] = useState('Standard');       // G2
+  const [freeDelivery, setFreeDelivery] = useState(false);            // G2
+  const [cashToRemovalist, setCashToRemovalist] = useState(false);    // G2
+  const [installationCost, setInstallationCost] = useState('');       // G2
   const [outstandingBalance, setOutstandingBalance] = useState('');
 
   const [activity, setActivity] = useState([]);
@@ -298,6 +302,10 @@ export default function WorkorderDetailPage() {
         setItems((data.items || []).filter(it => it.status !== 'Canceled'));
         setNotes(data.notes || '');
         setDeliveryCharged(data.delivery_charged ?? '');
+        setDeliveryType(data.delivery_type || 'Standard');
+        setFreeDelivery(!!data.free_delivery);
+        setCashToRemovalist(!!data.cash_to_removalist);
+        setInstallationCost(data.installation_cost ?? '');
         setOutstandingBalance(data.outstanding_balance ?? '');
         setActivity(data.activity || []);
         setImportant(!!data.important_flag);
@@ -426,6 +434,10 @@ export default function WorkorderDetailPage() {
         status: woStatus || wo.status,
         notes,
         delivery_charged: deliveryCharged === '' ? null : Number(deliveryCharged),
+        delivery_type: deliveryType,
+        free_delivery: !!freeDelivery,
+        cash_to_removalist: !!cashToRemovalist,
+        installation_cost: installationCost === '' ? null : Number(installationCost),
         outstanding_balance:
           outstandingBalance === ''
             ? wo.outstanding_balance
@@ -970,6 +982,51 @@ export default function WorkorderDetailPage() {
                     onChange={(e) => setDeliveryCharged(e.target.value)}
                     placeholder="Value"
                   />
+                </div>
+
+                {/* Delivery type + flags + installation cost (G2) */}
+                <div className="mt-3">
+                  <div className="text-sm text-gray-600 mb-1">Delivery Type</div>
+                  <select
+                    className="w-full border rounded p-2"
+                    value={deliveryType}
+                    onChange={(e) => setDeliveryType(e.target.value)}
+                  >
+                    <option value="Standard">Standard delivery</option>
+                    <option value="Standard + Installation">Standard + Installation</option>
+                    <option value="Customer Collect">Customer Collect (no delivery fee)</option>
+                  </select>
+                </div>
+                {deliveryType === 'Standard + Installation' && (
+                  <div className="mt-3">
+                    <div className="text-sm text-gray-600 mb-1">Installation cost to us ($)</div>
+                    <input
+                      type="number"
+                      step="0.01"
+                      className="w-full border rounded p-2"
+                      value={installationCost ?? ''}
+                      onChange={(e) => setInstallationCost(e.target.value)}
+                      placeholder="Value"
+                    />
+                  </div>
+                )}
+                <div className="mt-3 flex flex-col gap-1 text-sm text-gray-700">
+                  <label className="inline-flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={freeDelivery}
+                      onChange={(e) => setFreeDelivery(e.target.checked)}
+                    />
+                    Free delivery (included in sale)
+                  </label>
+                  <label className="inline-flex items-center gap-2">
+                    <input
+                      type="checkbox"
+                      checked={cashToRemovalist}
+                      onChange={(e) => setCashToRemovalist(e.target.checked)}
+                    />
+                    Customer pays removalist cash direct
+                  </label>
                 </div>
 
                 <div className="mt-3">


### PR DESCRIPTION
## G2 — Delivery type, free-delivery / cash-direct flags, installation cost

Second feature of the ops workstream. **Stacked on G1** (base branch = `feat/ops-g1-customer-type`) — review/merge G1 first. Do not merge without review.

### What this delivers
A **Delivery type** dropdown when creating/updating a workorder, plus **free delivery** and **cash-direct** flags and an **installation cost** field, so the deliveries data can finally be analysed by these dimensions.

### Data model — migration `0004_delivery_type`
On **both** `workorder` and `delivery`:
- `delivery_type` enum `Standard | Standard + Installation | Customer Collect` (nullable, no default — existing rows untagged per D3; app defaults new rows to `Standard`).
- `free_delivery`, `cash_to_removalist` boolean (default false = untagged).
- `installation_cost` numeric (our technician-callout cost). No `installation_charged` — installation is always billed inside `delivery_charged` (D2).

`Customer Collect` is a first-class **$0-fee** service, kept distinct from `free_delivery` (a Standard delivery given away). Independent of Podium tables. Applied to Neon **dev** (4 cols on each table verified; `schema_migrations` row `0004_delivery_type`).

### Code
- **workorder handler**: POST/PUT capture the fields; the auto-created delivery copies them from the workorder (like `delivery_charged`).
- **delivery handler**: POST/PUT + both GETs (single + list) include the fields.
- **create_workorder**: type dropdown + free/cash checkboxes + installation cost (shown for +Installation).
- **to-be-booked**: editable **Type / Flags** column (type dropdown + FREE/CASH checkboxes + inline install cost); **margin = charged − (quoted + installation_cost)**.
- **workorder/[id]**: same fields editable; hidden from the workshop kiosk (cost).
- **completed-deliveries**: read-only Type/Flags column + FREE/CASH/install badges + margin fix.

### Notes
- No new serverless function (still 3). No Production/prod-DB change.
- `CI=true npm run build` green (`main.fb20b18f.js`, +986 B).
- The $0-charged historical rows are NOT auto-tagged (D3) — Nick tags them via `zero-charged-deliveries-to-tag-2026-07-10.xlsx`; a follow-up applies those tags.
- Deferred: the "is this free / cash / customer-collect" confirm prompt when saving a $0 Standard delivery — noted for a later polish increment.
- See `db/PRODUCTION_MIGRATION_RUNBOOK.md` for how 0004 reaches Production.

### Reviewer checklist
- [x] Create a WO as Standard + Installation + Free delivery, and confirm the delivery appears in To-Be-Booked with the type, FREE badge, install cost, and correct (negative) margin.
- [x] A Customer Collect WO shows $0 delivery with no data-error feel.
- [x] Edit type/flags inline in To-Be-Booked; edits persist.
- [x] Workshop kiosk login does NOT see cost fields.
- [x] Completed Deliveries shows the Type/Flags column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
