### PR TITLE
Live wiring: filter inbox buckets locally — live GET /conversations has no filter params

### DIFF
--- a/lib/podium.js
+++ b/lib/podium.js
@@ -351,25 +351,83 @@ export async function paginate(userId, path, opts = {}) {
 // ---- Endpoint helpers (§15.4) ----------------------------------------------
 
 /**
+ * Normalise a LIVE §15 conversation object to the shape the rest of the stack
+ * (inbox routes, F4 bridge, React UI) expects — which is the mock fixture shape.
+ * VERIFIED 14 Jul 2026 against docs.podium.com/reference/the-conversation-object:
+ * live rows carry `closed` (bool), `assignedUserUid`, `assigneeUids[]`, `lastItemAt`
+ * — not the `status` / `assignedUser{uid}` / `assignees[{uid}]` / `lastMessageAt`
+ * fields everything downstream reads. Mock rows pass through unchanged; original
+ * live fields are kept alongside the derived ones.
+ */
+export function normalizeConversation(conv) {
+  if (!conv || typeof conv !== 'object') return conv;
+  const out = { ...conv };
+  if (out.status !== 'open' && out.status !== 'closed') {
+    out.status = out.closed === true ? 'closed' : 'open';
+  }
+  if (!Array.isArray(out.assignees)) {
+    const uids = Array.isArray(out.assigneeUids) && out.assigneeUids.length
+      ? out.assigneeUids
+      : (out.assignedUserUid ? [out.assignedUserUid] : []);
+    out.assignees = uids.filter(Boolean).map((uid) => ({ uid }));
+  }
+  if (!out.assignedUser) {
+    const primary = out.assignees[0]?.uid || null;
+    out.assignedUser = primary ? { uid: primary } : null;
+  }
+  if (!out.lastMessageAt) out.lastMessageAt = out.lastItemAt || out.updatedAt || null;
+  return out;
+}
+
+/**
+ * Does a (normalised) conversation fall inside the requested F11 bucket + status?
+ * Pure; used for the LIVE path where Podium cannot filter server-side.
+ */
+export function conversationMatchesFilters(conv, opts = {}) {
+  const assignees = Array.isArray(conv?.assignees) ? conv.assignees : [];
+  if (opts.unassigned && assignees.length) return false;
+  if (opts.assigneeUid && !assignees.some((a) => a?.uid === opts.assigneeUid)) return false;
+  if ((opts.status === 'open' || opts.status === 'closed') && conv?.status !== opts.status) return false;
+  return true;
+}
+
+/**
  * GET /v4/conversations (cursor+limit). Filters map to the F11 inbox buckets:
  *   • assigneeUid — "Assigned to You" / a specific rep (scope=mine)
  *   • unassigned  — the "Unassigned" bucket (no assignee)
  *   • status      — 'open' | 'closed' (the Open/Closed split within each bucket)
- * VERIFY the live Podium query-param names for unassigned + status at live wiring.
+ * VERIFIED at live wiring (14 Jul 2026, docs + a live 400 invalid_request_values):
+ * the live endpoint accepts ONLY `cursor` / `limit` / `locationUid` — no filter
+ * params exist. So live requests send just those, and the bucket/status filters are
+ * applied HERE over a wider page (up to 100 rows, the established F14 scan window),
+ * then sliced back to the requested limit. The mock still filters server-side, so
+ * Preview behaviour and the existing smoke contracts are unchanged.
  */
-export function listConversations(userId, opts = {}) {
+export async function listConversations(userId, opts = {}) {
   const query = { ...(opts.query || {}) };
   if (opts.limit) query.limit = opts.limit;
   if (opts.cursor) query.cursor = opts.cursor;
-  if (opts.assigneeUid) query.assigneeUid = opts.assigneeUid;
-  if (opts.unassigned) query.unassigned = 'true';
-  if (opts.status) query.status = opts.status;
-  return request(userId, 'GET', 'conversations', { query, client: opts.client });
+  if (isMock()) {
+    if (opts.assigneeUid) query.assigneeUid = opts.assigneeUid;
+    if (opts.unassigned) query.unassigned = 'true';
+    if (opts.status) query.status = opts.status;
+    return request(userId, 'GET', 'conversations', { query, client: opts.client });
+  }
+  const filtering = !!(opts.assigneeUid || opts.unassigned || opts.status === 'open' || opts.status === 'closed');
+  if (filtering) query.limit = 100; // scan window; sliced back below
+  const resp = await request(userId, 'GET', 'conversations', { query, client: opts.client });
+  let data = (Array.isArray(resp?.data) ? resp.data : []).map(normalizeConversation);
+  if (filtering) {
+    data = data.filter((c) => conversationMatchesFilters(c, opts));
+    if (opts.limit) data = data.slice(0, opts.limit);
+  }
+  return { ...resp, data };
 }
 
 /** GET /v4/conversations/{uid} */
-export function getConversation(userId, conversationUid, opts = {}) {
-  return request(userId, 'GET', `conversations/${conversationUid}`, { client: opts.client });
+export async function getConversation(userId, conversationUid, opts = {}) {
+  const conv = await request(userId, 'GET', `conversations/${conversationUid}`, { client: opts.client });
+  return isMock() ? conv : normalizeConversation(conv);
 }
 
 /** PATCH /v4/conversations/{uid} — update conversation fields. */
@@ -520,6 +578,7 @@ export default {
   getStoredToken, saveUserToken, tokenForUser,
   request, paginate,
   listConversations, getConversation, updateConversation, setConversationStatus,
+  normalizeConversation, conversationMatchesFilters,
   listMessages, sendMessage, listMessageTemplates, postInternalNote,
   getAssignee, assignConversation, getUsers, getContact, requestReview,
   createWebhook, listWebhooks, deleteWebhook,

--- a/scripts/podium-inbox-smoke.mjs
+++ b/scripts/podium-inbox-smoke.mjs
@@ -19,11 +19,11 @@
 
 process.env.PODIUM_MOCK = 'true';
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'smoke_secret';
-process.env.PODIUM_API_VERSION = process.env.PODIUM_API_VERSION || '2021-04-01';
+process.env.PODIUM_API_VERSION = process.env.PODIUM_API_VERSION || '2021.04.01';
 
 const jwt = (await import('jsonwebtoken')).default;
 const { clampLimit, filterUpdatedSince, resolveSelfPodiumUid, normalizeBucket, normalizeStatus } = await import('../lib/podiumInbox.js');
-const { listConversations, listMessages, sendMessage, listMessageTemplates, postInternalNote } = await import('../lib/podium.js');
+const { listConversations, listMessages, sendMessage, listMessageTemplates, postInternalNote, normalizeConversation, conversationMatchesFilters } = await import('../lib/podium.js');
 const { buildConversationIdentity, identityMatchesSearch } = await import('../lib/podiumContact.js');
 const inboxHandler = (await import('../lib/podiumRoutes/inbox.js')).default;
 
@@ -446,6 +446,51 @@ console.log('\nF14 conversation search:');
   check('identity: portal customer matched on podium_contact_id', id.matchedBy === 'podium_contact_id');
   check('identity: customerName preferred for the display name', id.displayName === 'Maria P (portal)' && id.customerName === 'Maria P (portal)');
   check('identity: search matches the matched portal customer name', identityMatchesSearch(id, c1, 'portal') === true);
+}
+
+{
+  // Live-wiring (14 Jul 2026): normalizeConversation maps the VERIFIED live §15
+  // conversation shape (closed / assignedUserUid / assigneeUids / lastItemAt — see
+  // docs.podium.com/reference/the-conversation-object) onto the mock-era fields the
+  // routes and UI read (status / assignedUser / assignees / lastMessageAt).
+  const live = {
+    uid: 'c1',
+    closed: false,
+    assignedUserUid: 'u1',
+    assigneeUids: ['u1', 'u2'],
+    lastItemAt: '2026-07-14T10:00:00Z',
+    updatedAt: '2026-07-14T09:00:00Z',
+    channel: { type: 'phone', identifier: '+61400111222' },
+    contactName: 'Maria P',
+  };
+  const n = normalizeConversation(live);
+  check('normalize: closed=false → status open', n.status === 'open');
+  check('normalize: assigneeUids → assignees[{uid}]', n.assignees.length === 2 && n.assignees[1].uid === 'u2');
+  check('normalize: primary assignee → assignedUser', n.assignedUser?.uid === 'u1');
+  check('normalize: lastItemAt → lastMessageAt', n.lastMessageAt === '2026-07-14T10:00:00Z');
+  check('normalize: original live fields kept', n.closed === false && n.assigneeUids.length === 2);
+
+  const nClosed = normalizeConversation({ uid: 'c2', closed: true, assignedUserUid: 'u3', updatedAt: '2026-07-14T08:00:00Z' });
+  check('normalize: closed=true → status closed', nClosed.status === 'closed');
+  check('normalize: single assignedUserUid → one assignee', nClosed.assignees.length === 1 && nClosed.assignees[0].uid === 'u3');
+  check('normalize: no lastItemAt falls back to updatedAt', nClosed.lastMessageAt === '2026-07-14T08:00:00Z');
+
+  const nBare = normalizeConversation({ uid: 'c3' });
+  check('normalize: bare row → open + unassigned', nBare.status === 'open' && nBare.assignees.length === 0 && nBare.assignedUser === null);
+
+  const mockRow = normalizeConversation({ uid: 'c4', status: 'closed', assignees: [{ uid: 'u9' }], assignedUser: { uid: 'u9' }, lastMessageAt: 'x' });
+  check('normalize: mock-shaped row passes through unchanged', mockRow.status === 'closed' && mockRow.assignees[0].uid === 'u9' && mockRow.lastMessageAt === 'x');
+
+  // conversationMatchesFilters — the LIVE-path bucket/status filter (live GET
+  // /conversations accepts only cursor/limit/locationUid; anything else 400s).
+  check('live filter: mine matches any assignee in the set', conversationMatchesFilters(n, { assigneeUid: 'u2' }) === true);
+  check('live filter: mine rejects a non-assignee', conversationMatchesFilters(n, { assigneeUid: 'u9' }) === false);
+  check('live filter: unassigned rejects an assigned row', conversationMatchesFilters(n, { unassigned: true }) === false);
+  check('live filter: unassigned matches a bare row', conversationMatchesFilters(nBare, { unassigned: true }) === true);
+  check('live filter: status open matches', conversationMatchesFilters(n, { status: 'open' }) === true);
+  check('live filter: status closed rejects an open row', conversationMatchesFilters(n, { status: 'closed' }) === false);
+  check('live filter: mine+open combined', conversationMatchesFilters(n, { assigneeUid: 'u1', status: 'open' }) === true);
+  check('live filter: no filters matches everything', conversationMatchesFilters(nClosed, {}) === true);
 }
 
 console.log(`\n✅ inbox smoke: ${passed} checks passed`);


### PR DESCRIPTION
## What
The live Podium API rejected the inbox's conversation-list calls with **400 `invalid_request_values` ("Unexpected field: assigneeUid")** — the second live-wiring blocker today (after the version-header fix, now resolved via env `PODIUM_API_VERSION=2021.04.01`).

Verified against docs.podium.com (reference/conversationindex-1 + the-conversation-object):
- Live `GET /v4/conversations` accepts **only** `cursor` / `limit` / `locationUid` — the `assigneeUid` / `unassigned` / `status` filter params our F11 buckets sent do not exist.
- Live conversation rows carry `closed` (bool) / `assignedUserUid` / `assigneeUids[]` / `lastItemAt` — not the `status` / `assignedUser{uid}` / `assignees[{uid}]` / `lastMessageAt` fields the routes, F4 bridge, and React UI read.

## Fix (`lib/podium.js`)
- `normalizeConversation()` — maps live rows onto the shape the whole stack already expects (originals kept alongside).
- `conversationMatchesFilters()` — pure bucket/status matcher.
- `listConversations()` — live requests send only cursor/limit; when a bucket/status filter is active it scans a 100-row page (the established F14 window) and slices back to the requested limit. **Mock behaviour untouched** (still filters server-side), so Preview flows and existing smoke contracts are unchanged.
- `getConversation()` — normalizes live single reads (F4 bridge).

## Test
- `node scripts/podium-inbox-smoke.mjs` → **119/119** (+18 new: normalizer + live filter matrix).
- `CI=true npm run build` green.
- After merge → prod deploy: /inbox All + Assigned-to-You + Open/Closed buckets should fill with live conversations (identity resolution already unblocked by the version-header env fix).

No migration, no new fn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)