### PR TITLE
F14 — Conversation search (name / phone / email via the F4 bridge)

### DIFF
--- a/lib/podiumContact.js
+++ b/lib/podiumContact.js
@@ -292,6 +292,98 @@ export async function buildCustomerPanel(client, userId, { conversationId, conta
   return panel;
 }
 
+// ---- F14 conversation search ----------------------------------------------
+
+/**
+ * Build a compact, searchable identity for a conversation, reusing the F4 bridge: the
+ * Podium contact behind it (name/phone/email) AND the matched portal customer
+ * (name/email/phone). Drives the inbox conversation search (feature F14) — filter the
+ * list by WHO a conversation is with, and give each row a real display name instead of a
+ * bare phone number. Reads only CRM metadata, never message bodies (P1).
+ *
+ * We already hold the conversation object (from GET /conversations), so the contact is
+ * resolved directly off conversation.contact.uid — no extra GET /conversations/{uid}.
+ * A missing/404 contact degrades to a channel-only stub (phone from the channel), so a
+ * phone-number search still works for conversations with no contact record.
+ *
+ * @param {object} client  pg client (caller owns the connection)
+ * @param {string} userId  acting rep's portal id (their Podium token is used, P4)
+ * @param {object} conv    a §15 conversation object
+ * @returns {Promise<{contactName:?string, customerName:?string, customerId:?number,
+ *   email:?string, phone:?string, matchedBy:string, displayName:?string}>}
+ */
+export async function buildConversationIdentity(client, userId, conv) {
+  const contactUid = conv?.contact?.uid || null;
+  let contact = null;
+  if (contactUid) {
+    try {
+      contact = normalizeContact(await getContact(userId, contactUid, { client }), conv);
+    } catch (err) {
+      if (err?.status !== 404) throw err; // contact gone upstream → fall through to a channel stub
+    }
+  }
+  if (!contact) {
+    const chan = conv?.channel || null;
+    contact = {
+      uid: contactUid,
+      name: null,
+      email: null,
+      phone: chan?.type === 'phone' ? chan?.identifier || null : null,
+      channels: [],
+      channel: chan,
+    };
+  }
+
+  const { customer, matchedBy } = await matchCustomer(client, contact);
+  const displayName =
+    customer?.name || contact.name || contact.phone || conv?.channel?.identifier || null;
+
+  return {
+    contactName: contact.name || null,
+    customerName: customer?.name || null,
+    customerId: customer?.id || null,
+    email: customer?.email || contact.email || null,
+    phone: customer?.phone || contact.phone || null,
+    matchedBy,
+    displayName,
+  };
+}
+
+/**
+ * Does a conversation's resolved identity match a free-text search term? Case-insensitive
+ * substring on name/email/handle; loose phone matching (digits only): substring of the
+ * full stored number (so a prefix typed in the stored format matches) PLUS last-8
+ * equality (so a full number typed in local 04xx form still matches a +61-stored one).
+ * The raw channel identifier is searched too (covers social handles + phone numbers).
+ * An empty/whitespace term matches everything.
+ */
+export function identityMatchesSearch(identity, conv, term) {
+  const q = String(term || '').trim().toLowerCase();
+  if (!q) return true;
+
+  const text = [
+    identity?.contactName,
+    identity?.customerName,
+    identity?.email,
+    identity?.displayName,
+    conv?.channel?.identifier,
+  ].filter(Boolean).map((s) => String(s).toLowerCase());
+  if (text.some((s) => s.includes(q))) return true;
+
+  const qDigits = q.replace(/\D/g, '');
+  if (qDigits.length >= 3) {
+    const phones = [identity?.phone, conv?.channel?.identifier]
+      .filter(Boolean)
+      .map((p) => String(p).replace(/\D/g, ''))
+      .filter(Boolean);
+    for (const p of phones) {
+      if (p.includes(qDigits)) return true;                                    // prefix/substring, stored form
+      if (qDigits.length >= 8 && p.slice(-8) === qDigits.slice(-8)) return true; // full number, cross-format
+    }
+  }
+  return false;
+}
+
 export default {
   normalizeContact,
   resolveContact,
@@ -303,4 +395,6 @@ export default {
   activeDeliveriesForCustomer,
   latestLeadFor,
   buildCustomerPanel,
+  buildConversationIdentity,
+  identityMatchesSearch,
 };

--- a/lib/podiumRoutes/inbox.js
+++ b/lib/podiumRoutes/inbox.js
@@ -42,6 +42,7 @@ import {
 import {
   resolveSelfPodiumUid, filterUpdatedSince, clampLimit, normalizeBucket, normalizeStatus,
 } from '../podiumInbox.js';
+import { buildConversationIdentity, identityMatchesSearch } from '../podiumContact.js';
 import { getClientWithTimezone } from '../db.js';
 
 const ALLOWED_ROLES = ['sales', 'superadmin'];
@@ -166,15 +167,27 @@ async function setStatusRoute(req, res, auth) {
 // GET ?resource=conversations — list conversations for an F11 bucket + status.
 //   bucket = mine (default) | unassigned | all   (legacy `scope` alias still honoured)
 //   status = open (default) | closed | all
+//   search = free text (F14) — filter the list by the customer NAME / PHONE / EMAIL
+//            behind each conversation, resolved via the F4 contact↔customer bridge.
 async function listConversationsRoute(req, res, auth) {
   const bucket = normalizeBucket(req.query?.bucket ?? req.query?.scope);
   const status = normalizeStatus(req.query?.status ?? 'open');
   const cursor = req.query?.cursor ? String(req.query.cursor) : undefined;
   const limit = clampLimit(req.query?.limit, 30);
+  const search = req.query?.search != null ? String(req.query.search).trim() : '';
 
   const client = await getClientWithTimezone();
   try {
-    const filters = { cursor, limit, status: status || undefined, client };
+    // F14: our §15 Podium reference has no native conversation-search param, so search is
+    // done here — scan a wider single page from the TOP of the bucket (up to 100) and
+    // filter by the resolved contact/customer identity. Without a search, page normally.
+    // (VERIFY at live wiring whether Podium later exposes a server-side search param.)
+    const filters = {
+      cursor: search ? undefined : cursor,
+      limit: search ? 100 : limit,
+      status: status || undefined,
+      client,
+    };
     if (bucket === 'mine') {
       const assigneeUid = await resolveSelfPodiumUid(client, auth);
       if (!assigneeUid) {
@@ -183,7 +196,8 @@ async function listConversationsRoute(req, res, auth) {
         // the Unassigned / All buckets), rather than silently showing everyone's.
         return res.status(200).json({
           data: [], metadata: { nextCursor: null, previousCursor: null },
-          bucket, scope: bucket, status, notLinked: true, mock: isMock(),
+          bucket, scope: bucket, status, notLinked: true,
+          search: search || null, searchTruncated: false, mock: isMock(),
         });
       }
       filters.assigneeUid = assigneeUid;
@@ -191,10 +205,30 @@ async function listConversationsRoute(req, res, auth) {
       filters.unassigned = true;
     }
     const resp = await listConversations(auth.id, filters);
+    let data = Array.isArray(resp?.data) ? resp.data : [];
+    let metadata = resp?.metadata || { nextCursor: null, previousCursor: null };
+    let searchTruncated = false;
+
+    if (search) {
+      const matched = [];
+      for (const conv of data) {
+        // Enrich via the F4 bridge (contact + matched customer) then filter. The `identity`
+        // rides back on each row so the UI can show a real name in the result list.
+        const identity = await buildConversationIdentity(client, auth.id, conv);
+        if (identityMatchesSearch(identity, conv, search)) matched.push({ ...conv, identity });
+      }
+      // The scan only covers the first page (≤100) of the bucket; flag if more exist so a
+      // very large inbox can warn the results may be incomplete.
+      searchTruncated = !!metadata.nextCursor;
+      data = matched;
+      metadata = { nextCursor: null, previousCursor: null };
+    }
+
     return res.status(200).json({
-      data: Array.isArray(resp?.data) ? resp.data : [],
-      metadata: resp?.metadata || { nextCursor: null, previousCursor: null },
-      bucket, scope: bucket, status, notLinked: false, mock: isMock(),
+      data,
+      metadata,
+      bucket, scope: bucket, status, notLinked: false,
+      search: search || null, searchTruncated, mock: isMock(),
     });
   } catch (err) {
     return respondUpstreamError(res, err, 'list conversations');

--- a/scripts/podium-inbox-smoke.mjs
+++ b/scripts/podium-inbox-smoke.mjs
@@ -24,6 +24,7 @@ process.env.PODIUM_API_VERSION = process.env.PODIUM_API_VERSION || '2021-04-01';
 const jwt = (await import('jsonwebtoken')).default;
 const { clampLimit, filterUpdatedSince, resolveSelfPodiumUid, normalizeBucket, normalizeStatus } = await import('../lib/podiumInbox.js');
 const { listConversations, listMessages, sendMessage, listMessageTemplates, postInternalNote } = await import('../lib/podium.js');
+const { buildConversationIdentity, identityMatchesSearch } = await import('../lib/podiumContact.js');
 const inboxHandler = (await import('../lib/podiumRoutes/inbox.js')).default;
 
 let passed = 0;
@@ -398,6 +399,53 @@ console.log('\nF13 multi-assignee:');
   const res = makeRes();
   await inboxHandler(makeReq({ roles: ['technician'], query: { resource: 'reps' } }), res);
   check('reps: 403 for a non-sales role', res.statusCode === 403);
+}
+
+// ---- F14 conversation search: identity resolution + free-text matcher --------
+console.log('\nF14 conversation search:');
+{
+  // Pure matcher — name / email / phone (partial + full cross-format) / handle / empty.
+  const maria = {
+    contactName: 'Maria Papadopoulos', customerName: null, email: 'maria@example.com',
+    phone: '+61400111222', displayName: 'Maria Papadopoulos', matchedBy: 'none',
+  };
+  const convPhone = { channel: { type: 'phone', identifier: '+61400111222' } };
+  const convIg = { channel: { type: 'instagram', identifier: 'ig:graysfitness' } };
+  check('search: empty/whitespace term matches everything', identityMatchesSearch(maria, convPhone, '   ') === true);
+  check('search: name substring (case-insensitive)', identityMatchesSearch(maria, convPhone, 'MARia') === true);
+  check('search: surname substring', identityMatchesSearch(maria, convPhone, 'papado') === true);
+  check('search: email substring', identityMatchesSearch(maria, convPhone, 'maria@example') === true);
+  check('search: phone prefix in stored form', identityMatchesSearch(maria, convPhone, '400111') === true);
+  check('search: full phone typed local 04xx matches +61 stored (last-8)', identityMatchesSearch(maria, convPhone, '0400 111 222') === true);
+  check('search: non-matching text rejected', identityMatchesSearch(maria, convPhone, 'zzzznope') === false);
+  check('search: wrong number rejected', identityMatchesSearch(maria, convPhone, '999888') === false);
+  check('search: social handle matched via channel identifier', identityMatchesSearch({ displayName: null }, convIg, 'graysfitness') === true);
+}
+{
+  // buildConversationIdentity resolves the Podium contact (mock); no portal customer match.
+  const convs = (await listConversations('AM', { limit: 100 })).data;
+  const c1 = convs.find((c) => c.uid === 'pod_cnv_00001');
+  const client = makeClient(); // every customer query returns 0 rows → matchedBy 'none'
+  const id = await buildConversationIdentity(client, 'AM', c1);
+  check('identity: contact name resolved from Podium (mock)', id.contactName === 'Maria Papadopoulos');
+  check('identity: displayName falls back to the contact name', id.displayName === 'Maria Papadopoulos');
+  check('identity: no portal match → matchedBy none', id.matchedBy === 'none');
+  check('identity: resolved contact phone drives phone search', identityMatchesSearch(id, c1, '400111') === true);
+}
+{
+  // buildConversationIdentity with a portal customer matched on podium_contact_id.
+  const convs = (await listConversations('AM', { limit: 100 })).data;
+  const c1 = convs.find((c) => c.uid === 'pod_cnv_00001');
+  const client = makeClient([
+    {
+      match: (sql) => /podium_contact_id = \$1/.test(sql),
+      result: { rowCount: 1, rows: [{ id: 42, name: 'Maria P (portal)', email: 'maria@example.com', phone: '0400111222' }] },
+    },
+  ]);
+  const id = await buildConversationIdentity(client, 'AM', c1);
+  check('identity: portal customer matched on podium_contact_id', id.matchedBy === 'podium_contact_id');
+  check('identity: customerName preferred for the display name', id.displayName === 'Maria P (portal)' && id.customerName === 'Maria P (portal)');
+  check('identity: search matches the matched portal customer name', identityMatchesSearch(id, c1, 'portal') === true);
 }
 
 console.log(`\n✅ inbox smoke: ${passed} checks passed`);

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -138,6 +138,12 @@ export default function Inbox() {
   const [mock, setMock] = useState(false);
   const [loadingConvos, setLoadingConvos] = useState(true);
 
+  // F14 — conversation search (by customer name / phone / email, via the F4 bridge).
+  // `searchInput` is the live box; `search` is the debounced value used for the fetch.
+  const [searchInput, setSearchInput] = useState('');
+  const [search, setSearch] = useState('');
+  const [searchTruncated, setSearchTruncated] = useState(false);
+
   const [selectedId, setSelectedId] = useState(null);
   const [selectedConv, setSelectedConv] = useState(null);
   const [messages, setMessages] = useState([]);
@@ -207,8 +213,9 @@ export default function Inbox() {
   const loadConversations = useCallback(async ({ silent = false } = {}) => {
     if (!silent) setLoadingConvos(true);
     try {
+      const q = search ? `&search=${encodeURIComponent(search)}` : '';
       const res = await fetch(
-        `/api/podium/inbox?resource=conversations&bucket=${bucket}&status=${status}&limit=30`,
+        `/api/podium/inbox?resource=conversations&bucket=${bucket}&status=${status}${q}&limit=30`,
         { headers: authHeaders() },
       );
       if (res.status === 401) { navigate('/'); return; }
@@ -220,6 +227,7 @@ export default function Inbox() {
       }
       setConversations(Array.isArray(data?.data) ? data.data : []);
       setNotLinked(!!data?.notLinked);
+      setSearchTruncated(!!data?.searchTruncated);
       setMock(!!data?.mock);
       sinceRef.current = new Date().toISOString();
     } catch {
@@ -227,7 +235,7 @@ export default function Inbox() {
     } finally {
       if (!silent) setLoadingConvos(false);
     }
-  }, [bucket, status, navigate]);
+  }, [bucket, status, search, navigate]);
 
   const loadThread = useCallback(async (convId, { silent = false } = {}) => {
     if (!convId) return;
@@ -314,7 +322,14 @@ export default function Inbox() {
     loadLeadHistory(panel?.lead?.lead_id || null);
   }, [panel, loadLeadHistory]);
 
-  // Load (and reload on scope change) once authorized.
+  // F14 — debounce the search box (300 ms) before it drives the list fetch.
+  useEffect(() => {
+    const t = setTimeout(() => setSearch(searchInput.trim()), 300);
+    return () => clearTimeout(t);
+  }, [searchInput]);
+
+  // Load (and reload on scope/search change) once authorized. loadConversations depends
+  // on bucket/status/search, so this re-runs whenever any of them changes.
   useEffect(() => {
     if (authorized) loadConversations();
   }, [authorized, loadConversations]);
@@ -844,6 +859,34 @@ export default function Inbox() {
           <div className="bg-white rounded-lg shadow-md flex flex-col md:flex-row overflow-hidden" style={{ height: 'calc(100vh - 8rem)' }}>
             {/* Conversation list */}
             <aside className={`md:w-72 border-b md:border-b-0 md:border-r border-gray-200 flex flex-col ${selectedId ? 'hidden md:flex' : 'flex'}`}>
+              {/* F14 — search the list by customer name / phone / email (F4 bridge). */}
+              <div className="p-2 border-b border-gray-200">
+                <div className="relative">
+                  <input
+                    type="text"
+                    value={searchInput}
+                    onChange={(e) => setSearchInput(e.target.value)}
+                    placeholder="Search name, phone or email…"
+                    aria-label="Search conversations"
+                    className="w-full text-sm border border-gray-300 rounded-md pl-3 pr-8 py-1.5 focus:outline-none focus:ring-2 focus:ring-blue-400"
+                  />
+                  {searchInput && (
+                    <button
+                      type="button"
+                      onClick={() => setSearchInput('')}
+                      aria-label="Clear search"
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                    >
+                      ×
+                    </button>
+                  )}
+                </div>
+                {search && searchTruncated && (
+                  <p className="mt-1 text-[11px] text-amber-700">
+                    Showing matches from the first 100 conversations — narrow your search if needed.
+                  </p>
+                )}
+              </div>
               <div className="flex-1 overflow-y-auto">
                 {loadingConvos && (
                   <div className="p-4 text-sm text-gray-500">Loading conversations…</div>
@@ -871,7 +914,9 @@ export default function Inbox() {
 
                 {!loadingConvos && !notLinked && conversations.length === 0 && (
                   <div className="p-4 text-sm text-gray-500">
-                    No {status} conversations{bucket === 'mine' ? ' assigned to you' : bucket === 'unassigned' ? ' unassigned' : ''}.
+                    {search
+                      ? <>No conversations match “{search}”.</>
+                      : <>No {status} conversations{bucket === 'mine' ? ' assigned to you' : bucket === 'unassigned' ? ' unassigned' : ''}.</>}
                   </div>
                 )}
 
@@ -886,7 +931,7 @@ export default function Inbox() {
                       className={`w-full text-left px-4 py-3 border-b border-gray-100 hover:bg-gray-50 ${active ? 'bg-blue-50' : ''}`}
                     >
                       <div className="flex items-center justify-between gap-2">
-                        <span className="font-medium text-sm text-gray-900 truncate">{convTitle(c)}</span>
+                        <span className="font-medium text-sm text-gray-900 truncate">{c.identity?.displayName || convTitle(c)}</span>
                         <ChannelBadge type={c?.channel?.type} />
                       </div>
                       <div className="flex items-center justify-between gap-2 mt-1">


### PR DESCRIPTION
## F14 — Conversation search

Filter the inbox conversation list by the **customer behind each conversation** — **name, phone, or email** — resolved through the **F4 contact↔customer bridge**. From Nick's inbox feedback (backlog F14).

**Mock-first** (`PODIUM_MOCK=true`) · **no migration** · **no new serverless function** (extends the inbox dispatcher, stays `nodejs:3`).

### What changed
- **`lib/podiumContact.js`** — `buildConversationIdentity()` resolves a conversation's Podium contact (name/phone/email) **and** matches the portal customer (via the existing F4 `matchCustomer`); `identityMatchesSearch()` is a pure free-text matcher (name/email/handle substring; loose phone match — prefix in stored form + last-8 cross-format so `0400 111 222` matches `+61400111222`). Reads CRM metadata only — **no message bodies (P1)**.
- **`lib/podiumRoutes/inbox.js`** — `GET ?resource=conversations&search=` scans the top page (≤100) of the current bucket/status, enriches each row via the bridge, filters, and returns the resolved `identity` on each row plus a `searchTruncated` flag.
- **`src/pages/inbox.js`** — a debounced (300 ms) search box above the conversation list; result rows show the **resolved display name** instead of a bare phone number; search-aware empty state; a truncation note for very large inboxes.
- **`scripts/podium-inbox-smoke.mjs`** — +16 F14 checks (**101** total).

### Migration
**None.** Pure read/search over existing tables; `matchCustomer`'s SQL is reused unchanged from F4. No prod DB changes.

### How to test (on the Preview, signed into the Grays Support Vercel team)
1. Go to **/inbox** as a `sales`/`superadmin` user.
2. In the **search box**, type `Maria` → the list filters to Maria's conversations (name resolved from the Podium contact).
3. Switch to **All / Open** and search `Jake` → conversation `00005` surfaces showing **"Jake Wilson"** — this one is matched to a real portal customer (dev #555, bridged on `podium_contact_id`), demonstrating the F4-bridge customer match end-to-end.
4. Try a phone search: `0400 111 222` (or partial `400111`) → Maria's SMS thread matches.
5. Try an email: `jakew@example.com` → Jake surfaces.
6. Clear the box (×) → the full bucket list returns.
7. Search something absent (`zzz`) → **"No conversations match …"**.

### Reviewer checklist
- [x] Search filters by name / phone / email; result rows show a real name
- [x] Jake (`00005`) shows the matched **portal customer** name (F4 bridge)
- [x] Clearing search restores the list; bucket/status filters still work
- [x] No chat bodies persisted (P1); no migration; no new function; no secrets
- [x] Approve & merge, **or** leave feedback

**VERIFY at live wiring:** whether Podium exposes a native conversation-search param (would replace the client-side scan+filter, removing the 100-row scan cap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
