### PR TITLE
F7b — Awaiting-Workorder queue (logistics)

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -12,6 +12,7 @@ import deliveryHandler from '../lib/handlers/delivery.js';
 import collectionsHandler from '../lib/handlers/collections.js';
 import winningsHandler from '../lib/handlers/winnings.js';
 import leadsHandler from '../lib/handlers/leads.js';
+import logisticsHandler from '../lib/handlers/logistics.js';
 import lotsHandler from '../lib/handlers/lots.js';
 import { buildJourney } from '../lib/customerJourney.js';
 
@@ -93,6 +94,11 @@ export default async function handler(req, res) {
       case 'leads':
       case 'lead':
         return leadsHandler(req, res, parts.slice(1));
+      // Logistics work queues (F7b). Pass the segments AFTER "logistics"; the handler
+      // also accepts ?resource= (the query form the front-end uses — safe under Vercel's
+      // multi-segment routing). JWT-gated to logistics/superadmin.
+      case 'logistics':
+        return logisticsHandler(req, res, parts.slice(1));
       case 'delivery':
         return deliveryHandler(req, res);
       case 'collections':

--- a/lib/handlers/logistics.js
+++ b/lib/handlers/logistics.js
@@ -1,0 +1,81 @@
+// lib/handlers/logistics.js — Logistics work queues (feature F7b).
+//
+// The logistics side of the funnel seam (execution-plan §F7). F7a (the salesperson)
+// raises a MYOB quote/invoice on a lead → stage 'Quoted' + `quote_invoice_id`. This
+// handler surfaces those quoted-but-not-yet-converted leads as a daily worklist for the
+// LOGISTICS person to work through: confirm the customer has paid (cross-checking MYOB),
+// then create the workorder (that action is F7c). F7b itself is a read-only queue.
+//
+// Routed through the api/[...path].js catch-all as a `logistics` case, which passes the
+// path segments AFTER "logistics". To stay on the app's proven-safe routing convention
+// (Vercel platform-404s multi-segment paths into the catch-all — F6 hit this and moved
+// to the query form), the front-end calls the QUERY form and this handler resolves the
+// resource from EITHER the path segment OR ?resource=:
+//   GET /api/logistics?resource=awaiting-workorder   ← the front-end uses this
+//   GET /api/logistics/awaiting-workorder            ← same result, if it ever routes
+//
+// Gated to logistics/superadmin via the login JWT (getAuthUser + hasAnyRole) — the server
+// is the real authority (F9 formalises nav). No message bodies are touched (P1 not in
+// scope — leads carry CRM metadata only).
+
+import { getClientWithTimezone } from '../db.js';
+import { getAuthUser, hasAnyRole } from '../rbac.js';
+
+const ALLOWED_ROLES = ['logistics', 'superadmin'];
+
+// The joined shape the Awaiting-Workorder worklist renders. Mirrors the leads handler's
+// LEAD_SELECT (customer + assignee names) but scoped to what logistics needs: the raised
+// invoice, the order value, the channel, and a handle back to the customer/conversation.
+// Order OLDEST-first (updated_at ASC) so the longest-waiting quote is worked first (FIFO).
+// updated_at is the best available proxy for "quoted at" — F7a stamps it when it moves the
+// lead to Quoted (no dedicated quoted_at column; noted as a known limitation).
+const AWAITING_SELECT = `
+  SELECT l.lead_id, l.stage, l.source, l.source_channel, l.customer_id,
+         l.podium_conversation_id, l.value_est, l.order_total, l.quote_invoice_id,
+         l.product_interest, l.assigned_to, l.created_at, l.updated_at,
+         c.name  AS customer_name, c.email AS customer_email, c.phone AS customer_phone,
+         u.name  AS assigned_name
+    FROM leads l
+    LEFT JOIN customers c ON c.id = l.customer_id
+    LEFT JOIN users     u ON u.id = l.assigned_to
+   WHERE l.stage = 'Quoted'::lead_stage
+     AND l.quote_invoice_id IS NOT NULL
+     AND btrim(l.quote_invoice_id) <> ''
+   ORDER BY l.updated_at ASC, l.lead_id ASC
+`;
+
+// sub = the path segments AFTER "logistics" (e.g. ['awaiting-workorder']).
+// deps.getClient lets the offline smoke inject a fake pg client (default = real pool).
+export default async function handler(req, res, sub = [], deps = {}) {
+  const auth = getAuthUser(req);
+  if (!auth) return res.status(401).json({ error: 'Not authenticated' });
+  if (!hasAnyRole(auth.roles, ALLOWED_ROLES)) {
+    return res.status(403).json({ error: 'Requires the logistics role to use the logistics queues' });
+  }
+
+  // Resolve the resource from the path segment OR ?resource= (query form is the safe one).
+  const seg = Array.isArray(sub) ? sub[0] : undefined;
+  const resource = (seg || req.query?.resource || '').toString();
+
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET']);
+    return res.status(405).json({ error: 'Method not allowed for this logistics route' });
+  }
+  if (resource !== 'awaiting-workorder') {
+    return res.status(404).json({ error: 'Unknown logistics resource' });
+  }
+
+  const getClient = deps.getClient || getClientWithTimezone;
+  const client = await getClient();
+  try {
+    const r = await client.query(AWAITING_SELECT);
+    return res.status(200).json(r.rows);
+  } catch (err) {
+    console.error('Logistics API error:', err);
+    // leads/lead_stage_log may be absent on a bare DB (pre-release prod) — degrade to empty.
+    if (err?.code === '42P01') return res.status(200).json([]);
+    return res.status(500).json({ error: 'Server error' });
+  } finally {
+    client.release();
+  }
+}

--- a/scripts/podium-logistics-smoke.mjs
+++ b/scripts/podium-logistics-smoke.mjs
@@ -1,0 +1,147 @@
+// scripts/podium-logistics-smoke.mjs — offline smoke for the F7b logistics queue handler.
+//
+// Exercises lib/handlers/logistics.js with an INJECTED fake pg client (deps.getClient), so
+// there is NO network, NO database, NO secrets:
+//
+//   node scripts/podium-logistics-smoke.mjs
+//
+// Covers: auth/role gates (logistics + superadmin allowed, others 403), method gate,
+// resource resolution from BOTH the path segment and ?resource=, the unknown-resource
+// 404, the Quoted-with-invoice filter in the SELECT, the bare-array shape, the 42P01
+// (leads table absent) → empty-array degrade, and client release. The end-to-end SELECT
+// is additionally round-tripped read-only against the Neon dev branch (see report).
+
+process.env.JWT_SECRET = process.env.JWT_SECRET || 'smoke_secret';
+
+const jwt = (await import('jsonwebtoken')).default;
+const logisticsHandler = (await import('../lib/handlers/logistics.js')).default;
+
+let passed = 0;
+function check(name, cond, detail) {
+  if (!cond) throw new Error(`FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  passed += 1;
+  console.log(`  ✓ ${name}`);
+}
+
+// ---- Fake pg client (records queries, returns scripted results) ---------------
+function makeClient(scripts = []) {
+  const calls = [];
+  return {
+    calls,
+    released: false,
+    release() { this.released = true; },
+    async query(sql, params) {
+      calls.push({ sql, params });
+      for (const s of scripts) {
+        if (typeof s.match === 'function' ? s.match(sql) : s.match.test(sql)) {
+          if (s.throws) throw s.throws;
+          return s.result ?? { rowCount: 0, rows: [] };
+        }
+      }
+      return { rowCount: 0, rows: [] };
+    },
+  };
+}
+const depsFor = (client) => ({ getClient: async () => client });
+
+function makeReq({ method = 'GET', roles = ['logistics'], id = 'LG', email = 'logistics@graysfitness.com.au', query = {}, noAuth = false } = {}) {
+  const headers = {};
+  if (!noAuth) headers.authorization = `Bearer ${jwt.sign({ id, email, roles }, process.env.JWT_SECRET, { expiresIn: '1h' })}`;
+  return { method, headers, query, body: {} };
+}
+function makeRes() {
+  return {
+    statusCode: 0, body: null, headers: {},
+    setHeader(k, v) { this.headers[k] = v; },
+    status(c) { this.statusCode = c; return this; },
+    json(o) { this.body = o; return this; },
+  };
+}
+
+const AWAIT_RE = /FROM leads l/i;
+const rowsResult = { rowCount: 2, rows: [
+  { lead_id: 5, stage: 'Quoted', quote_invoice_id: '20431', order_total: 3590, customer_id: 26, customer_name: 'Demo Customer', source_channel: 'phone', updated_at: '2026-07-12T02:00:00Z' },
+  { lead_id: 6, stage: 'Quoted', quote_invoice_id: '20500', order_total: 1795, customer_id: 555, customer_name: 'Another Customer', source_channel: 'email', updated_at: '2026-07-13T02:00:00Z' },
+] };
+
+console.log('Logistics queue (F7b) smoke — fake client, no DB\n');
+
+// ---- auth + method gates (return before any DB) -------------------------------
+console.log('auth / method gates:');
+{
+  const res = makeRes();
+  await logisticsHandler(makeReq({ noAuth: true }), res, ['awaiting-workorder'], depsFor(makeClient()));
+  check('401 without auth', res.statusCode === 401);
+}
+{
+  const res = makeRes();
+  await logisticsHandler(makeReq({ roles: ['sales'], query: { resource: 'awaiting-workorder' } }), res, [], depsFor(makeClient()));
+  check('403 for a sales role (not logistics)', res.statusCode === 403);
+}
+{
+  const res = makeRes();
+  await logisticsHandler(makeReq({ roles: ['technician'], query: { resource: 'awaiting-workorder' } }), res, [], depsFor(makeClient()));
+  check('403 for a technician role', res.statusCode === 403);
+}
+{
+  const res = makeRes();
+  await logisticsHandler(makeReq({ method: 'POST', query: { resource: 'awaiting-workorder' } }), res, [], depsFor(makeClient()));
+  check('405 for a non-GET method', res.statusCode === 405 && res.headers.Allow?.includes('GET'));
+}
+{
+  const res = makeRes();
+  await logisticsHandler(makeReq({ query: { resource: 'nope' } }), res, [], depsFor(makeClient()));
+  check('404 for an unknown resource', res.statusCode === 404);
+}
+
+// ---- GET awaiting-workorder — resource via QUERY form (the front-end path) -----
+console.log('\nGET /api/logistics?resource=awaiting-workorder:');
+{
+  const client = makeClient([{ match: AWAIT_RE, result: rowsResult }]);
+  const res = makeRes();
+  await logisticsHandler(makeReq({ query: { resource: 'awaiting-workorder' } }), res, [], depsFor(client));
+  check('200 returns a bare array of rows', res.statusCode === 200 && Array.isArray(res.body) && res.body.length === 2, `status ${res.statusCode}`);
+  check('client released', client.released === true);
+  const q = client.calls.find((c) => AWAIT_RE.test(c.sql));
+  check('SELECT filters stage = Quoted', !!q && /stage = 'Quoted'::lead_stage/i.test(q.sql));
+  check('SELECT requires a non-empty quote_invoice_id', !!q && /quote_invoice_id IS NOT NULL/i.test(q.sql) && /btrim\(l\.quote_invoice_id\) <> ''/i.test(q.sql));
+  check('SELECT orders oldest-first (updated_at ASC)', !!q && /ORDER BY l\.updated_at ASC/i.test(q.sql));
+}
+
+// ---- resource via PATH segment (the fallback route form) ----------------------
+console.log('\nGET /api/logistics/awaiting-workorder (path form):');
+{
+  const client = makeClient([{ match: AWAIT_RE, result: rowsResult }]);
+  const res = makeRes();
+  await logisticsHandler(makeReq(), res, ['awaiting-workorder'], depsFor(client));
+  check('200 via the path segment too', res.statusCode === 200 && res.body.length === 2);
+}
+
+// ---- superadmin is allowed ----------------------------------------------------
+console.log('\nrole coverage:');
+{
+  const client = makeClient([{ match: AWAIT_RE, result: rowsResult }]);
+  const res = makeRes();
+  await logisticsHandler(makeReq({ roles: ['superadmin'], query: { resource: 'awaiting-workorder' } }), res, [], depsFor(client));
+  check('200 for superadmin', res.statusCode === 200);
+}
+{
+  // a user holding BOTH sales + logistics still gets in (set membership)
+  const client = makeClient([{ match: AWAIT_RE, result: { rowCount: 0, rows: [] } }]);
+  const res = makeRes();
+  await logisticsHandler(makeReq({ roles: ['sales', 'logistics'], query: { resource: 'awaiting-workorder' } }), res, [], depsFor(client));
+  check('200 for a sales+logistics user', res.statusCode === 200 && Array.isArray(res.body));
+}
+
+// ---- degrade gracefully when leads is absent (42P01) --------------------------
+console.log('\nbare-DB degrade:');
+{
+  const err = new Error('relation "leads" does not exist'); err.code = '42P01';
+  const client = makeClient([{ match: AWAIT_RE, throws: err }]);
+  const res = makeRes();
+  await logisticsHandler(makeReq({ query: { resource: 'awaiting-workorder' } }), res, [], depsFor(client));
+  check('200 empty array when leads table is missing (42P01)', res.statusCode === 200 && Array.isArray(res.body) && res.body.length === 0);
+  check('client released after error', client.released === true);
+}
+
+console.log(`\n✅ logistics smoke: ${passed} checks passed`);

--- a/src/App.js
+++ b/src/App.js
@@ -8,6 +8,7 @@ import LandingPage from './pages/landingpage';
 import Settings from './pages/settings';
 import Inbox from './pages/inbox';
 import Leads from './pages/leads';
+import AwaitingWorkorder from './pages/logistics/awaiting-workorder';
 
 import ProductsPage from './pages/products';
 import EditProduct from './pages/products/edit';
@@ -109,6 +110,7 @@ function App() {
         <Route path="/settings" element={<Settings />} />
         <Route path="/inbox" element={<Inbox />} />
         <Route path="/leads" element={<Leads />} />
+        <Route path="/logistics/awaiting-workorder" element={<AwaitingWorkorder />} />
 
         <Route path="/products" element={<ProductsPage />} />
         <Route path="/products/:sku/edit" element={<EditProduct />} />

--- a/src/pages/dashboard.js
+++ b/src/pages/dashboard.js
@@ -47,6 +47,9 @@ export default function Dashboard() {
   // /api/podium/inbox and /api/leads).
   const canUseInbox = hasAnyRole(getRoles(), ['sales', 'superadmin']);
   const canUseLeads = canUseInbox;
+  // F7b: the Awaiting-Workorder queue is a logistics tool (the server also gates
+  // /api/logistics). superadmin sees it too.
+  const canUseLogistics = hasAnyRole(getRoles(), ['logistics', 'superadmin']);
 
   // base datasets
   const [products, setProducts] = useState([]);
@@ -273,6 +276,13 @@ export default function Dashboard() {
           {canUseLeads && (
             <Link to="/leads" className="text-gray-700 hover:bg-gray-200 p-2 rounded">
               Lead Funnel
+            </Link>
+          )}
+
+          {/* Awaiting-Workorder queue — logistics/superadmin (F7b) */}
+          {canUseLogistics && (
+            <Link to="/logistics/awaiting-workorder" className="text-gray-700 hover:bg-gray-200 p-2 rounded">
+              Awaiting Workorder
             </Link>
           )}
 

--- a/src/pages/logistics/awaiting-workorder.js
+++ b/src/pages/logistics/awaiting-workorder.js
@@ -1,0 +1,187 @@
+// src/pages/logistics/awaiting-workorder.js — Awaiting-Workorder queue (feature F7b).
+//
+// The logistics daily worklist over the F7b backend (lib/handlers/logistics.js →
+// GET /api/logistics?resource=awaiting-workorder). It lists leads a salesperson has
+// QUOTED (stage 'Quoted' with a MYOB `quote_invoice_id`, raised in F7a) that are waiting
+// on payment + workorder creation. Logistics works this list top-down (oldest first),
+// cross-checking MYOB for payment; converting a row into a workorder is F7c (a future
+// action button here). This page is read-only.
+//
+// Gated to logistics/superadmin (display-only here; the server re-checks on the login
+// JWT). The query form (?resource=) keeps us on the app's proven-safe single-segment
+// routing convention. No message bodies are touched — leads carry CRM metadata only.
+
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import toast from 'react-hot-toast';
+import BackButton from '../../components/backbutton';
+import HomeButton from '../../components/homebutton';
+import { authHeaders, getToken, getRoles, hasAnyRole } from '../../utils/auth';
+import { parseMaybeJson } from '../../utils/http';
+
+const LOGISTICS_ROLES = ['logistics', 'superadmin'];
+
+// Channel label map (mirrors the leads Kanban CHANNELS map).
+const CHANNELS = {
+  phone: 'SMS', sms: 'SMS', email: 'Email', facebook: 'Facebook',
+  instagram: 'Instagram', google: 'Google', webchat: 'Webchat', whatsapp: 'WhatsApp',
+};
+
+function money(v) {
+  if (v === null || v === undefined || v === '') return null;
+  const n = Number(v);
+  if (Number.isNaN(n)) return null;
+  return n.toLocaleString('en-AU', { style: 'currency', currency: 'AUD' });
+}
+
+// Human "time since" for the age column (from updated_at ≈ when it was quoted).
+function ageSince(iso) {
+  if (!iso) return '—';
+  const then = new Date(iso);
+  if (Number.isNaN(then.getTime())) return '—';
+  const mins = Math.max(0, Math.round((Date.now() - then.getTime()) / 60000));
+  if (mins < 60) return `${mins}m`;
+  const hrs = Math.round(mins / 60);
+  if (hrs < 48) return `${hrs}h`;
+  const days = Math.round(hrs / 24);
+  return `${days}d`;
+}
+
+export default function AwaitingWorkorder() {
+  const navigate = useNavigate();
+
+  const [authorized, setAuthorized] = useState(false);
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    if (!getToken()) { navigate('/'); return; }
+    if (!hasAnyRole(getRoles(), LOGISTICS_ROLES)) {
+      toast.error('The awaiting-workorder queue is for logistics users');
+      navigate('/dashboard');
+      return;
+    }
+    setAuthorized(true);
+  }, [navigate]);
+
+  const load = useCallback(async ({ silent = false } = {}) => {
+    if (!silent) setLoading(true);
+    try {
+      const res = await fetch('/api/logistics?resource=awaiting-workorder', { headers: authHeaders() });
+      if (res.status === 401) { navigate('/'); return; }
+      if (res.status === 403) { toast.error('The awaiting-workorder queue is for logistics users'); navigate('/dashboard'); return; }
+      const data = await parseMaybeJson(res);
+      if (!res.ok) { toast.error(data?.error || 'Could not load the queue'); return; }
+      setRows(Array.isArray(data) ? data : []);
+    } catch {
+      toast.error('Server error loading the queue');
+    } finally {
+      if (!silent) setLoading(false);
+    }
+  }, [navigate]);
+
+  useEffect(() => {
+    if (authorized) load();
+  }, [authorized, load]);
+
+  if (!authorized) return null;
+
+  return (
+    <div className="min-h-screen bg-gray-100 p-4 md:p-6">
+      <div className="max-w-6xl mx-auto">
+        <div className="flex items-center gap-2 mb-4">
+          <BackButton />
+          <HomeButton />
+          <div className="ml-auto">
+            <button
+              onClick={() => load()}
+              className="text-sm px-3 py-1.5 rounded border border-gray-300 bg-white hover:bg-gray-50"
+            >
+              Refresh
+            </button>
+          </div>
+        </div>
+
+        <header className="mb-4">
+          <h1 className="text-2xl font-bold flex items-center gap-3">
+            Awaiting Workorder
+            <span className="text-sm font-medium bg-amber-100 text-amber-800 rounded-full px-2.5 py-0.5">
+              {rows.length}
+            </span>
+          </h1>
+          <p className="text-sm text-gray-600 mt-1">
+            Quoted leads with a raised invoice, waiting on payment. Confirm payment in MYOB, then
+            create the workorder. Worked oldest-first.
+          </p>
+        </header>
+
+        {loading ? (
+          <div className="bg-white rounded shadow p-8 text-center text-gray-500">Loading…</div>
+        ) : rows.length === 0 ? (
+          <div className="bg-white rounded shadow p-8 text-center text-gray-500">
+            No leads are awaiting a workorder. When a salesperson raises a quote, it appears here.
+          </div>
+        ) : (
+          <div className="bg-white rounded shadow overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead>
+                <tr className="text-left text-gray-500 border-b">
+                  <th className="px-4 py-3 font-medium">Customer</th>
+                  <th className="px-4 py-3 font-medium">Channel</th>
+                  <th className="px-4 py-3 font-medium">Invoice #</th>
+                  <th className="px-4 py-3 font-medium">Value</th>
+                  <th className="px-4 py-3 font-medium">Sales rep</th>
+                  <th className="px-4 py-3 font-medium">Quoted</th>
+                  <th className="px-4 py-3 font-medium">Conversation</th>
+                </tr>
+              </thead>
+              <tbody>
+                {rows.map((r) => {
+                  const value = money(r.order_total) ?? money(r.value_est);
+                  const rep = r.assigned_name || r.assigned_to || 'Unassigned';
+                  const channel = r.source_channel ? (CHANNELS[String(r.source_channel).toLowerCase()] || r.source_channel) : '—';
+                  const custName = r.customer_name || (r.customer_id ? `Customer #${r.customer_id}` : 'Unmatched');
+                  return (
+                    <tr key={r.lead_id} className="border-b last:border-0 hover:bg-gray-50 align-top">
+                      <td className="px-4 py-3">
+                        {r.customer_id ? (
+                          <Link to={`/customers/${r.customer_id}`} className="font-medium text-blue-700 hover:underline">
+                            {custName}
+                          </Link>
+                        ) : (
+                          <span className="font-medium">{custName}</span>
+                        )}
+                        {r.product_interest ? (
+                          <div className="text-xs text-gray-500 mt-0.5">{r.product_interest}</div>
+                        ) : null}
+                        {r.customer_email ? (
+                          <div className="text-xs text-gray-400 mt-0.5">{r.customer_email}</div>
+                        ) : null}
+                      </td>
+                      <td className="px-4 py-3">{channel}</td>
+                      <td className="px-4 py-3 font-mono">{r.quote_invoice_id || '—'}</td>
+                      <td className="px-4 py-3">{value || '—'}</td>
+                      <td className="px-4 py-3">{rep}</td>
+                      <td className="px-4 py-3 text-gray-600" title={r.updated_at || ''}>{ageSince(r.updated_at)} ago</td>
+                      <td className="px-4 py-3">
+                        {r.customer_id ? (
+                          <Link to={`/customers/${r.customer_id}`} className="text-blue-600 hover:underline">
+                            Open
+                          </Link>
+                        ) : r.podium_conversation_id ? (
+                          <Link to="/inbox" className="text-blue-600 hover:underline">Inbox</Link>
+                        ) : (
+                          <span className="text-gray-400">—</span>
+                        )}
+                      </td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## F7b — Awaiting-Workorder queue (logistics)

The logistics side of the funnel seam (execution-plan §F7b). F7a lets a salesperson raise a MYOB quote/invoice on a lead → stage **Quoted** + `quote_invoice_id`. This PR surfaces those quoted-but-not-yet-converted leads as a **daily worklist for logistics** to work through: confirm payment (cross-checking MYOB), then create the workorder. Converting a row into a workorder is **F7c** (a future action button here) — F7b is a **read-only queue**.

### What's in it
- **`lib/handlers/logistics.js`** (new) — `GET /api/logistics?resource=awaiting-workorder` returns **Quoted** leads that carry a non-empty `quote_invoice_id`, joined to customer + assignee, **oldest-first** (longest-waiting quote worked first). JWT-gated to **logistics/superadmin**. `42P01`-safe (returns `[]` on a bare DB).
- **`api/[...path].js`** — new `logistics` case delegating to the handler. **No new serverless function** (stays within the Hobby 12-fn cap).
- **`src/pages/logistics/awaiting-workorder.js`** (new) — worklist table: customer, channel, invoice #, value, sales rep, age, and a link through to the conversation (Customer-360, F6).
- **`src/App.js`** — `/logistics/awaiting-workorder` route.
- **`src/pages/dashboard.js`** — nav link gated to **logistics/superadmin**.
- **`scripts/podium-logistics-smoke.mjs`** (new) — **15/15** offline (fake-client injection).

### Routing note
Uses the **query form** (`?resource=awaiting-workorder`, single path segment) — the app's proven-safe convention after the Vercel multi-segment-path routing regression (F6 hit it and moved to the query form). The handler also accepts the path segment if it ever routes.

### Scope / safety
- **No migration** — `leads.quote_invoice_id` / `order_total` shipped in F0 `0001` (reconfirmed on Neon dev).
- **No new serverless fn.**
- **Read-only**; no message bodies touched (**P1**).
- Server is the real authority (`getAuthUser` + `hasAnyRole`); F9 will formalise nav.

### Preview
Vercel Preview build = **success** — inspector `https://vercel.com/grays-supports-projects/grays-internal/489JpABuTmH4ST5WaVubUew3KjNU` (branch alias is SSO-gated under grays-supports-projects).

**Demo data:** one clearly-labelled demo Quoted lead was seeded on the Neon **dev** branch (lead #5, invoice `DEMO-20431`, customer #2, rep BR) so the queue shows a row on the Preview. Safe to delete: `DELETE FROM lead_stage_log WHERE lead_id=5; DELETE FROM leads WHERE lead_id=5;` (dev only).

### Test steps
1. Log in as a **superadmin** (or a user holding the `logistics` role).
2. Dashboard → **Awaiting Workorder** in the sidebar (hidden for sales-only/technician users).
3. The queue lists Quoted leads with a raised invoice, oldest-first. Verify the demo row: customer name, channel **SMS**, invoice **DEMO-20431**, value **$5,990**, rep **Brett**, an age, and an **Open** link.
4. Click the customer → lands on the Customer-360 page (the conversation is reachable from its Conversations tab).
5. As a **sales-only** user, confirm the nav link is absent and `GET /api/logistics?resource=awaiting-workorder` returns **403**.

### Reviewer checklist
- [x] Queue shows the right leads (Quoted + invoice), oldest-first.
- [x] Gating correct: logistics/superadmin only (nav + API 403 for others).
- [x] Empty-state reads well when there's nothing to work.
- [x] Columns/links are what logistics needs day-to-day.
- [x] Confirm the F7c action ("Confirm payment & create workorder") is the intended next step from this queue.

Do not merge without review. 🤖 Generated with [Claude Code](https://claude.com/claude-code)