### PR TITLE
Fix workorder detail: product-search dropdown off-screen + cancel/edit wrong row

### DIFF
--- a/src/pages/delivery_operations/workorder/[id].js
+++ b/src/pages/delivery_operations/workorder/[id].js
@@ -154,7 +154,10 @@ function ProductSelect({ products, value, onChange, placeholder = 'Search SKU, n
     const onReflow = () => {
       if (!anchorRef.current) return;
       const r = anchorRef.current.getBoundingClientRect();
-      setMenuPos({ top: r.bottom + window.scrollY, left: r.left + window.scrollX, width: r.width });
+      // Menu is position:fixed (viewport-relative) — use raw getBoundingClientRect
+      // coords WITHOUT scroll offsets, or it drifts off-screen once the page is
+      // scrolled (e.g. a workorder with many items).
+      setMenuPos({ top: r.bottom, left: r.left, width: r.width });
     };
     document.addEventListener('mousedown', onDoc);
     window.addEventListener('keydown', onEsc);
@@ -171,7 +174,10 @@ function ProductSelect({ products, value, onChange, placeholder = 'Search SKU, n
   useEffect(() => {
     if (open && anchorRef.current) {
       const r = anchorRef.current.getBoundingClientRect();
-      setMenuPos({ top: r.bottom + window.scrollY, left: r.left + window.scrollX, width: r.width });
+      // Menu is position:fixed (viewport-relative) — use raw getBoundingClientRect
+      // coords WITHOUT scroll offsets, or it drifts off-screen once the page is
+      // scrolled (e.g. a workorder with many items).
+      setMenuPos({ top: r.bottom, left: r.left, width: r.width });
     }
   }, [open]);
 
@@ -516,13 +522,15 @@ export default function WorkorderDetailPage() {
     })();
   }, [id, navigate, userId]);
 
-  // Update local existing item field
-  const setItemField = (idx, key, val) => {
-    setItems((arr) => {
-      const copy = [...arr];
-      copy[idx] = { ...copy[idx], [key]: val };
-      return copy;
-    });
+  // Update local existing item field.
+  // Keyed by the stable workorder_items_id — NOT the render index, because the
+  // table renders `items.filter(status !== 'Canceled')`, so the rendered index
+  // diverges from the real array index as soon as any item is Canceled (which
+  // made edits/cancels land on the wrong row — the "every other item" bug).
+  const setItemField = (workorder_items_id, key, val) => {
+    setItems((arr) => arr.map((it) =>
+      it.workorder_items_id === workorder_items_id ? { ...it, [key]: val } : it
+    ));
   };
 
   // Update pending new item field
@@ -941,7 +949,7 @@ export default function WorkorderDetailPage() {
                             <select
                               className="border rounded px-2 py-1 w-full"
                               value={it.technician_id || ''}
-                              onChange={(e) => setItemField(idx, 'technician_id', e.target.value)}
+                              onChange={(e) => setItemField(it.workorder_items_id, 'technician_id', e.target.value)}
                             >
                               <option value="" disabled>Select tech</option>
                               {techs.map((t) => (
@@ -954,7 +962,7 @@ export default function WorkorderDetailPage() {
                             <select
                               className="border rounded px-2 py-1 w-full"
                               value={it.status}
-                              onChange={(e) => setItemField(idx, 'status', e.target.value)}
+                              onChange={(e) => setItemField(it.workorder_items_id, 'status', e.target.value)}
                             >
                               <option>Not in Workshop</option>
                               <option>In Workshop</option>
@@ -972,7 +980,7 @@ export default function WorkorderDetailPage() {
                                 className="border rounded px-2 py-1 w-full"
                                 value={it.selling_price ?? ''}
                                 placeholder="e.g. 199.00"
-                                onChange={(e) => setItemField(idx, 'selling_price', e.target.value)}
+                                onChange={(e) => setItemField(it.workorder_items_id, 'selling_price', e.target.value)}
                               />
                             </td>
                           )}
@@ -1000,7 +1008,7 @@ export default function WorkorderDetailPage() {
                                   className="border rounded px-2 py-1 w-full"
                                   value={it.item_sn ?? ''}
                                   placeholder="Machine base serial number, or a note"
-                                  onChange={(e) => setItemField(idx, 'item_sn', e.target.value)}
+                                  onChange={(e) => setItemField(it.workorder_items_id, 'item_sn', e.target.value)}
                                   onClick={stop}
                                 />
                                 <div className="text-xs text-gray-600 mt-2">


### PR DESCRIPTION
## Fix two workorder-detail bugs: product search "no results" + cancel/edit hitting the wrong row

Both are on `src/pages/delivery_operations/workorder/[id].js`. Frontend-only, no migration, no new function.

### Bug 1 — Add-product search shows no results when the workorder already has many items
**Cause:** the searchable product dropdown (`ProductSelect`) renders its menu with `position: fixed` (viewport-relative), but computed its coordinates as `getBoundingClientRect().bottom + window.scrollY` / `.left + window.scrollX`. On a short workorder `scrollY ≈ 0` so it looked fine; on a workorder with many items the page is scrolled down, so the menu was pushed **off-screen below the viewport**. The matches were being computed correctly — you just couldn't see the dropdown, so it read as "no results".
**Fix:** for a `fixed` menu, use the raw `getBoundingClientRect()` coords with **no scroll offset**.
**Note on the API:** `/api/products` returns the full catalogue (`SELECT sku, brand, name, stock, price FROM product`, no `LIMIT`), so the API was not the cause.

### Bug 2 — Cancelling/editing items only affects "every other item"
**Cause:** the item rows are rendered from `items.filter(it => it.status !== 'Canceled').map((it, idx) => …)`, so `idx` is the **filtered** position. But `setItemField(idx, …)` wrote `items[idx]` on the **full** array. As soon as one item is set to Canceled it drops out of the filtered list, the two index spaces diverge, and every subsequent status/technician/price/serial change lands on the **wrong row** — so you can't cancel them all.
**Fix:** key `setItemField` by the stable `workorder_items_id` instead of the render index; all 4 call sites (status, technician, selling price, serial) updated. (The separate **Remove** button already used the id and was fine.)

### Test steps
1. Open a workorder that has **many** line items (enough that the page scrolls).
2. Scroll down, click **+ Add Product**, and type in the SKU/name box → confirm the dropdown now appears **right under the field** with results (previously blank).
3. In the item table, set several items' **Status → Canceled** one after another (or change Technician/Status on various rows) → confirm the change always applies to the **row you clicked**, and you can Cancel **all** items, not every other one.
4. Sanity-check the **Remove** button and **Save** still behave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
