### PR TITLE
Live wiring: newest-first inbox (synthetic tail cursor) + message thread opens at latest

### DIFF
--- a/lib/podium.js
+++ b/lib/podium.js
@@ -392,6 +392,24 @@ export function conversationMatchesFilters(conv, opts = {}) {
 }
 
 /**
+ * Synthesise the "start from the newest row" cursor for Podium's live cursor
+ * pagination. VERIFIED empirically 14 Jul 2026 on the Grays org (6,714
+ * conversations): the live list endpoints return rows OLDEST-FIRST with no sort
+ * param, but the opaque cursor is base64 JSON `{cursor, direction}` whose inner
+ * value is a URL-safe-base64 Erlang term `%{id: <int>}` (keyset pagination).
+ * Sending `direction:"prev"` from a max-int id returns the newest page directly.
+ * This reaches into an undocumented format, so every caller MUST fall back to the
+ * plain forward listing if a request made with this cursor fails (and log it) —
+ * a Podium-side format change must degrade, never break, the inbox.
+ */
+export function podiumTailCursor() {
+  // ETF binary for %{id: 2147483647}: version, map arity 1, small-atom "id", int32.
+  const bytes = [0x83, 0x74, 0, 0, 0, 1, 0x77, 2, 0x69, 0x64, 0x62, 0x7f, 0xff, 0xff, 0xff];
+  const etf = Buffer.from(bytes).toString('base64').replace(/\+/g, '-').replace(/\//g, '_');
+  return Buffer.from(JSON.stringify({ cursor: etf, direction: 'prev' })).toString('base64');
+}
+
+/**
  * GET /v4/conversations (cursor+limit). Filters map to the F11 inbox buckets:
  *   • assigneeUid — "Assigned to You" / a specific rep (scope=mine)
  *   • unassigned  — the "Unassigned" bucket (no assignee)
@@ -402,6 +420,14 @@ export function conversationMatchesFilters(conv, opts = {}) {
  * applied HERE over a wider page (up to 100 rows, the established F14 scan window),
  * then sliced back to the requested limit. The mock still filters server-side, so
  * Preview behaviour and the existing smoke contracts are unchanged.
+ *
+ * Ordering (live): the raw list is OLDEST-first, so with no caller cursor we start
+ * from podiumTailCursor() and REVERSE each page for newest-first display. Walking
+ * "prev" from the tail, the upstream cursor that continues to OLDER rows is
+ * `previousCursor` — so the returned metadata maps nextCursor to it, preserving the
+ * frontend's existing "nextCursor = more of the list" contract. If the synthetic
+ * cursor is rejected (Podium format change), we log and fall back to the plain
+ * oldest-first listing rather than failing the inbox.
  */
 export async function listConversations(userId, opts = {}) {
   const query = { ...(opts.query || {}) };
@@ -415,13 +441,36 @@ export async function listConversations(userId, opts = {}) {
   }
   const filtering = !!(opts.assigneeUid || opts.unassigned || opts.status === 'open' || opts.status === 'closed');
   if (filtering) query.limit = 100; // scan window; sliced back below
-  const resp = await request(userId, 'GET', 'conversations', { query, client: opts.client });
+
+  let resp;
+  let newestFirst = true;
+  if (opts.cursor) {
+    // Caller is paging with a cursor we handed out (an upstream previousCursor):
+    // rows still come back oldest-first within the page; keep reversing.
+    resp = await request(userId, 'GET', 'conversations', { query, client: opts.client });
+  } else {
+    try {
+      resp = await request(userId, 'GET', 'conversations', {
+        query: { ...query, cursor: podiumTailCursor() }, client: opts.client,
+      });
+    } catch (err) {
+      console.error('podium listConversations: tail cursor rejected, falling back to oldest-first:', err.message);
+      newestFirst = false;
+      resp = await request(userId, 'GET', 'conversations', { query, client: opts.client });
+    }
+  }
+
   let data = (Array.isArray(resp?.data) ? resp.data : []).map(normalizeConversation);
+  if (newestFirst) data.reverse();
   if (filtering) {
     data = data.filter((c) => conversationMatchesFilters(c, opts));
     if (opts.limit) data = data.slice(0, opts.limit);
   }
-  return { ...resp, data };
+  const upstream = resp?.metadata || {};
+  const metadata = newestFirst
+    ? { nextCursor: upstream.previousCursor || null, previousCursor: upstream.nextCursor || null }
+    : upstream;
+  return { ...resp, data, metadata };
 }
 
 /** GET /v4/conversations/{uid} */
@@ -443,12 +492,33 @@ export function setConversationStatus(userId, conversationUid, status, opts = {}
   return updateConversation(userId, conversationUid, { status }, opts);
 }
 
-/** GET /v4/conversations/{uid}/messages (cursor+limit). Bodies are live-only (P1). */
-export function listMessages(userId, conversationUid, opts = {}) {
-  const query = {};
-  if (opts.limit) query.limit = opts.limit;
-  if (opts.cursor) query.cursor = opts.cursor;
-  return request(userId, 'GET', `conversations/${conversationUid}/messages`, { query, client: opts.client });
+/**
+ * GET /v4/conversations/{uid}/messages. Bodies are live-only (P1).
+ * VERIFIED at live wiring (14 Jul 2026): the live endpoint is undocumented and
+ * rejects `limit` outright (400 invalid_request_values "Unexpected field: limit"),
+ * so live requests send only `cursor`. The raw thread is also OLDEST-first (same
+ * paginator as conversations), so with no caller cursor we start from the tail
+ * (podiumTailCursor()) to open the thread at its LATEST messages; the rows within
+ * the page come back ascending, which is already the order a chat view renders.
+ * Falls back to the plain (oldest-first) read if the synthetic cursor is rejected.
+ */
+export async function listMessages(userId, conversationUid, opts = {}) {
+  if (isMock()) {
+    const query = {};
+    if (opts.limit) query.limit = opts.limit;
+    if (opts.cursor) query.cursor = opts.cursor;
+    return request(userId, 'GET', `conversations/${conversationUid}/messages`, { query, client: opts.client });
+  }
+  const path = `conversations/${conversationUid}/messages`;
+  if (opts.cursor) {
+    return request(userId, 'GET', path, { query: { cursor: opts.cursor }, client: opts.client });
+  }
+  try {
+    return await request(userId, 'GET', path, { query: { cursor: podiumTailCursor() }, client: opts.client });
+  } catch (err) {
+    console.error('podium listMessages: tail cursor rejected, falling back to oldest-first:', err.message);
+    return request(userId, 'GET', path, { query: {}, client: opts.client });
+  }
 }
 
 /**
@@ -578,7 +648,7 @@ export default {
   getStoredToken, saveUserToken, tokenForUser,
   request, paginate,
   listConversations, getConversation, updateConversation, setConversationStatus,
-  normalizeConversation, conversationMatchesFilters,
+  normalizeConversation, conversationMatchesFilters, podiumTailCursor,
   listMessages, sendMessage, listMessageTemplates, postInternalNote,
   getAssignee, assignConversation, getUsers, getContact, requestReview,
   createWebhook, listWebhooks, deleteWebhook,

--- a/scripts/podium-inbox-smoke.mjs
+++ b/scripts/podium-inbox-smoke.mjs
@@ -23,7 +23,7 @@ process.env.PODIUM_API_VERSION = process.env.PODIUM_API_VERSION || '2021.04.01';
 
 const jwt = (await import('jsonwebtoken')).default;
 const { clampLimit, filterUpdatedSince, resolveSelfPodiumUid, normalizeBucket, normalizeStatus } = await import('../lib/podiumInbox.js');
-const { listConversations, listMessages, sendMessage, listMessageTemplates, postInternalNote, normalizeConversation, conversationMatchesFilters } = await import('../lib/podium.js');
+const { listConversations, listMessages, sendMessage, listMessageTemplates, postInternalNote, normalizeConversation, conversationMatchesFilters, podiumTailCursor } = await import('../lib/podium.js');
 const { buildConversationIdentity, identityMatchesSearch } = await import('../lib/podiumContact.js');
 const inboxHandler = (await import('../lib/podiumRoutes/inbox.js')).default;
 
@@ -491,6 +491,21 @@ console.log('\nF14 conversation search:');
   check('live filter: status closed rejects an open row', conversationMatchesFilters(n, { status: 'closed' }) === false);
   check('live filter: mine+open combined', conversationMatchesFilters(n, { assigneeUid: 'u1', status: 'open' }) === true);
   check('live filter: no filters matches everything', conversationMatchesFilters(nClosed, {}) === true);
+}
+
+{
+  // Live-wiring (14 Jul 2026): podiumTailCursor() — the synthetic "start from the
+  // newest row" cursor for Podium's keyset pagination (verified against the live
+  // format: outer base64 JSON {cursor, direction}, inner URL-safe-base64 ETF
+  // %{id: <int32 max>}). If Podium changes the format, callers fall back to the
+  // plain oldest-first listing — these checks pin OUR encoding, not Podium's.
+  const outer = JSON.parse(Buffer.from(podiumTailCursor(), 'base64').toString('utf8'));
+  check('tail cursor: outer wrapper has direction prev', outer.direction === 'prev');
+  const inner = Buffer.from(String(outer.cursor).replace(/-/g, '+').replace(/_/g, '/'), 'base64');
+  check('tail cursor: inner is an ETF map (0x83 0x74)', inner[0] === 0x83 && inner[1] === 0x74);
+  check('tail cursor: keyed on atom id', inner.slice(8, 10).toString('utf8') === 'id');
+  check('tail cursor: int32 max payload', inner.readInt32BE(11) === 2147483647);
+  check('tail cursor: inner base64 is URL-safe', !/[+/]/.test(outer.cursor));
 }
 
 console.log(`\n✅ inbox smoke: ${passed} checks passed`);


### PR DESCRIPTION
## What broke on production (after #66)
Testing live with Nick: the inbox filled, but with **April-2024 closed conversations**, and opening any thread failed with 502.

Two more live-vs-mock mismatches (Grays org has **6,714 conversations / 68 pages**):

1. **Live `GET /v4/conversations` returns rows OLDEST-first** and has no sort param — the current open chats sit ~68 pages deep, so the 100-row window only ever saw ancient history.
2. **Live `GET /conversations/{uid}/messages` is undocumented and rejects `limit`** (400 `invalid_request_values` "Unexpected field: limit") — every thread read 502'd. It is also oldest-first.

## Fix (`lib/podium.js`)
Podium's opaque cursor turned out to be base64 JSON `{cursor, direction}` over a URL-safe-base64 Erlang keyset `%{id: <int>}`. Verified live: sending `direction:"prev"` from an int32-max id returns **the newest page in one request**, and the upstream `previousCursor` then walks older pages.

- `podiumTailCursor()` — synthesises that start-from-newest cursor (encoding pinned by smoke tests).
- `listConversations()` (live, no caller cursor) starts from the tail, **reverses the page for newest-first display**, and remaps metadata so `nextCursor` still means "more of the displayed list". Bucket/status filters now scan the newest 100 (was: oldest 100).
- `listMessages()` (live) sends only `cursor` (no `limit`) and opens the thread at its **latest** messages via the same tail cursor; rows within a page are ascending = chat render order.
- **Fallback everywhere**: if Podium ever rejects the synthetic cursor (format change), we log `tail cursor rejected` and degrade to the plain oldest-first listing — never a broken inbox.
- Mock paths untouched.

## Risk note
The tail cursor leans on an **undocumented cursor format** (there is no documented sort/filter alternative — this is what makes the inbox usable at all). The logged fallback contains the blast radius. The durable fix on the roadmap is a webhook-fed conversation *metadata* index (no message bodies, P1 intact) once the F2 webhook is registered — flagged for the build agent.

## Test
- `node scripts/podium-inbox-smoke.mjs` → **124/124** (+5 pinning our cursor encoding). *(Commit message says 129 — typo, it's 124.)*
- `CI=true npm run build` green (no frontend change, `main.2cb7f38c.js` unchanged).
- Live verification pre-PR (via Nick's session): tail request returned the newest 100 conversations (40 open, up to 14 Jul 11:56 AEST) ending at the current open thread; `previousCursor` walked 8→3 Jul. Thread-read fix testable only post-merge (Preview runs mock).

No migration, no new fn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)