### PR TITLE
F1 hotfix: static function entries for the Podium OAuth endpoints (Vercel multi-segment routing regression)

### DIFF
--- a/api/podium/oauth/callback.js
+++ b/api/podium/oauth/callback.js
@@ -1,0 +1,7 @@
+// api/podium/oauth/callback.js — static function entry for the OAuth callback.
+//
+// HOTFIX (14 Jul 2026): same as oauth/start.js — Vercel no longer routes
+// multi-segment paths into api/podium/[...podium].js, and this URL is the exact
+// redirect_uri registered with the Podium app (must match byte-for-byte), so it gets
+// its own static function file. Handler body unchanged in lib/podiumRoutes/.
+export { default } from '../../../lib/podiumRoutes/oauthCallback.js';

--- a/api/podium/oauth/start.js
+++ b/api/podium/oauth/start.js
@@ -1,0 +1,9 @@
+// api/podium/oauth/start.js — static function entry for the OAuth start endpoint.
+//
+// HOTFIX (14 Jul 2026): Vercel stopped routing multi-segment paths
+// (/api/podium/oauth/start) into the api/podium/[...podium].js catch-all — the
+// platform returns NOT_FOUND before the function runs (same regression F6 hit with
+// /api/customers/:id/journey on 13 Jul). Static file paths still route normally, so
+// this file pins the exact URL the Settings page calls. The handler body is unchanged
+// in lib/podiumRoutes/oauthStart.js; the catch-all keeps serving status/inbox/etc.
+export { default } from '../../../lib/podiumRoutes/oauthStart.js';


### PR DESCRIPTION
## What
Two new 1-line serverless function files that re-export the existing handlers:

- `api/podium/oauth/start.js` → `lib/podiumRoutes/oauthStart.js`
- `api/podium/oauth/callback.js` → `lib/podiumRoutes/oauthCallback.js`

No handler logic, frontend, env, or Podium-app config changes. Function count goes 3 → 5 (Hobby cap 12).

## Why
Live Podium wiring (14 Jul) failed at the first step: **Settings → Connect my Podium account** showed *Could not start Podium connection*. Network capture on production shows `GET /api/podium/oauth/start` returning a **platform-level 404** (plain-text `NOT_FOUND`, no function invoked).

Diagnosis: Vercel has stopped routing **multi-segment** paths into non-Next catch-all functions — `/api/podium/status` (1 segment) reaches `api/podium/[...podium].js` fine, `/api/podium/oauth/start` (2 segments) never does. This is the same platform regression F6 hit on 13 Jul with `/api/customers/:id/journey` (hotfixed then by switching to the query form).

For OAuth the query-form workaround is not safe: the callback URL is the `redirect_uri` registered with the Podium app and must match byte-for-byte, and Podium appending `?code=…` to a URL that already has a query string is untested. Static file paths still route normally (e.g. `api/podium/webhook.js`), so pinning the two OAuth URLs as static function files keeps every URL exactly as registered.

## Heads-up (out of scope here)
The same regression very likely breaks other multi-segment path forms on production, e.g. `POST /api/leads/:id/stage` / `:id/quote` if the UI calls the path form — `curl /api/leads/1/stage` also returns the platform 404. Worth a follow-up sweep.

## Test
- Preview: `GET <preview>/api/podium/oauth/start` without auth should now return **401 JSON** `{"error":"Not authenticated"}` (function reached) instead of the plain-text platform 404.
- Preview runs mock (no Podium env in Preview scope), so the full connect loopback flow is exercisable from Settings.
- After merge → production deploy: Settings → *Connect my Podium account* should redirect to Podium's consent screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)