### PR TITLE
F15 — In-inbox product price/stock widget

### DIFF
--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -1679,12 +1679,16 @@ function WorkorderModal({ workorderId, detail, loading, onClose }) {
 const PRODUCT_RESULT_CAP = 60; // render at most this many matches (the table has ~1,000 rows)
 
 function ProductLookupModal({ products, loaded, search, setSearch, onClose }) {
-  const term = String(search || '').trim().toLowerCase();
+  // Token-based, order-independent match — mirrors the product page's search
+  // (src/pages/products/index.js): split on spaces, every keyword must appear
+  // somewhere in "sku name brand" so "Life Treadmill SE3 HD" matches
+  // "Life Fitness 95T Treadmill with Discover SE3 HD console".
+  const keywords = String(search || '').toLowerCase().split(' ').filter(Boolean);
   const all = Array.isArray(products) ? products : [];
-  const matches = term
+  const matches = keywords.length
     ? all.filter((p) => {
-        const hay = `${p.name || ''} ${p.brand || ''} ${p.sku || ''}`.toLowerCase();
-        return hay.includes(term);
+        const hay = `${p.sku || ''} ${p.name || ''} ${p.brand || ''}`.toLowerCase();
+        return keywords.every((kw) => hay.includes(kw));
       })
     : all;
   const shown = matches.slice(0, PRODUCT_RESULT_CAP);

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -160,6 +160,14 @@ export default function Inbox() {
   const fileInputRef = useRef(null);
   const attachmentsRef = useRef([]); // latest attachments, for object-URL cleanup on unmount
 
+  // F15 — product price/stock widget. The list is fetched ONCE when the Inbox opens
+  // and cached client-side (Nick's feedback), then filtered in the browser. Retail
+  // price + stock only — no x-user-access header is sent, so avg_cost is never returned.
+  const [products, setProducts] = useState([]);
+  const [productsLoaded, setProductsLoaded] = useState(false);
+  const [showProducts, setShowProducts] = useState(false);
+  const [productSearch, setProductSearch] = useState('');
+
   // F4 incr 2 — customer side panel state.
   const [panel, setPanel] = useState(null);
   const [panelLoading, setPanelLoading] = useState(false);
@@ -350,6 +358,19 @@ export default function Inbox() {
       .then((r) => (r.ok ? parseMaybeJson(r) : null))
       .then((d) => { if (Array.isArray(d?.reps)) setReps(d.reps); })
       .catch(() => { /* reps list is best-effort */ });
+  }, [authorized]);
+
+  // F15 — fetch the product price/stock list ONCE and cache it (Nick's feedback:
+  // "fetch once when the Inbox opens"). Reuses the existing GET /api/products case
+  // (a bare array of {sku, brand, name, stock, price}); no x-user-access header is
+  // sent, so a sales rep never receives avg_cost. Filtering is done in the browser.
+  useEffect(() => {
+    if (!authorized) return;
+    fetch('/api/products', { headers: authHeaders() })
+      .then((r) => (r.ok ? parseMaybeJson(r) : null))
+      .then((d) => { if (Array.isArray(d)) setProducts(d); })
+      .catch(() => { /* product list is best-effort */ })
+      .finally(() => setProductsLoaded(true));
   }, [authorized]);
 
   // F12 — keep the latest attachments in a ref and revoke their object URLs on unmount
@@ -853,6 +874,15 @@ export default function Inbox() {
                   </button>
                 ))}
               </div>
+              {/* F15 — in-inbox product price/stock lookup (list cached client-side). */}
+              <button
+                type="button"
+                onClick={() => setShowProducts(true)}
+                className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-gray-300 bg-white text-sm text-gray-700 hover:bg-gray-50"
+                title="Look up product price and stock"
+              >
+                <span aria-hidden="true">🔍</span> Price &amp; stock
+              </button>
             </div>
           </div>
 
@@ -1208,6 +1238,17 @@ export default function Inbox() {
           detail={woDetail}
           loading={woLoading}
           onClose={closeWorkorder}
+        />
+      )}
+
+      {/* F15 — product price/stock lookup modal (uses the client-cached product list). */}
+      {showProducts && (
+        <ProductLookupModal
+          products={products}
+          loaded={productsLoaded}
+          search={productSearch}
+          setSearch={setProductSearch}
+          onClose={() => setShowProducts(false)}
         />
       )}
     </>
@@ -1626,6 +1667,100 @@ function WorkorderModal({ workorderId, detail, loading, onClose }) {
             </>
           )}
         </div>
+      </div>
+    </div>
+  );
+}
+
+// ---- Product price/stock lookup (F15) ------------------------------------------
+// A read-only in-inbox widget so a rep can quote price + stock without leaving the
+// chat. The product list is fetched once (client-cached) by the Inbox and passed in;
+// this modal only filters it in the browser. Retail price + stock only — no cost.
+const PRODUCT_RESULT_CAP = 60; // render at most this many matches (the table has ~1,000 rows)
+
+function ProductLookupModal({ products, loaded, search, setSearch, onClose }) {
+  const term = String(search || '').trim().toLowerCase();
+  const all = Array.isArray(products) ? products : [];
+  const matches = term
+    ? all.filter((p) => {
+        const hay = `${p.name || ''} ${p.brand || ''} ${p.sku || ''}`.toLowerCase();
+        return hay.includes(term);
+      })
+    : all;
+  const shown = matches.slice(0, PRODUCT_RESULT_CAP);
+
+  return (
+    <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4" onClick={onClose}>
+      <div
+        className="bg-white rounded-lg shadow-lg w-full max-w-xl max-h-[85vh] flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <header className="flex items-center justify-between px-5 py-3 border-b border-gray-200">
+          <h2 className="text-lg font-bold">Product price &amp; stock</h2>
+          <button type="button" onClick={onClose} className="text-gray-400 hover:text-gray-700 text-xl leading-none" aria-label="Close">×</button>
+        </header>
+
+        <div className="px-5 pt-4">
+          <input
+            type="text"
+            autoFocus
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder="Search by product, brand or SKU…"
+            aria-label="Search products"
+            className="w-full text-sm border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+          />
+        </div>
+
+        <div className="flex-1 overflow-y-auto px-5 py-3">
+          {!loaded && <div className="text-sm text-gray-500">Loading products…</div>}
+
+          {loaded && all.length === 0 && (
+            <div className="text-sm text-gray-400">Product list unavailable.</div>
+          )}
+
+          {loaded && all.length > 0 && matches.length === 0 && (
+            <div className="text-sm text-gray-500">No products match “{search.trim()}”.</div>
+          )}
+
+          {loaded && shown.length > 0 && (
+            <ul className="divide-y divide-gray-100 border border-gray-200 rounded-lg">
+              {shown.map((p) => {
+                const inStock = Number(p.stock) > 0;
+                return (
+                  <li key={p.sku} className="flex items-center justify-between gap-3 px-3 py-2">
+                    <div className="min-w-0">
+                      <div className="font-medium text-gray-900 truncate">{p.name || p.sku}</div>
+                      <div className="text-xs text-gray-500 truncate">
+                        {[p.brand, p.sku].filter(Boolean).join(' · ')}
+                      </div>
+                    </div>
+                    <div className="text-right shrink-0">
+                      <div className="font-semibold text-gray-900">{money(p.price) ?? '—'}</div>
+                      <span
+                        className={`inline-block text-[11px] font-semibold px-2 py-0.5 rounded-full ${
+                          inStock ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-700'
+                        }`}
+                      >
+                        {inStock ? `In stock: ${p.stock}` : 'Out of stock'}
+                      </span>
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+
+          {loaded && matches.length > shown.length && (
+            <p className="mt-2 text-[11px] text-gray-500">
+              Showing the first {shown.length} of {matches.length} matches — refine your search to narrow it.
+            </p>
+          )}
+        </div>
+
+        <footer className="px-5 py-2 border-t border-gray-200 text-[11px] text-gray-400">
+          Retail price and current stock. Loaded once when the Inbox opened.
+        </footer>
       </div>
     </div>
   );


### PR DESCRIPTION
## F15 — Product price/stock widget (Nick's 6 Jul feedback)

Adds an in-inbox **Price & stock** lookup so a salesperson can quote a customer without leaving the chat.

### What it does
- A **"🔍 Price & stock"** button in the Inbox header opens a search modal.
- The product list is **fetched once** when the Inbox opens and **cached client-side** (exactly as Nick requested); typing filters it in the browser by **product name / brand / SKU**.
- Each row shows the **retail price (AUD)** and **stock** (green "In stock: N" / grey "Out of stock").

### Scope / how it's built
- **Reuses the existing `GET /api/products`** case (a bare array of `{sku, brand, name, stock, price}`) — **no new serverless function**, so the deployment stays at `nodejs:3` (well under the Hobby 12-fn cap). Same reuse pattern as F17 (which reused `GET /api/workorder`).
- **Cost-safe:** the widget sends **no `x-user-access` header**, so `avg_cost` is never returned — a sales rep sees retail price + stock only.
- **Frontend-only**, one file: `src/pages/inbox.js`. **No migration.**
- Rendering is capped at 60 matches (the `product` table has ~1,006 rows) with a "refine your search" note.

### Migration
None.

### Feature flags / mocked
None. `/api/products` reads the **real** `product` table (already live on prod), so this works the same on Preview and Production — there is no mock path to swap later.

### Preview
See the Vercel Preview on this PR (latest build from `336755c`).

### Test steps
1. Open the Preview, log in as a **sales** (or superadmin) user, go to **/inbox**.
2. Click **🔍 Price & stock** in the header.
3. Type a product name, brand, or SKU — the list filters live. **Order-independent:** try `Life Treadmill SE3 HD` and confirm a "Life Fitness 95T Treadmill with Discover SE3 HD console" style row still matches (words can be in any order, like the product page's search).
4. Clear the box to see the full list (first 60 shown, with the "refine your search" note).
5. Close with **×** or by clicking the backdrop.
6. Confirm **no cost** figure appears anywhere in the widget.

### Reviewer checklist
- [x] Button appears in the Inbox header; modal opens/closes.
- [x] Search filters by name / brand / SKU; price + stock render correctly.
- [x] Search is order-independent (matches the product-page method).
- [x] No cost (`avg_cost`) is exposed to a sales user.
- [x] List is fetched once on Inbox open (Network tab: a single `/api/products` call), not per keystroke.
- [x] Build is green; deployment stays at 3 functions (no new `api/` file).

---

### Update — 13 Jul 2026 (folds F15 review feedback, commit `336755c`)
Nick's F15 report feedback: *"use the same search method that is in the product page, where it doesn't have to be in the exact order (e.g. Life Fitness 95T Treadmill with Discover SE3 HD console will come up when searching 'Life Treadmill SE3 HD')."*

Done. `ProductLookupModal` now uses the **exact token-based, order-independent match from `src/pages/products/index.js`**: the query is split on spaces and **every** keyword must be a substring of `"sku name brand"` (was a single whole-string `includes()`). Frontend-only, `src/pages/inbox.js` (+8/-4), no migration, still `nodejs:3`. Build green (`main.bfaff9af.js`, −4 B).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
