### PR TITLE
F6 — Customer-360 + unified journey (Podium/CRM)

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -13,6 +13,7 @@ import collectionsHandler from '../lib/handlers/collections.js';
 import winningsHandler from '../lib/handlers/winnings.js';
 import leadsHandler from '../lib/handlers/leads.js';
 import lotsHandler from '../lib/handlers/lots.js';
+import { buildJourney } from '../lib/customerJourney.js';
 
 /** Robust path segmentation that works on Vercel + Next.js local */
 function segs(req) {
@@ -42,10 +43,12 @@ export default async function handler(req, res) {
       case undefined:
         return res.status(200).json({ ok: true, message: 'API root' });
 
-      // Primary routes + aliases so old front-end calls still work
+      // Primary routes + aliases so old front-end calls still work.
+      // Pass the segments AFTER "customers" so /api/customers/:id/journey (F6) parses
+      // (this catch-all otherwise only destructures [root, sub]).
       case 'customers':
       case 'customer':
-        return handleCustomers(req, res, sub);
+        return handleCustomers(req, res, parts.slice(1));
 
       case 'products':
       case 'product':
@@ -110,7 +113,22 @@ export default async function handler(req, res) {
 }
 
 /* ---------- CUSTOMERS ---------- */
-async function handleCustomers(req, res, subId) {
+// `rest` = path segments after "customers" (e.g. ['26'] or ['26','journey'] for F6).
+async function handleCustomers(req, res, rest = []) {
+  const [subId, subResource] = Array.isArray(rest) ? rest : [rest];
+
+  // F6 — Customer-360 unified journey: GET /api/customers/:id/journey.
+  // Merges lead_stage_log ∪ workorder_logs (+ delivery records) into one timeline.
+  // Read-only; sits in the general customers area (same access level as the other
+  // customer reads — F9 will formalise nav gating). No message bodies touched (P1 n/a).
+  if (subResource === 'journey') {
+    if (req.method !== 'GET') return methodNotAllowed(res, ['GET']);
+    if (!subId) return res.status(400).json({ error: 'Missing customer ID' });
+    const result = await buildJourney(subId);
+    if (!result) return res.status(404).json({ error: 'Customer not found' });
+    return res.status(200).json(result);
+  }
+
   const client = await getClientWithTimezone();
   try {
     const { method, query, body } = req;

--- a/api/[...path].js
+++ b/api/[...path].js
@@ -117,14 +117,20 @@ export default async function handler(req, res) {
 async function handleCustomers(req, res, rest = []) {
   const [subId, subResource] = Array.isArray(rest) ? rest : [rest];
 
-  // F6 — Customer-360 unified journey: GET /api/customers/:id/journey.
+  // F6 — Customer-360 unified journey. Reachable as BOTH the REST path
+  // (GET /api/customers/:id/journey) and the query form the rest of the app uses
+  // (GET /api/customers?id=:id&resource=journey) — the query form is the proven-safe
+  // convention across this app (edit page, workorder modal, inbox all use ?id=), so the
+  // front-end calls that and we don't depend on 3-segment path routing on Vercel.
   // Merges lead_stage_log ∪ workorder_logs (+ delivery records) into one timeline.
   // Read-only; sits in the general customers area (same access level as the other
   // customer reads — F9 will formalise nav gating). No message bodies touched (P1 n/a).
-  if (subResource === 'journey') {
+  const wantsJourney = subResource === 'journey' || String(req.query?.resource || '') === 'journey';
+  if (wantsJourney) {
     if (req.method !== 'GET') return methodNotAllowed(res, ['GET']);
-    if (!subId) return res.status(400).json({ error: 'Missing customer ID' });
-    const result = await buildJourney(subId);
+    const cid = subId ?? req.query?.id;
+    if (!cid) return res.status(400).json({ error: 'Missing customer ID' });
+    const result = await buildJourney(cid);
     if (!result) return res.status(404).json({ error: 'Customer not found' });
     return res.status(200).json(result);
   }

--- a/lib/customerJourney.js
+++ b/lib/customerJourney.js
@@ -1,0 +1,163 @@
+// lib/customerJourney.js — Customer-360 unified journey (feature F6).
+//
+// Merges a customer's front-half funnel and back-half fulfilment history into ONE
+// chronological timeline that reads
+//   Lead → Contacted → Quoted → Payment → Workorder → In Workshop → Completed → Booked → Delivered
+// by UNION-ing three append-only / record sources:
+//   1. lead_stage_log  — the F5 funnel (the NULL→New row IS "lead created", so we don't
+//      synthesize a separate created event).
+//   2. workorder + workorder_logs — the existing back-half audit trail. The WORKORDER_CREATED
+//      log row is excluded and re-synthesized from the workorder row so every workorder
+//      anchors exactly once with its invoice/status; the delivery lifecycle
+//      (DELIVERY_ORDER_CREATED / DELIVERY_BOOKED / ORDER_DISPATCHED) already lives here.
+//   3. delivery — the concrete booking record (scheduled date / suburb / status).
+//
+// Read-only. Touches no chat message bodies (P1 is not in scope — these are internal
+// CRM/ops logs only). Consumed by the `journey` sub-resource of the customers route in
+// api/[...path].js (Hobby-cap discipline: NO new serverless function).
+
+import { getClientWithTimezone } from './db.js';
+
+// One query, common shape, oldest → newest. `to_val` carries the meaningful state for the
+// row (lead stage / item status / workorder status / delivery status); `note` carries the
+// free-text / structured detail. `actor` is the acting user's 2-char id, joined to a name.
+const JOURNEY_SQL = `
+WITH ev AS (
+  -- 1. Lead funnel (lead_stage_log; NULL→stage = created)
+  SELECT lsl.created_at            AS event_time,
+         'lead'::text              AS category,
+         CASE WHEN lsl.from_stage IS NULL THEN 'LEAD_CREATED' ELSE 'LEAD_STAGE' END AS code,
+         lsl.from_stage::text      AS from_val,
+         lsl.to_stage::text        AS to_val,
+         lsl.notes_log             AS note,
+         lsl.user_id               AS actor,
+         'lead'::text              AS ref_type,
+         lsl.lead_id               AS ref_id
+    FROM lead_stage_log lsl
+    JOIN leads l ON l.lead_id = lsl.lead_id
+   WHERE l.customer_id = $1
+
+  UNION ALL
+  -- 2a. Workorder created (synthesized from the row; matching log row excluded below)
+  SELECT w.date_created, 'workorder',
+         'WORKORDER_CREATED', NULL, w.status::text,
+         CONCAT_WS(' · ', 'Invoice ' || w.invoice_id, NULLIF(w.delivery_suburb, '')),
+         w.salesperson, 'workorder', w.workorder_id
+    FROM workorder w
+   WHERE w.customer_id = $1
+
+  UNION ALL
+  -- 2b. Workorder + delivery lifecycle log (append-only), minus the created row
+  SELECT wl.created_at, 'workorder',
+         wl.event_type::text, NULL, wl.item_status::text,
+         wl.notes_log, wl.user_id, 'workorder', wl.workorder_id
+    FROM workorder_logs wl
+    JOIN workorder w2 ON w2.workorder_id = wl.workorder_id
+   WHERE w2.customer_id = $1
+     AND wl.event_type <> 'WORKORDER_CREATED'
+
+  UNION ALL
+  -- 3. Delivery record (concrete booking: scheduled date / suburb / current status)
+  SELECT d.date_created, 'delivery',
+         'DELIVERY_RECORD', NULL, d.delivery_status::text,
+         CONCAT_WS(' · ',
+           CASE WHEN d.delivery_date IS NOT NULL
+                THEN 'Booked ' || to_char(d.delivery_date, 'DD Mon YYYY') END,
+           NULLIF(d.delivery_suburb, '')),
+         NULL, 'delivery', d.delivery_id
+    FROM delivery d
+   WHERE d.customer_id = $1
+)
+SELECT ev.event_time, ev.category, ev.code, ev.from_val, ev.to_val, ev.note,
+       ev.actor, ev.ref_type, ev.ref_id, u.name AS actor_name
+  FROM ev
+  LEFT JOIN users u ON u.id = ev.actor
+ ORDER BY ev.event_time ASC NULLS LAST, ev.ref_type, ev.ref_id;
+`;
+
+// Human-readable titles for the back-half workorder_log_event codes.
+const WO_EVENT_LABELS = {
+  WORKORDER_CREATED: 'Workorder created',
+  WORKORDER_STATUS_CHANGED: 'Workorder status changed',
+  ITEM_IN_WORKSHOP: 'Item moved to workshop',
+  ITEM_STATUS_CHANGED: 'Item status changed',
+  ITEM_COMPLETED: 'Item completed',
+  WORKORDER_COMPLETED: 'Workorder completed',
+  DELIVERY_ORDER_CREATED: 'Delivery order created',
+  DELIVERY_BOOKED: 'Delivery booked',
+  ORDER_DISPATCHED: 'Order dispatched',
+  PAYMENT_UPDATED: 'Payment updated',
+  NOTE_ADDED: 'Note added',
+  ITEM_ADDED: 'Item added',
+  ITEM_REMOVED: 'Item removed',
+  WORKORDER_FLAG_CHANGED: 'Flag changed',
+  WORKORDER_REOPENED: 'Workorder reopened',
+};
+
+/**
+ * Turn a raw union row into a normalized timeline event {title, detail, ...}.
+ * Pure — no I/O — so it is unit-testable offline (scripts/podium-journey-smoke.mjs).
+ */
+export function labelEvent(row) {
+  const { category, code, from_val: fromVal, to_val: toVal, note } = row;
+  const detailParts = [];
+  let title;
+
+  if (category === 'lead') {
+    if (code === 'LEAD_CREATED') {
+      title = `Lead created — ${toVal || 'New'}`;
+    } else {
+      title = `${fromVal || '—'} → ${toVal || '—'}`;
+    }
+    if (note) detailParts.push(note);
+  } else if (category === 'delivery') {
+    title = `Delivery — ${toVal || 'record'}`;
+    if (note) detailParts.push(note);
+  } else {
+    // workorder
+    title = WO_EVENT_LABELS[code] || code;
+    if (code === 'WORKORDER_CREATED') {
+      if (toVal) detailParts.push(`Status: ${toVal}`);
+    } else if (toVal) {
+      detailParts.push(toVal); // item status for item-level events
+    }
+    if (note) detailParts.push(note);
+  }
+
+  return {
+    event_time: row.event_time,
+    category,
+    code,
+    ref_type: row.ref_type,
+    ref_id: row.ref_id,
+    title,
+    detail: detailParts.filter(Boolean).join(' · ') || null,
+    actor: row.actor || null,
+    actor_name: row.actor_name || null,
+  };
+}
+
+/**
+ * Build the Customer-360 journey for a customer.
+ * @returns {Promise<null | { customer, events }>}  null when the customer doesn't exist.
+ * `deps.getClient` lets the offline smoke inject a fake pg client (default = real pool).
+ */
+export async function buildJourney(customerId, deps = {}) {
+  const getClient = deps.getClient || getClientWithTimezone;
+  const client = await getClient();
+  try {
+    const c = await client.query(
+      `SELECT id, name, email, phone, address, customer_type, podium_contact_id
+         FROM customers WHERE id = $1`,
+      [customerId]
+    );
+    if (!c.rowCount) return null;
+    const r = await client.query(JOURNEY_SQL, [customerId]);
+    return { customer: c.rows[0], events: (r.rows || []).map(labelEvent) };
+  } finally {
+    client.release();
+  }
+}
+
+// Exported for the offline smoke to assert the SQL shape without hitting a DB.
+export const __JOURNEY_SQL = JOURNEY_SQL;

--- a/scripts/podium-journey-smoke.mjs
+++ b/scripts/podium-journey-smoke.mjs
@@ -1,0 +1,96 @@
+// scripts/podium-journey-smoke.mjs — offline checks for the Customer-360 journey (F6).
+//
+// No DB, no network: exercises the pure labelEvent mapping and buildJourney's merge/shape
+// via an injected fake pg client. Run: `node scripts/podium-journey-smoke.mjs`.
+
+import { labelEvent, buildJourney, __JOURNEY_SQL } from '../lib/customerJourney.js';
+
+let pass = 0, fail = 0;
+function ok(cond, msg) {
+  if (cond) { pass++; } else { fail++; console.error('  ✗', msg); }
+}
+
+// ---- 1. labelEvent: lead created (NULL→New) -------------------------------------------
+{
+  const e = labelEvent({ event_time: '2026-07-01T00:00:00Z', category: 'lead', code: 'LEAD_CREATED',
+    from_val: null, to_val: 'New', note: 'Added to funnel from inbox', actor: 'GA', ref_type: 'lead', ref_id: 3, actor_name: 'Grace' });
+  ok(e.title === 'Lead created — New', 'lead created title');
+  ok(e.detail === 'Added to funnel from inbox', 'lead created detail = note');
+  ok(e.category === 'lead' && e.ref_id === 3, 'lead created passthrough');
+  ok(e.actor_name === 'Grace', 'actor_name preserved');
+}
+
+// ---- 2. labelEvent: lead stage transition ---------------------------------------------
+{
+  const e = labelEvent({ category: 'lead', code: 'LEAD_STAGE', from_val: 'Contacted', to_val: 'Quoted', note: null, ref_type: 'lead', ref_id: 3 });
+  ok(e.title === 'Contacted → Quoted', 'stage transition title');
+  ok(e.detail === null, 'stage transition no note → null detail');
+}
+
+// ---- 3. labelEvent: workorder created (status in detail) ------------------------------
+{
+  const e = labelEvent({ category: 'workorder', code: 'WORKORDER_CREATED', from_val: null, to_val: 'Work Ordered',
+    note: 'Invoice INV-1001 · Altona', actor: 'BR', ref_type: 'workorder', ref_id: 42 });
+  ok(e.title === 'Workorder created', 'WO created title');
+  ok(e.detail === 'Status: Work Ordered · Invoice INV-1001 · Altona', 'WO created detail combines status + note');
+}
+
+// ---- 4. labelEvent: item + delivery events -------------------------------------------
+{
+  const item = labelEvent({ category: 'workorder', code: 'ITEM_IN_WORKSHOP', to_val: 'In Workshop', note: 'Treadmill', ref_type: 'workorder', ref_id: 42 });
+  ok(item.title === 'Item moved to workshop', 'item-in-workshop title');
+  ok(item.detail === 'In Workshop · Treadmill', 'item status + note detail');
+
+  const del = labelEvent({ category: 'delivery', code: 'DELIVERY_RECORD', to_val: 'Booked for Delivery', note: 'Booked 12 Jul 2026 · Richmond', ref_type: 'delivery', ref_id: 7 });
+  ok(del.title === 'Delivery — Booked for Delivery', 'delivery title uses status');
+  ok(del.detail === 'Booked 12 Jul 2026 · Richmond', 'delivery detail = note');
+
+  const unknown = labelEvent({ category: 'workorder', code: 'SOMETHING_NEW', to_val: null, note: null, ref_type: 'workorder', ref_id: 9 });
+  ok(unknown.title === 'SOMETHING_NEW', 'unknown code falls back to raw code');
+}
+
+// ---- 5. buildJourney: merge + shape via a fake client --------------------------------
+{
+  const custRow = { id: 26, name: 'Adhal Iqbal', email: 'a@x.com', phone: '0400000000', address: 'Altona', customer_type: 'Individual', podium_contact_id: null };
+  const unionRows = [
+    { event_time: '2026-07-01T00:00:00Z', category: 'lead', code: 'LEAD_CREATED', from_val: null, to_val: 'New', note: null, actor: 'GA', ref_type: 'lead', ref_id: 3, actor_name: 'Grace' },
+    { event_time: '2026-07-03T00:00:00Z', category: 'workorder', code: 'WORKORDER_CREATED', from_val: null, to_val: 'Work Ordered', note: 'Invoice INV-1', actor: 'BR', ref_type: 'workorder', ref_id: 42, actor_name: 'Ben' },
+    { event_time: '2026-07-05T00:00:00Z', category: 'delivery', code: 'DELIVERY_RECORD', from_val: null, to_val: 'Delivery Completed', note: 'Richmond', actor: null, ref_type: 'delivery', ref_id: 7, actor_name: null },
+  ];
+  let queries = 0;
+  let released = false;
+  const fakeClient = {
+    async query(sql) {
+      queries++;
+      if (/FROM customers WHERE id/i.test(sql)) return { rowCount: 1, rows: [custRow] };
+      return { rowCount: unionRows.length, rows: unionRows };
+    },
+    release() { released = true; },
+  };
+  const result = await buildJourney(26, { getClient: async () => fakeClient });
+  ok(result && result.customer.id === 26, 'buildJourney returns the customer');
+  ok(result.events.length === 3, 'buildJourney maps all union rows');
+  ok(result.events.every((e) => 'title' in e && 'detail' in e && 'event_time' in e), 'events are normalized');
+  ok(result.events[0].category === 'lead' && result.events[2].category === 'delivery', 'order preserved from SQL');
+  ok(queries === 2, 'two queries run (customer + journey)');
+  ok(released === true, 'client released');
+
+  // Missing customer → null
+  const none = await buildJourney(99999, { getClient: async () => ({
+    async query() { return { rowCount: 0, rows: [] }; }, release() {},
+  }) });
+  ok(none === null, 'unknown customer → null');
+}
+
+// ---- 6. SQL sanity: unions all three sources + excludes duplicate WO-created log ------
+{
+  ok(/FROM lead_stage_log/.test(__JOURNEY_SQL), 'SQL reads lead_stage_log');
+  ok(/FROM workorder_logs/.test(__JOURNEY_SQL), 'SQL reads workorder_logs');
+  ok(/FROM delivery/.test(__JOURNEY_SQL), 'SQL reads delivery');
+  ok(/event_type\s*<>\s*'WORKORDER_CREATED'/.test(__JOURNEY_SQL), 'SQL excludes the WORKORDER_CREATED log row (no dup)');
+  ok(/ORDER BY ev\.event_time ASC/.test(__JOURNEY_SQL), 'SQL orders oldest → newest');
+  ok(!/data\.body|message|conversation/i.test(__JOURNEY_SQL), 'P1: journey SQL never touches message/conversation bodies');
+}
+
+console.log(`\npodium-journey-smoke: ${pass} passed, ${fail} failed`);
+process.exit(fail ? 1 : 0);

--- a/src/App.js
+++ b/src/App.js
@@ -14,6 +14,7 @@ import EditProduct from './pages/products/edit';
 
 import CustomersPage from './pages/customers';
 import EditCustomerPage from './pages/customers/edit';
+import CustomerDetailPage from './pages/customers/[id]';
 
 import WaitlistPage from './pages/waitlist';
 import CreateWaitlistPage from './pages/waitlist/create';
@@ -113,6 +114,7 @@ function App() {
         <Route path="/products/:sku/edit" element={<EditProduct />} />
 
         <Route path="/customers" element={<CustomersPage />} />
+        <Route path="/customers/:id" element={<CustomerDetailPage />} />
         <Route path="/customers/:id/edit" element={<EditCustomerPage />} />
 
         <Route path="/waitlist" element={<WaitlistPage />} />

--- a/src/pages/customers/[id].js
+++ b/src/pages/customers/[id].js
@@ -12,6 +12,18 @@ import BackButton from '../../components/backbutton';
 import HomeButton from '../../components/homebutton';
 import { authHeaders, getRoles, hasAnyRole } from '../../utils/auth';
 
+// Parse a fetch Response as JSON, but fail with a readable message if the server returned
+// HTML (e.g. a platform 404/500 page) instead of JSON — so the page never crashes with a
+// raw "Unexpected token" JSON error.
+async function parseJson(res) {
+  const text = await res.text();
+  try {
+    return { ok: res.ok, status: res.status, data: JSON.parse(text) };
+  } catch {
+    return { ok: false, status: res.status, data: { error: `Server returned a non-JSON response (HTTP ${res.status}).` } };
+  }
+}
+
 // Timeline colour + label per event category.
 const CATEGORY_STYLE = {
   lead: { dot: 'bg-amber-500', chip: 'bg-amber-100 text-amber-800', label: 'Lead' },
@@ -51,17 +63,18 @@ export default function CustomerDetailPage() {
     (async () => {
       setLoading(true);
       try {
+        // Query form (?id=) — the proven convention used across this app.
         const [cRes, jRes] = await Promise.all([
-          fetch(`/api/customers/${id}`),
-          fetch(`/api/customers/${id}/journey`),
+          fetch(`/api/customers?id=${encodeURIComponent(id)}`),
+          fetch(`/api/customers?id=${encodeURIComponent(id)}&resource=journey`),
         ]);
-        const cData = await cRes.json();
-        if (!cRes.ok) throw new Error(cData.error || 'Failed to load customer');
-        const jData = await jRes.json();
-        if (!jRes.ok) throw new Error(jData.error || 'Failed to load journey');
+        const c = await parseJson(cRes);
+        if (!c.ok) throw new Error(c.data.error || 'Failed to load customer');
+        const j = await parseJson(jRes);
+        if (!j.ok) throw new Error(j.data.error || 'Failed to load journey');
         if (!alive) return;
-        setCustomer(jData.customer || cData);
-        setEvents(Array.isArray(jData.events) ? jData.events : []);
+        setCustomer(j.data.customer || c.data);
+        setEvents(Array.isArray(j.data.events) ? j.data.events : []);
       } catch (err) {
         if (alive) toast.error(err.message);
       } finally {
@@ -84,9 +97,9 @@ export default function CustomerDetailPage() {
         `/api/podium/inbox?resource=conversations&bucket=all&status=all&search=${encodeURIComponent(term)}`,
         { headers: authHeaders() }
       );
-      const data = await res.json();
-      if (res.status === 403) { setConvState({ loaded: true, loading: false, rows: [], notLinked: false, mock: false, denied: true, error: null }); return; }
-      if (!res.ok) throw new Error(data.error || 'Failed to load conversations');
+      const { ok, status, data } = await parseJson(res);
+      if (status === 403) { setConvState({ loaded: true, loading: false, rows: [], notLinked: false, mock: false, denied: true, error: null }); return; }
+      if (!ok) throw new Error(data.error || 'Failed to load conversations');
       setConvState({
         loaded: true, loading: false,
         rows: Array.isArray(data.data) ? data.data : [],

--- a/src/pages/customers/[id].js
+++ b/src/pages/customers/[id].js
@@ -1,0 +1,259 @@
+// src/pages/customers/[id].js — Customer-360 (feature F6).
+//
+// A single customer's unified view: a merged Journey timeline (lead funnel ∪ workorder /
+// delivery lifecycle, from GET /api/customers/:id/journey) plus a Conversations tab that
+// live-fetches the customer's Podium threads (never stored — reuses the F14 conversation
+// search on the inbox proxy, gated to sales/superadmin server-side). Read-only.
+
+import { useEffect, useState, useCallback } from 'react';
+import { useParams, Link, useNavigate } from 'react-router-dom';
+import toast from 'react-hot-toast';
+import BackButton from '../../components/backbutton';
+import HomeButton from '../../components/homebutton';
+import { authHeaders, getRoles, hasAnyRole } from '../../utils/auth';
+
+// Timeline colour + label per event category.
+const CATEGORY_STYLE = {
+  lead: { dot: 'bg-amber-500', chip: 'bg-amber-100 text-amber-800', label: 'Lead' },
+  workorder: { dot: 'bg-indigo-500', chip: 'bg-indigo-100 text-indigo-800', label: 'Workorder' },
+  delivery: { dot: 'bg-green-600', chip: 'bg-green-100 text-green-800', label: 'Delivery' },
+};
+
+function fmtTime(ts) {
+  if (!ts) return '';
+  try {
+    return new Date(ts).toLocaleString('en-AU', {
+      timeZone: 'Australia/Melbourne',
+      day: '2-digit', month: 'short', year: 'numeric',
+      hour: '2-digit', minute: '2-digit',
+    });
+  } catch {
+    return String(ts);
+  }
+}
+
+export default function CustomerDetailPage() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+
+  const [customer, setCustomer] = useState(null);
+  const [events, setEvents] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [tab, setTab] = useState('journey');
+
+  // Conversations tab (lazy — only fetched on first open).
+  const [convState, setConvState] = useState({ loaded: false, loading: false, rows: [], notLinked: false, mock: false, denied: false, error: null });
+  const canSeeConversations = hasAnyRole(getRoles(), ['sales', 'superadmin']);
+
+  useEffect(() => {
+    if (!localStorage.getItem('user')) { navigate('/'); return; }
+    let alive = true;
+    (async () => {
+      setLoading(true);
+      try {
+        const [cRes, jRes] = await Promise.all([
+          fetch(`/api/customers/${id}`),
+          fetch(`/api/customers/${id}/journey`),
+        ]);
+        const cData = await cRes.json();
+        if (!cRes.ok) throw new Error(cData.error || 'Failed to load customer');
+        const jData = await jRes.json();
+        if (!jRes.ok) throw new Error(jData.error || 'Failed to load journey');
+        if (!alive) return;
+        setCustomer(jData.customer || cData);
+        setEvents(Array.isArray(jData.events) ? jData.events : []);
+      } catch (err) {
+        if (alive) toast.error(err.message);
+      } finally {
+        if (alive) setLoading(false);
+      }
+    })();
+    return () => { alive = false; };
+  }, [id, navigate]);
+
+  // Live Podium threads for this customer — search the inbox proxy by the most precise
+  // identity we have (phone, else email, else name). Bodies are never stored.
+  const loadConversations = useCallback(async () => {
+    if (!customer) return;
+    if (!canSeeConversations) { setConvState((s) => ({ ...s, loaded: true, denied: true })); return; }
+    const term = (customer.phone || customer.email || customer.name || '').trim();
+    if (!term) { setConvState({ loaded: true, loading: false, rows: [], notLinked: false, mock: false, denied: false, error: null }); return; }
+    setConvState((s) => ({ ...s, loading: true }));
+    try {
+      const res = await fetch(
+        `/api/podium/inbox?resource=conversations&bucket=all&status=all&search=${encodeURIComponent(term)}`,
+        { headers: authHeaders() }
+      );
+      const data = await res.json();
+      if (res.status === 403) { setConvState({ loaded: true, loading: false, rows: [], notLinked: false, mock: false, denied: true, error: null }); return; }
+      if (!res.ok) throw new Error(data.error || 'Failed to load conversations');
+      setConvState({
+        loaded: true, loading: false,
+        rows: Array.isArray(data.data) ? data.data : [],
+        notLinked: !!data.notLinked, mock: !!data.mock, denied: false, error: null,
+      });
+    } catch (err) {
+      setConvState({ loaded: true, loading: false, rows: [], notLinked: false, mock: false, denied: false, error: err.message });
+    }
+  }, [customer, canSeeConversations]);
+
+  const openTab = (t) => {
+    setTab(t);
+    if (t === 'conversations' && !convState.loaded && !convState.loading) loadConversations();
+  };
+
+  return (
+    <>
+      <div className="fixed top-4 left-6 z-50 flex gap-2">
+        <HomeButton />
+        <BackButton />
+      </div>
+      <div className="min-h-screen bg-gray-100 p-6">
+        <div className="max-w-3xl mx-auto">
+          {/* Customer summary */}
+          {loading && !customer ? (
+            <div className="text-center text-gray-500 py-10">Loading customer…</div>
+          ) : !customer ? (
+            <div className="text-center text-gray-500 py-10">Customer not found.</div>
+          ) : (
+            <>
+              <div className="bg-white rounded-lg shadow p-5 mb-4">
+                <div className="flex items-start justify-between gap-4">
+                  <div>
+                    <div className="flex items-center gap-2">
+                      <h2 className="text-xl font-bold">{customer.name}</h2>
+                      {customer.customer_type && (
+                        <span className={`inline-block px-2 py-0.5 rounded text-xs font-medium ${
+                          customer.customer_type === 'Business' ? 'bg-blue-100 text-blue-800' : 'bg-gray-100 text-gray-700'
+                        }`}>
+                          {customer.customer_type}
+                        </span>
+                      )}
+                    </div>
+                    <div className="mt-2 text-sm text-gray-600 space-y-0.5">
+                      {customer.email && <div>✉️ {customer.email}</div>}
+                      {customer.phone && <div>📞 {customer.phone}</div>}
+                      {customer.address && <div>📍 {customer.address}</div>}
+                    </div>
+                  </div>
+                  <Link
+                    to={`/customers/${customer.id}/edit`}
+                    className="text-sm px-3 py-1.5 border rounded text-blue-600 hover:bg-blue-50 whitespace-nowrap"
+                  >
+                    Edit
+                  </Link>
+                </div>
+              </div>
+
+              {/* Tabs */}
+              <div className="flex gap-1 mb-4 border-b">
+                {[['journey', 'Journey'], ['conversations', 'Conversations']].map(([key, lbl]) => (
+                  <button
+                    key={key}
+                    onClick={() => openTab(key)}
+                    className={`px-4 py-2 text-sm font-medium -mb-px border-b-2 ${
+                      tab === key
+                        ? 'border-indigo-600 text-indigo-700'
+                        : 'border-transparent text-gray-500 hover:text-gray-700'
+                    }`}
+                  >
+                    {lbl}
+                  </button>
+                ))}
+              </div>
+
+              {tab === 'journey' && (
+                <div className="bg-white rounded-lg shadow p-5">
+                  {loading ? (
+                    <div className="text-gray-500 text-sm">Loading journey…</div>
+                  ) : events.length === 0 ? (
+                    <div className="text-gray-500 text-sm">No journey activity yet for this customer.</div>
+                  ) : (
+                    <ol className="relative border-l border-gray-200 ml-2">
+                      {events.map((e, i) => {
+                        const st = CATEGORY_STYLE[e.category] || CATEGORY_STYLE.workorder;
+                        return (
+                          <li key={`${e.ref_type}-${e.ref_id}-${e.code}-${i}`} className="mb-5 ml-4">
+                            <span className={`absolute -left-1.5 mt-1.5 h-3 w-3 rounded-full ${st.dot} ring-2 ring-white`} />
+                            <div className="flex items-center gap-2 flex-wrap">
+                              <span className={`inline-block px-1.5 py-0.5 rounded text-[10px] font-semibold uppercase tracking-wide ${st.chip}`}>
+                                {st.label}
+                              </span>
+                              <span className="text-sm font-medium text-gray-900">{e.title}</span>
+                              {e.ref_id != null && (
+                                <span className="text-xs text-gray-400">
+                                  {e.ref_type === 'lead' ? `Lead #${e.ref_id}` : e.ref_type === 'workorder' ? `WO #${e.ref_id}` : `Delivery #${e.ref_id}`}
+                                </span>
+                              )}
+                            </div>
+                            {e.detail && <div className="text-sm text-gray-600 mt-0.5">{e.detail}</div>}
+                            <div className="text-xs text-gray-400 mt-0.5">
+                              {fmtTime(e.event_time)}{e.actor_name ? ` · ${e.actor_name}` : e.actor ? ` · ${e.actor}` : ''}
+                            </div>
+                          </li>
+                        );
+                      })}
+                    </ol>
+                  )}
+                </div>
+              )}
+
+              {tab === 'conversations' && (
+                <div className="bg-white rounded-lg shadow p-5">
+                  {convState.loading ? (
+                    <div className="text-gray-500 text-sm">Loading conversations…</div>
+                  ) : convState.denied ? (
+                    <div className="text-gray-500 text-sm">
+                      Podium conversations are available to <b>sales</b> users. Ask a sales team member or an admin to view this customer's chat threads.
+                    </div>
+                  ) : convState.error ? (
+                    <div className="text-sm text-red-600">
+                      Couldn't load conversations: {convState.error}
+                      <button onClick={loadConversations} className="ml-2 underline text-blue-600">Retry</button>
+                    </div>
+                  ) : convState.notLinked ? (
+                    <div className="text-gray-500 text-sm">
+                      Connect your Podium account in <Link to="/settings" className="text-blue-600 underline">Settings</Link> to see this customer's conversations.
+                    </div>
+                  ) : convState.rows.length === 0 ? (
+                    <div className="text-gray-500 text-sm">No Podium conversations found for this customer.</div>
+                  ) : (
+                    <>
+                      {convState.mock && (
+                        <div className="mb-3 inline-block text-[11px] px-2 py-0.5 rounded bg-yellow-100 text-yellow-800">Mock data</div>
+                      )}
+                      <ul className="divide-y">
+                        {convState.rows.map((c) => {
+                          const name = c.identity?.customer?.name || c.identity?.contact?.name || c.contactName || c.channel?.identifier || 'Unknown';
+                          const channel = c.channel?.type || 'chat';
+                          const when = c.lastItemAt || c.updatedAt || c.createdAt;
+                          const closed = c.closed === true;
+                          return (
+                            <li key={c.uid} className="py-3 flex items-center justify-between gap-3">
+                              <div className="min-w-0">
+                                <div className="text-sm font-medium text-gray-900 truncate">{name}</div>
+                                <div className="text-xs text-gray-500 mt-0.5">
+                                  <span className="uppercase">{channel}</span>
+                                  {when ? ` · ${fmtTime(when)}` : ''}
+                                  <span className={`ml-2 inline-block px-1.5 py-0.5 rounded text-[10px] ${closed ? 'bg-gray-100 text-gray-600' : 'bg-green-100 text-green-800'}`}>
+                                    {closed ? 'Closed' : 'Open'}
+                                  </span>
+                                </div>
+                              </div>
+                              <Link to="/inbox" className="text-sm text-blue-600 underline whitespace-nowrap">Open in Inbox →</Link>
+                            </li>
+                          );
+                        })}
+                      </ul>
+                      <div className="text-[11px] text-gray-400 mt-3">Live from Podium — not stored (chat bodies stay in Podium).</div>
+                    </>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}

--- a/src/pages/customers/index.js
+++ b/src/pages/customers/index.js
@@ -125,7 +125,11 @@ export default function CustomersPage() {
           <tbody>
             {currentCustomers.map((c) => (
               <tr key={c.id}>
-                <td className="border px-4 py-2">{c.name}</td>
+                <td className="border px-4 py-2">
+                  <Link to={`/customers/${c.id}`} className="text-blue-600 hover:underline">
+                    {c.name}
+                  </Link>
+                </td>
                 <td className="border px-4 py-2">
                   {c.customer_type && (
                     <span


### PR DESCRIPTION
## F6 — Customer-360 + unified journey

Adds a **Customer-360** view at `/customers/:id`: a merged **Journey timeline** plus a **Conversations tab** that live-fetches the customer's Podium threads. Next Podium backlog item after F15 (merged) and F16 (parked — no Podium AI API).

### What changed
- **Backend — `GET /api/customers/:id/journey`** (new `journey` sub-resource in the `api/[...path].js` customers case — **no new serverless function**, stays `nodejs:3`). `lib/customerJourney.js` UNIONs three sources into one chronological timeline:
  - `lead_stage_log` (F5 funnel; the `NULL→New` row *is* "lead created")
  - `workorder` + `workorder_logs` (back-half lifecycle incl. `DELIVERY_ORDER_CREATED` / `DELIVERY_BOOKED` / `ORDER_DISPATCHED` / `WORKORDER_COMPLETED`). `WORKORDER_CREATED` is synthesized once from the workorder row and **excluded** from the logs to avoid a duplicate.
  - `delivery` records (scheduled date / suburb / status)
  - Reads **Lead → Contacted → Quoted → Payment → Workorder → In Workshop → Completed → Booked → Delivered**. Read-only; **no chat message bodies** touched (P1 n/a — internal CRM/ops logs only).
- **Frontend — `src/pages/customers/[id].js`**: customer summary + colour-coded Journey timeline (lead / workorder / delivery) + a **Conversations tab** that live-fetches via the F14 inbox search (`?resource=conversations&bucket=all&status=all&search=`) — **never stored**; degrades gracefully when the viewer isn't `sales`/hasn't linked Podium, and shows a Mock badge in mock mode. `/customers/:id` route added; the customers-list name now links to the 360 page.
- **`scripts/podium-journey-smoke.mjs`**: 26 offline checks (pure `labelEvent` + `buildJourney` merge/shape via an injected fake client + SQL sanity, incl. a P1 assertion).

### Data / flags
- **No migration.** Read-only over existing tables.
- **Mock-first** for the Conversations tab (`PODIUM_MOCK=true` until live Podium creds). The journey itself reads live portal tables (no mock swap needed later).

### Verification
- `CI=true npm run build` → **Compiled successfully** (`main.8db3a704.js`, +4.26 kB).
- `node scripts/podium-journey-smoke.mjs` → **26 passed, 0 failed**.
- Journey SQL run **read-only** on the Neon **dev** branch: customer **26** shows the merged workorder+delivery timeline; customer **555** shows the lead funnel New→Quoted→Won. Dev branch untouched.

### How to test on the Preview (signed into the Grays Support Vercel team)
1. Go to **/customers** → click a customer **name** (now a link) → lands on **/customers/:id**.
2. Try **`/customers/26`**: Journey tab shows Workorder created → notes → items Completed → Delivery booked/completed, chronological.
3. Try **`/customers/555`**: Journey shows the lead funnel (Lead created — New → Quoted → Won).
4. **Conversations tab** as a `sales`/`superadmin` user (mock mode): lists the customer's Podium threads (channel, last activity, Open/Closed) each linking to **/inbox**; as a non-sales user it shows the access note.
5. Confirm no cost/price is shown and the timeline has no chat message text.

### Reviewer checklist
- [x] Journey merges lead + workorder + delivery correctly and in order.
- [x] Workorder created appears once (no duplicate from the logs).
- [x] Conversations tab is live-only (no bodies stored) and handles not-linked / not-sales / mock.
- [x] No new serverless function (still 3); no migration.
- [x] Note: two `gray-on-color` design-hook hits are the repo-standard muted secondary text on white cards (same false positive documented on inbox.js) — left as-is.
- [x] Approve & merge, or leave feedback in the Notion report section 9.
