### PR TITLE
Live wiring: contact details, chronological threads, and working open/close

### DIFF
--- a/lib/podium.js
+++ b/lib/podium.js
@@ -479,17 +479,28 @@ export async function getConversation(userId, conversationUid, opts = {}) {
   return isMock() ? conv : normalizeConversation(conv);
 }
 
-/** PATCH /v4/conversations/{uid} — update conversation fields. */
-export function updateConversation(userId, conversationUid, patch, opts = {}) {
-  return request(userId, 'PATCH', `conversations/${conversationUid}`, { body: patch, client: opts.client });
+/**
+ * Update conversation fields. VERIFIED at live wiring (14 Jul 2026,
+ * docs.podium.com/reference/conversationupdate-1): the LIVE endpoint is
+ * **PUT** /v4/conversations/{uid} (PATCH does not exist → 404 "Not found") with
+ * body fields `closed` (boolean) / `assignedUserUid` / `conversationAssigneeUids` /
+ * `assignedByName`. The mock keeps its original PATCH contract.
+ */
+export async function updateConversation(userId, conversationUid, patch, opts = {}) {
+  if (isMock()) {
+    return request(userId, 'PATCH', `conversations/${conversationUid}`, { body: patch, client: opts.client });
+  }
+  const conv = await request(userId, 'PUT', `conversations/${conversationUid}`, { body: patch, client: opts.client });
+  return normalizeConversation(conv);
 }
 
 /**
- * Open or close a conversation. VERIFY the live Podium endpoint/field for this at
- * wiring — our reference doesn't pin it; the mock accepts a `status` patch.
+ * Open or close a conversation. The mock takes `{ status: 'open'|'closed' }`; the
+ * LIVE PUT body field is `{ closed: boolean }` (see updateConversation).
  */
 export function setConversationStatus(userId, conversationUid, status, opts = {}) {
-  return updateConversation(userId, conversationUid, { status }, opts);
+  const patch = isMock() ? { status } : { closed: status === 'closed' };
+  return updateConversation(userId, conversationUid, patch, opts);
 }
 
 /**
@@ -498,9 +509,11 @@ export function setConversationStatus(userId, conversationUid, status, opts = {}
  * rejects `limit` outright (400 invalid_request_values "Unexpected field: limit"),
  * so live requests send only `cursor`. The raw thread is also OLDEST-first (same
  * paginator as conversations), so with no caller cursor we start from the tail
- * (podiumTailCursor()) to open the thread at its LATEST messages; the rows within
- * the page come back ascending, which is already the order a chat view renders.
- * Falls back to the plain (oldest-first) read if the synthetic cursor is rejected.
+ * (podiumTailCursor()) to open the thread at its LATEST messages. The tail page
+ * came back NEWEST-first in live testing, so the page is re-sorted ascending by
+ * createdAt — the order a chat view renders (oldest top, newest bottom) — which is
+ * also safe if Podium returns ascending rows. Falls back to the plain
+ * (oldest-first) read if the synthetic cursor is rejected.
  */
 export async function listMessages(userId, conversationUid, opts = {}) {
   if (isMock()) {
@@ -510,15 +523,21 @@ export async function listMessages(userId, conversationUid, opts = {}) {
     return request(userId, 'GET', `conversations/${conversationUid}/messages`, { query, client: opts.client });
   }
   const path = `conversations/${conversationUid}/messages`;
+  let resp;
   if (opts.cursor) {
-    return request(userId, 'GET', path, { query: { cursor: opts.cursor }, client: opts.client });
+    resp = await request(userId, 'GET', path, { query: { cursor: opts.cursor }, client: opts.client });
+  } else {
+    try {
+      resp = await request(userId, 'GET', path, { query: { cursor: podiumTailCursor() }, client: opts.client });
+    } catch (err) {
+      console.error('podium listMessages: tail cursor rejected, falling back to oldest-first:', err.message);
+      resp = await request(userId, 'GET', path, { query: {}, client: opts.client });
+    }
   }
-  try {
-    return await request(userId, 'GET', path, { query: { cursor: podiumTailCursor() }, client: opts.client });
-  } catch (err) {
-    console.error('podium listMessages: tail cursor rejected, falling back to oldest-first:', err.message);
-    return request(userId, 'GET', path, { query: {}, client: opts.client });
-  }
+  const data = (Array.isArray(resp?.data) ? resp.data : [])
+    .slice()
+    .sort((a, b) => (Date.parse(a?.createdAt) || 0) - (Date.parse(b?.createdAt) || 0));
+  return { ...resp, data };
 }
 
 /**

--- a/lib/podiumContact.js
+++ b/lib/podiumContact.js
@@ -45,6 +45,35 @@ export function normalizeContact(raw, conversation = null) {
   };
 }
 
+// Channel types whose identifier is a phone number (§15 conversation object:
+// ["apple","car_wars","email","facebook","fallback_email","google","google_brand",
+//  "iframe","instagram","phone","secure","sms","text","whatsapp"]). Social channels
+// carry opaque handles — those are neither a phone nor an email.
+const PHONE_CHANNEL_TYPES = new Set(['phone', 'sms', 'text', 'whatsapp']);
+
+/**
+ * Contact stub built from the conversation itself, for when there is no contact
+ * record to fetch. VERIFIED at live wiring (14 Jul 2026): LIVE conversations carry
+ * NO `contact` object (docs.podium.com/reference/the-conversation-object), and the
+ * live contacts list cannot be filtered by phone/email — so `contactName` + the
+ * channel identifier ARE the contact details, and they're enough for the F4
+ * email/phone customer match to run.
+ */
+export function channelStubContact(conversation, contactUid = null) {
+  const chan = conversation?.channel || null;
+  const ident = chan?.identifier || null;
+  const isEmail = typeof ident === 'string' && ident.includes('@');
+  const isPhone = !isEmail && !!ident && PHONE_CHANNEL_TYPES.has(String(chan?.type || ''));
+  return {
+    uid: contactUid,
+    name: conversation?.contactName || null,
+    email: isEmail ? ident : null,
+    phone: isPhone ? ident : null,
+    channels: [],
+    channel: chan,
+  };
+}
+
 /**
  * Resolve the Podium contact behind a conversation (or a direct contactId), AS the
  * logged-in rep (P4). Prefers a direct `contactId`; otherwise reads the conversation
@@ -59,25 +88,14 @@ export async function resolveContact(userId, { conversationId, contactId, client
 
   if (!contactUid && conversationId) {
     conversation = await getConversation(userId, String(conversationId), { client });
-    // conversation.contact.uid is the durable reference (the Contacts API is the
-    // source of truth; the message-event contact hint is deprecated, §15.6).
+    // conversation.contact.uid is the durable reference where it exists (mock rows).
+    // LIVE conversations have no contact object at all — the stub below carries the
+    // details the conversation itself holds (contactName + channel identifier).
     contactUid = conversation?.contact?.uid || null;
   }
 
   if (!contactUid) {
-    // No contact record to resolve. If we at least have the conversation, hand back a
-    // channel-only stub so the UI can still label the thread (e.g. the phone number).
-    if (conversation) {
-      const chan = conversation.channel || null;
-      return {
-        uid: null,
-        name: null,
-        email: null,
-        phone: chan?.type === 'phone' ? chan?.identifier || null : null,
-        channels: [],
-        channel: chan,
-      };
-    }
+    if (conversation) return channelStubContact(conversation);
     return null;
   }
 
@@ -322,17 +340,7 @@ export async function buildConversationIdentity(client, userId, conv) {
       if (err?.status !== 404) throw err; // contact gone upstream → fall through to a channel stub
     }
   }
-  if (!contact) {
-    const chan = conv?.channel || null;
-    contact = {
-      uid: contactUid,
-      name: null,
-      email: null,
-      phone: chan?.type === 'phone' ? chan?.identifier || null : null,
-      channels: [],
-      channel: chan,
-    };
-  }
+  if (!contact) contact = channelStubContact(conv, contactUid);
 
   const { customer, matchedBy } = await matchCustomer(client, contact);
   const displayName =

--- a/scripts/podium-inbox-smoke.mjs
+++ b/scripts/podium-inbox-smoke.mjs
@@ -24,7 +24,7 @@ process.env.PODIUM_API_VERSION = process.env.PODIUM_API_VERSION || '2021.04.01';
 const jwt = (await import('jsonwebtoken')).default;
 const { clampLimit, filterUpdatedSince, resolveSelfPodiumUid, normalizeBucket, normalizeStatus } = await import('../lib/podiumInbox.js');
 const { listConversations, listMessages, sendMessage, listMessageTemplates, postInternalNote, normalizeConversation, conversationMatchesFilters, podiumTailCursor } = await import('../lib/podium.js');
-const { buildConversationIdentity, identityMatchesSearch } = await import('../lib/podiumContact.js');
+const { buildConversationIdentity, identityMatchesSearch, channelStubContact } = await import('../lib/podiumContact.js');
 const inboxHandler = (await import('../lib/podiumRoutes/inbox.js')).default;
 
 let passed = 0;
@@ -506,6 +506,21 @@ console.log('\nF14 conversation search:');
   check('tail cursor: keyed on atom id', inner.slice(8, 10).toString('utf8') === 'id');
   check('tail cursor: int32 max payload', inner.readInt32BE(11) === 2147483647);
   check('tail cursor: inner base64 is URL-safe', !/[+/]/.test(outer.cursor));
+}
+
+{
+  // Live-wiring (14 Jul 2026): channelStubContact — LIVE conversations carry no
+  // contact object, so the stub must lift contactName + the channel identifier
+  // (phone for phone-ish channels, email when the identifier is an address,
+  // neither for opaque social handles) so the F4 customer match can still run.
+  const sms = channelStubContact({ contactName: 'Will Fleming', channel: { type: 'sms', identifier: '+61400999888' } });
+  check('stub: sms channel → name + phone', sms.name === 'Will Fleming' && sms.phone === '+61400999888' && sms.email === null);
+  const mail = channelStubContact({ contactName: 'Edna', channel: { type: 'email', identifier: 'edna@example.com' } });
+  check('stub: email identifier → email, no phone', mail.email === 'edna@example.com' && mail.phone === null);
+  const fb = channelStubContact({ contactName: 'FB Person', channel: { type: 'facebook', identifier: 'fb:someone' } });
+  check('stub: social handle → neither phone nor email, name kept', fb.name === 'FB Person' && fb.phone === null && fb.email === null);
+  const bare = channelStubContact(null);
+  check('stub: no conversation → empty stub', bare.name === null && bare.phone === null && bare.email === null && bare.uid === null);
 }
 
 console.log(`\n✅ inbox smoke: ${passed} checks passed`);


### PR DESCRIPTION
## What broke on production (after #67)
Nick's live testing surfaced three more live-vs-mock mismatches:

1. **Contact panel: "No contact details available from Podium"** — live conversations carry **no `contact` object** at all (docs: the-conversation-object), and the live contacts list can't be filtered by phone/email. The panel's fallback stub had nothing to show and the F4 customer match never ran.
2. **Thread order reversed** (newest at top) — the live tail page returns messages newest-first.
3. **Close conversation → "Not found in Podium"** — the live update endpoint is **PUT** `/v4/conversations/{uid}` with `{closed: boolean}` (docs: conversationupdate-1); our PATCH `{status}` hit a non-existent route.

## Fix
- `lib/podiumContact.js`: new `channelStubContact()` lifts **`contactName` + the channel identifier** from the conversation itself (phone for phone-ish channels, email for addresses, neither for opaque social handles), used by both `resolveContact` and `buildConversationIdentity` — the panel shows real details and the **email/phone customer match now runs on live rows**.
- `lib/podium.js` `listMessages` (live): page re-sorted **ascending by `createdAt`** (chat render order; safe either way).
- `lib/podium.js` `updateConversation`/`setConversationStatus` (live): **PUT** with `{closed}` (+ result normalised). Mock contracts unchanged (PATCH + `{status}`), so Preview flows and existing smoke checks still pass.

## Test
- `node scripts/podium-inbox-smoke.mjs` → **128/128** (+4 for the stub matrix).
- `CI=true npm run build` green (no frontend change).
- Post-merge live checks: open a thread (oldest→newest, newest at bottom), contact panel shows name + phone/email and matches the portal customer where one exists, Close/Reopen moves the conversation between Open/Closed buckets.

No migration, no new fn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)