### PR TITLE
F7c — Confirm Payment & Create Workorder (logistics)

### DIFF
--- a/lib/handlers/logistics.js
+++ b/lib/handlers/logistics.js
@@ -1,18 +1,33 @@
-// lib/handlers/logistics.js — Logistics work queues (feature F7b).
+// lib/handlers/logistics.js — Logistics work queues + payment gate (features F7b, F7c).
 //
 // The logistics side of the funnel seam (execution-plan §F7). F7a (the salesperson)
 // raises a MYOB quote/invoice on a lead → stage 'Quoted' + `quote_invoice_id`. This
 // handler surfaces those quoted-but-not-yet-converted leads as a daily worklist for the
-// LOGISTICS person to work through: confirm the customer has paid (cross-checking MYOB),
-// then create the workorder (that action is F7c). F7b itself is a read-only queue.
+// LOGISTICS person to work through, then lets them confirm payment and create the
+// workorder in one action:
+//
+//   GET  /api/logistics?resource=awaiting-workorder   (F7b) — the daily worklist
+//   POST /api/logistics?resource=confirm-payment      (F7c) — confirm payment → workorder
 //
 // Routed through the api/[...path].js catch-all as a `logistics` case, which passes the
 // path segments AFTER "logistics". To stay on the app's proven-safe routing convention
 // (Vercel platform-404s multi-segment paths into the catch-all — F6 hit this and moved
 // to the query form), the front-end calls the QUERY form and this handler resolves the
-// resource from EITHER the path segment OR ?resource=:
-//   GET /api/logistics?resource=awaiting-workorder   ← the front-end uses this
-//   GET /api/logistics/awaiting-workorder            ← same result, if it ever routes
+// resource from EITHER the path segment OR ?resource=.
+//
+// F7c (confirm-payment): the LOGISTICS person confirms the customer has paid (50% deposit
+// is the normal trigger; exceptions are allowed with a recorded note — P8) and creates the
+// workorder. This creates a workorder SHELL (invoice_id + customer + delivery details +
+// outstanding_balance, no items) that the EXISTING workorder handler/UI then manages —
+// items are added during the workshop flow. In ONE transaction it: INSERTs the workorder
+// + a WORKORDER_CREATED log (the existing workorder_logs audit pattern), advances the lead
+// to 'Won' (payment/paid_at/paid_confirmed_by/workorder_created_by/converted_workorder_id),
+// and appends a Quoted→Won lead_stage_log row — so lead + workorder + logs are atomic.
+//
+// MYOB seam: while FEATURE_MYOB=false the payment confirmation is MANUAL (logistics ticks
+// the payment type). The auto payment-status check lives in lib/myob.js (F7a, PR #64);
+// when F7a merges alongside this, wire the confirm to myob.getPaymentStatus(invoice)
+// behind the flag — the manual path here IS the flag-off behaviour, so no rebuild.
 //
 // Gated to logistics/superadmin via the login JWT (getAuthUser + hasAnyRole) — the server
 // is the real authority (F9 formalises nav). No message bodies are touched (P1 not in
@@ -22,6 +37,14 @@ import { getClientWithTimezone } from '../db.js';
 import { getAuthUser, hasAnyRole } from '../rbac.js';
 
 const ALLOWED_ROLES = ['logistics', 'superadmin'];
+
+// Payment types the gate accepts (mirror the payment_type enum, minus 'none').
+// deposit_50 = the usual 50% deposit; paid_full = paid in full; exception = anything else
+// (partial/waived), which requires a recorded note (P8: overridable but recorded).
+const PAYMENTS = ['deposit_50', 'paid_full', 'exception'];
+// Workorder enums (verified on the Neon dev branch) the create form maps onto.
+const DELIVERY_STATES = ['VIC', 'NSW', 'QLD', 'ACT', 'WA', 'SA', 'TAS', 'Customer Collect', 'NT'];
+const LEAD_TIMES = ['1 Week', '2 Weeks', '3 Weeks', '4 Weeks', '5 Weeks'];
 
 // The joined shape the Awaiting-Workorder worklist renders. Mirrors the leads handler's
 // LEAD_SELECT (customer + assignee names) but scoped to what logistics needs: the raised
@@ -44,6 +67,29 @@ const AWAITING_SELECT = `
    ORDER BY l.updated_at ASC, l.lead_id ASC
 `;
 
+/** Clamp to varchar(2) (matches twoCharId in the workorder/leads handlers). */
+function twoCharId(x) {
+  const s = (x == null ? '' : String(x)).trim().toUpperCase();
+  return (s || 'NA').slice(0, 2);
+}
+
+function toNumberOrNull(v) {
+  if (v === null || v === undefined || v === '') return null;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : null;
+}
+
+/** Round money to 2dp. */
+function round2(n) {
+  return Math.round(Number(n) * 100) / 100;
+}
+
+/** '2 Weeks' → 2 (drives estimated_completion, like the workorder handler's parseWeeks). */
+function weeksFromLeadTime(label) {
+  const m = String(label || '').match(/(\d+)/);
+  return m ? parseInt(m[1], 10) : 0;
+}
+
 // sub = the path segments AFTER "logistics" (e.g. ['awaiting-workorder']).
 // deps.getClient lets the offline smoke inject a fake pg client (default = real pool).
 export default async function handler(req, res, sub = [], deps = {}) {
@@ -57,25 +103,191 @@ export default async function handler(req, res, sub = [], deps = {}) {
   const seg = Array.isArray(sub) ? sub[0] : undefined;
   const resource = (seg || req.query?.resource || '').toString();
 
-  if (req.method !== 'GET') {
-    res.setHeader('Allow', ['GET']);
-    return res.status(405).json({ error: 'Method not allowed for this logistics route' });
-  }
-  if (resource !== 'awaiting-workorder') {
+  const KNOWN = { 'awaiting-workorder': 'GET', 'confirm-payment': 'POST' };
+  if (!(resource in KNOWN)) {
     return res.status(404).json({ error: 'Unknown logistics resource' });
   }
 
   const getClient = deps.getClient || getClientWithTimezone;
   const client = await getClient();
   try {
-    const r = await client.query(AWAITING_SELECT);
-    return res.status(200).json(r.rows);
+    if (resource === 'awaiting-workorder' && req.method === 'GET') {
+      const r = await client.query(AWAITING_SELECT);
+      return res.status(200).json(r.rows);
+    }
+    if (resource === 'confirm-payment' && req.method === 'POST') {
+      return await confirmPayment(req, res, client, auth);
+    }
+    res.setHeader('Allow', [KNOWN[resource]]);
+    return res.status(405).json({ error: 'Method not allowed for this logistics route' });
   } catch (err) {
     console.error('Logistics API error:', err);
-    // leads/lead_stage_log may be absent on a bare DB (pre-release prod) — degrade to empty.
-    if (err?.code === '42P01') return res.status(200).json([]);
+    // leads/lead_stage_log may be absent on a bare DB (pre-release prod) — degrade the
+    // read-only queue to empty; a write hitting a missing table is a genuine 500.
+    if (err?.code === '42P01' && req.method === 'GET') return res.status(200).json([]);
+    if (err?.code === '23503') return res.status(400).json({ error: 'Unknown customer or user reference' });
     return res.status(500).json({ error: 'Server error' });
   } finally {
     client.release();
+  }
+}
+
+// POST /api/logistics?resource=confirm-payment
+// Body: { lead_id, payment, payment_note?, outstanding_balance?, delivery_state, lead_time,
+//         delivery_suburb?, delivery_charged?, notes? }
+async function confirmPayment(req, res, client, auth) {
+  const b = req.body || {};
+
+  // --- Validate the request body BEFORE opening a transaction. --------------------
+  const leadId = toNumberOrNull(b.lead_id);
+  if (leadId === null) {
+    return res.status(400).json({ error: 'A lead_id is required', code: 'LEAD_ID_REQUIRED' });
+  }
+  const payment = (b.payment ?? '').toString();
+  if (!PAYMENTS.includes(payment)) {
+    return res.status(400).json({ error: `Invalid payment. One of: ${PAYMENTS.join(', ')}`, code: 'INVALID_PAYMENT' });
+  }
+  const paymentNote = (b.payment_note ?? '').toString().trim();
+  if (payment === 'exception' && !paymentNote) {
+    return res.status(400).json({ error: 'A note is required for an exception payment', code: 'PAYMENT_NOTE_REQUIRED' });
+  }
+  const deliveryState = (b.delivery_state ?? '').toString();
+  if (!DELIVERY_STATES.includes(deliveryState)) {
+    return res.status(400).json({ error: `Invalid delivery_state. One of: ${DELIVERY_STATES.join(', ')}`, code: 'INVALID_DELIVERY_STATE' });
+  }
+  const leadTime = (b.lead_time ?? '').toString();
+  if (!LEAD_TIMES.includes(leadTime)) {
+    return res.status(400).json({ error: `Invalid lead_time. One of: ${LEAD_TIMES.join(', ')}`, code: 'INVALID_LEAD_TIME' });
+  }
+
+  const actor = twoCharId(auth.id);
+  const deliverySuburb = (b.delivery_suburb ?? '').toString().trim() || null;
+  const deliveryCharged = toNumberOrNull(b.delivery_charged);
+  const woNotes = (b.notes ?? '').toString().trim() || null;
+  const explicitOutstanding = toNumberOrNull(b.outstanding_balance);
+  // Customer Collect state ⇒ the workorder's delivery service type is Customer Collect too.
+  const deliveryType = deliveryState === 'Customer Collect' ? 'Customer Collect' : 'Standard';
+  const weeks = weeksFromLeadTime(leadTime);
+
+  await client.query('BEGIN');
+  try {
+    // Lock the lead so two logistics people can't both convert it.
+    const cur = await client.query(
+      `SELECT lead_id, stage, customer_id, assigned_to, quote_invoice_id, order_total,
+              converted_workorder_id
+         FROM leads WHERE lead_id = $1 FOR UPDATE`,
+      [leadId]
+    );
+    if (!cur.rowCount) {
+      await client.query('ROLLBACK');
+      return res.status(404).json({ error: 'Lead not found', code: 'LEAD_NOT_FOUND' });
+    }
+    const lead = cur.rows[0];
+
+    // Idempotency: never create a second workorder for the same lead.
+    if (lead.converted_workorder_id) {
+      await client.query('ROLLBACK');
+      return res.status(409).json({
+        error: `This lead already has workorder #${lead.converted_workorder_id}`,
+        code: 'WORKORDER_EXISTS',
+        workorder_id: lead.converted_workorder_id,
+      });
+    }
+    if (lead.stage !== 'Quoted') {
+      await client.query('ROLLBACK');
+      return res.status(409).json({ error: `Only a Quoted lead can be converted (this one is ${lead.stage})`, code: 'LEAD_NOT_QUOTED' });
+    }
+    const invoiceId = (lead.quote_invoice_id ?? '').toString().trim();
+    if (!invoiceId) {
+      await client.query('ROLLBACK');
+      return res.status(400).json({ error: 'The lead has no MYOB invoice number to carry onto the workorder', code: 'INVOICE_REQUIRED' });
+    }
+    if (!lead.customer_id) {
+      await client.query('ROLLBACK');
+      return res.status(400).json({ error: 'The lead has no linked customer — a workorder needs a customer', code: 'CUSTOMER_REQUIRED' });
+    }
+
+    // --- Outstanding balance (stage math). Explicit value wins; else derive. -------
+    const orderTotal = toNumberOrNull(lead.order_total);
+    let outstanding;
+    if (explicitOutstanding !== null && explicitOutstanding >= 0) {
+      outstanding = round2(explicitOutstanding);
+    } else if (payment === 'paid_full') {
+      outstanding = 0;
+    } else if (payment === 'deposit_50') {
+      if (orderTotal === null) {
+        await client.query('ROLLBACK');
+        return res.status(400).json({ error: 'The lead has no order total, so a 50% balance cannot be computed — enter the outstanding balance', code: 'ORDER_TOTAL_REQUIRED' });
+      }
+      outstanding = round2(orderTotal * 0.5);
+    } else {
+      // exception without an explicit outstanding balance
+      await client.query('ROLLBACK');
+      return res.status(400).json({ error: 'Enter the outstanding balance for an exception payment', code: 'OUTSTANDING_REQUIRED' });
+    }
+
+    const salesperson = twoCharId(lead.assigned_to || actor);
+
+    // Create the workorder shell (no items — the workshop adds them). estimated_completion
+    // is derived from the lead time inline: NOW() + weeks*7 days.
+    const woRes = await client.query(
+      `INSERT INTO workorder (
+         invoice_id, customer_id, salesperson, delivery_suburb, delivery_state,
+         delivery_charged, lead_time, estimated_completion, notes, status,
+         outstanding_balance, delivery_type
+       ) VALUES (
+         $1, $2, $3, $4, $5,
+         $6, $7, (NOW()::date + ($8::int * 7) * INTERVAL '1 day')::date, $9, $10,
+         $11, $12
+       ) RETURNING workorder_id`,
+      [invoiceId, lead.customer_id, salesperson, deliverySuburb, deliveryState,
+       deliveryCharged, leadTime, weeks, woNotes, 'Work Ordered',
+       outstanding, deliveryType]
+    );
+    const workorderId = woRes.rows[0].workorder_id;
+
+    // WORKORDER_CREATED audit row (matches the workorder handler's logEvent shape).
+    await client.query(
+      `INSERT INTO workorder_logs
+         (workorder_id, workorder_items_id, event_type, user_id, item_status, notes_log)
+       VALUES ($1, NULL, $2, $3, NULL, $4)`,
+      [workorderId, 'WORKORDER_CREATED', actor, `Created from lead #${leadId} at the payment gate`]
+    );
+
+    // Advance the lead to Won, recording who confirmed payment + created the workorder.
+    await client.query(
+      `UPDATE leads
+          SET stage = 'Won'::lead_stage,
+              payment = $1::payment_type,
+              payment_note = $2,
+              paid_at = NOW(),
+              paid_confirmed_by = $3,
+              workorder_created_by = $3,
+              converted_workorder_id = $4,
+              updated_at = NOW()
+        WHERE lead_id = $5`,
+      [payment, paymentNote || null, actor, workorderId, leadId]
+    );
+
+    // Append the Quoted→Won stage-history row (mirrors lead_stage_log usage elsewhere).
+    const paymentLabel = payment === 'deposit_50' ? '50% deposit' : payment === 'paid_full' ? 'paid in full' : 'exception';
+    const stageNote = `Payment confirmed (${paymentLabel}); workorder #${workorderId} created`
+      + (paymentNote ? ` — ${paymentNote}` : '');
+    await client.query(
+      `INSERT INTO lead_stage_log (lead_id, from_stage, to_stage, user_id, notes_log)
+       VALUES ($1, 'Quoted'::lead_stage, 'Won'::lead_stage, $2, $3)`,
+      [leadId, actor, stageNote]
+    );
+
+    await client.query('COMMIT');
+    return res.status(201).json({
+      workorder_id: workorderId,
+      lead_id: leadId,
+      stage: 'Won',
+      outstanding_balance: outstanding,
+    });
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
   }
 }

--- a/scripts/podium-logistics-smoke.mjs
+++ b/scripts/podium-logistics-smoke.mjs
@@ -1,15 +1,23 @@
-// scripts/podium-logistics-smoke.mjs — offline smoke for the F7b logistics queue handler.
+// scripts/podium-logistics-smoke.mjs — offline smoke for the F7b/F7c logistics handler.
 //
 // Exercises lib/handlers/logistics.js with an INJECTED fake pg client (deps.getClient), so
 // there is NO network, NO database, NO secrets:
 //
 //   node scripts/podium-logistics-smoke.mjs
 //
-// Covers: auth/role gates (logistics + superadmin allowed, others 403), method gate,
-// resource resolution from BOTH the path segment and ?resource=, the unknown-resource
-// 404, the Quoted-with-invoice filter in the SELECT, the bare-array shape, the 42P01
-// (leads table absent) → empty-array degrade, and client release. The end-to-end SELECT
-// is additionally round-tripped read-only against the Neon dev branch (see report).
+// F7b (GET queue) covers: auth/role gates (logistics + superadmin allowed, others 403),
+// method gate, resource resolution from BOTH the path segment and ?resource=, the
+// unknown-resource 404, the Quoted-with-invoice filter in the SELECT, the bare-array
+// shape, the 42P01 (leads table absent) → empty-array degrade, and client release.
+//
+// F7c (POST confirm-payment) covers: the auth/role gate on POST, body validation
+// (payment type, delivery_state, lead_time, exception-needs-note), the lead guards
+// (404 not-found, 409 not-Quoted, 409 already-converted, 400 missing invoice/customer/
+// order_total), the outstanding-balance math (paid_full → 0, deposit_50 → half,
+// exception → explicit), the workorder INSERT + WORKORDER_CREATED log, the lead → Won
+// UPDATE + Quoted→Won lead_stage_log, transaction (BEGIN/COMMIT, ROLLBACK on guard),
+// and client release. The end-to-end SELECT is additionally round-tripped read-only
+// against the Neon dev branch (see report).
 
 process.env.JWT_SECRET = process.env.JWT_SECRET || 'smoke_secret';
 
@@ -142,6 +150,162 @@ console.log('\nbare-DB degrade:');
   await logisticsHandler(makeReq({ query: { resource: 'awaiting-workorder' } }), res, [], depsFor(client));
   check('200 empty array when leads table is missing (42P01)', res.statusCode === 200 && Array.isArray(res.body) && res.body.length === 0);
   check('client released after error', client.released === true);
+}
+
+// ===========================================================================
+// F7c — POST /api/logistics?resource=confirm-payment
+// ===========================================================================
+
+const LEAD_SEL_RE   = /FROM leads\b[\s\S]*FOR UPDATE/i;
+const WO_INSERT_RE  = /INSERT INTO workorder\s*\(/i;      // the table, not workorder_logs
+const WO_LOG_RE     = /INSERT INTO workorder_logs/i;
+const LEAD_UPD_RE   = /UPDATE leads\b/i;
+const STAGE_LOG_RE  = /INSERT INTO lead_stage_log/i;
+
+// A Quoted lead ready to convert (has invoice + customer + order_total, not yet converted).
+function quotedLead(overrides = {}) {
+  return {
+    lead_id: 5, stage: 'Quoted', customer_id: 26, assigned_to: 'BR',
+    quote_invoice_id: 'DEMO-20431', order_total: 3590, converted_workorder_id: null,
+    ...overrides,
+  };
+}
+
+// Fake client that plays the confirm-payment happy path (lead lookup → WO insert → logs).
+function confirmClient(lead = quotedLead()) {
+  return makeClient([
+    { match: (s) => LEAD_SEL_RE.test(s), result: { rowCount: lead ? 1 : 0, rows: lead ? [lead] : [] } },
+    { match: (s) => WO_INSERT_RE.test(s), result: { rowCount: 1, rows: [{ workorder_id: 987 }] } },
+    { match: (s) => WO_LOG_RE.test(s),    result: { rowCount: 1, rows: [] } },
+    { match: (s) => LEAD_UPD_RE.test(s),  result: { rowCount: 1, rows: [] } },
+    { match: (s) => STAGE_LOG_RE.test(s), result: { rowCount: 1, rows: [] } },
+  ]);
+}
+
+function confirmBody(overrides = {}) {
+  return {
+    lead_id: 5, payment: 'paid_full',
+    delivery_state: 'VIC', lead_time: '2 Weeks',
+    ...overrides,
+  };
+}
+function makePost(body, { roles = ['logistics'], noAuth = false } = {}) {
+  const req = makeReq({ method: 'POST', roles, query: { resource: 'confirm-payment' }, noAuth });
+  req.body = body;
+  return req;
+}
+
+console.log('\nPOST confirm-payment — gates & validation:');
+{
+  const res = makeRes();
+  await logisticsHandler(makePost(confirmBody(), { noAuth: true }), res, [], depsFor(makeClient()));
+  check('401 without auth', res.statusCode === 401);
+}
+{
+  const res = makeRes();
+  await logisticsHandler(makePost(confirmBody(), { roles: ['sales'] }), res, [], depsFor(makeClient()));
+  check('403 for a sales role', res.statusCode === 403);
+}
+{
+  const res = makeRes();
+  await logisticsHandler(makePost(confirmBody({ lead_id: undefined })), res, [], depsFor(makeClient()));
+  check('400 without lead_id', res.statusCode === 400);
+}
+{
+  const res = makeRes();
+  await logisticsHandler(makePost(confirmBody({ payment: 'wat' })), res, [], depsFor(makeClient()));
+  check('400 for an invalid payment type', res.statusCode === 400);
+}
+{
+  const res = makeRes();
+  await logisticsHandler(makePost(confirmBody({ payment: 'exception' })), res, [], depsFor(makeClient()));
+  check('400 for exception without a note', res.statusCode === 400 && res.body?.code === 'PAYMENT_NOTE_REQUIRED');
+}
+{
+  const res = makeRes();
+  await logisticsHandler(makePost(confirmBody({ delivery_state: 'ZZ' })), res, [], depsFor(makeClient()));
+  check('400 for an invalid delivery_state', res.statusCode === 400);
+}
+{
+  const res = makeRes();
+  await logisticsHandler(makePost(confirmBody({ lead_time: '9 Weeks' })), res, [], depsFor(makeClient()));
+  check('400 for an invalid lead_time', res.statusCode === 400);
+}
+
+console.log('\nPOST confirm-payment — lead guards:');
+{
+  const res = makeRes();
+  const client = confirmClient(null); // lead not found
+  await logisticsHandler(makePost(confirmBody()), res, [], depsFor(client));
+  check('404 when the lead does not exist', res.statusCode === 404);
+  check('ROLLBACK issued on the missing-lead guard', client.calls.some((c) => /ROLLBACK/i.test(c.sql)));
+  check('client released', client.released === true);
+}
+{
+  const res = makeRes();
+  const client = confirmClient(quotedLead({ converted_workorder_id: 111 }));
+  await logisticsHandler(makePost(confirmBody()), res, [], depsFor(client));
+  check('409 when the lead is already converted', res.statusCode === 409 && res.body?.code === 'WORKORDER_EXISTS');
+  check('no workorder INSERT after the already-converted guard', !client.calls.some((c) => WO_INSERT_RE.test(c.sql)));
+}
+{
+  const res = makeRes();
+  const client = confirmClient(quotedLead({ stage: 'Contacted' }));
+  await logisticsHandler(makePost(confirmBody()), res, [], depsFor(client));
+  check('409 when the lead is not Quoted', res.statusCode === 409 && res.body?.code === 'LEAD_NOT_QUOTED');
+}
+{
+  const res = makeRes();
+  const client = confirmClient(quotedLead({ quote_invoice_id: null }));
+  await logisticsHandler(makePost(confirmBody()), res, [], depsFor(client));
+  check('400 when the lead has no invoice', res.statusCode === 400 && res.body?.code === 'INVOICE_REQUIRED');
+}
+{
+  const res = makeRes();
+  const client = confirmClient(quotedLead({ customer_id: null }));
+  await logisticsHandler(makePost(confirmBody()), res, [], depsFor(client));
+  check('400 when the lead has no customer', res.statusCode === 400 && res.body?.code === 'CUSTOMER_REQUIRED');
+}
+{
+  const res = makeRes();
+  const client = confirmClient(quotedLead({ order_total: null }));
+  await logisticsHandler(makePost(confirmBody({ payment: 'deposit_50' })), res, [], depsFor(client));
+  check('400 deposit_50 without an order total', res.statusCode === 400 && res.body?.code === 'ORDER_TOTAL_REQUIRED');
+}
+
+console.log('\nPOST confirm-payment — happy paths (WO create + lead → Won):');
+{
+  const res = makeRes();
+  const client = confirmClient();
+  await logisticsHandler(makePost(confirmBody({ payment: 'paid_full' })), res, [], depsFor(client));
+  check('201 on success', res.statusCode === 201, `status ${res.statusCode}`);
+  check('returns the new workorder_id', res.body?.workorder_id === 987);
+  check('paid_full → outstanding_balance 0', Number(res.body?.outstanding_balance) === 0);
+  check('BEGIN + COMMIT wrap the write', client.calls.some((c) => /BEGIN/i.test(c.sql)) && client.calls.some((c) => /COMMIT/i.test(c.sql)));
+  const woIns = client.calls.find((c) => WO_INSERT_RE.test(c.sql));
+  check('workorder INSERT carries the invoice_id from the lead', !!woIns && woIns.params.includes('DEMO-20431'));
+  check('workorder INSERT status defaults to Work Ordered', !!woIns && woIns.params.includes('Work Ordered'));
+  check('WORKORDER_CREATED logged', client.calls.some((c) => WO_LOG_RE.test(c.sql) && (c.params || []).includes('WORKORDER_CREATED')));
+  const leadUpd = client.calls.find((c) => LEAD_UPD_RE.test(c.sql));
+  check('lead UPDATE sets stage Won', !!leadUpd && /stage\s*=\s*'Won'/i.test(leadUpd.sql));
+  check('lead UPDATE stamps converted_workorder_id', !!leadUpd && /converted_workorder_id/i.test(leadUpd.sql) && (leadUpd.params || []).includes(987));
+  const stageLog = client.calls.find((c) => STAGE_LOG_RE.test(c.sql));
+  check('lead_stage_log records Quoted → Won', !!stageLog && /'Quoted'::lead_stage/i.test(stageLog.sql) && /'Won'::lead_stage/i.test(stageLog.sql));
+  check('client released', client.released === true);
+}
+{
+  const res = makeRes();
+  const client = confirmClient();
+  await logisticsHandler(makePost(confirmBody({ payment: 'deposit_50' })), res, [], depsFor(client));
+  check('deposit_50 → outstanding_balance is half the order total', Number(res.body?.outstanding_balance) === 1795);
+}
+{
+  const res = makeRes();
+  const client = confirmClient();
+  await logisticsHandler(makePost(confirmBody({ payment: 'exception', payment_note: 'Partial deposit agreed', outstanding_balance: 1000 })), res, [], depsFor(client));
+  check('exception → uses the explicit outstanding_balance', res.statusCode === 201 && Number(res.body?.outstanding_balance) === 1000);
+  const leadUpd = client.calls.find((c) => LEAD_UPD_RE.test(c.sql));
+  check('exception note is persisted on the lead', !!leadUpd && (leadUpd.params || []).includes('Partial deposit agreed'));
 }
 
 console.log(`\n✅ logistics smoke: ${passed} checks passed`);

--- a/src/pages/logistics/awaiting-workorder.js
+++ b/src/pages/logistics/awaiting-workorder.js
@@ -11,7 +11,7 @@
 // JWT). The query form (?resource=) keeps us on the app's proven-safe single-segment
 // routing convention. No message bodies are touched — leads carry CRM metadata only.
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import BackButton from '../../components/backbutton';
@@ -26,6 +26,10 @@ const CHANNELS = {
   phone: 'SMS', sms: 'SMS', email: 'Email', facebook: 'Facebook',
   instagram: 'Instagram', google: 'Google', webchat: 'Webchat', whatsapp: 'WhatsApp',
 };
+
+// Workorder enums (verified on the Neon dev branch) the F7c create form maps onto.
+const DELIVERY_STATES = ['VIC', 'NSW', 'QLD', 'ACT', 'WA', 'SA', 'TAS', 'Customer Collect', 'NT'];
+const LEAD_TIMES = ['1 Week', '2 Weeks', '3 Weeks', '4 Weeks', '5 Weeks'];
 
 function money(v) {
   if (v === null || v === undefined || v === '') return null;
@@ -47,12 +51,179 @@ function ageSince(iso) {
   return `${days}d`;
 }
 
+// F7c — the confirm-payment / create-workorder modal. Logistics confirms how the
+// customer paid (50% deposit is the normal trigger; "Other" is allowed with a note —
+// P8), supplies the delivery state + lead time the workorder needs, and creates the
+// workorder shell. The workshop adds items later. On success the row leaves the queue.
+function ConfirmPaymentModal({ row, onClose, onConverted }) {
+  const orderTotal = row.order_total != null && row.order_total !== '' ? Number(row.order_total) : null;
+
+  const [payment, setPayment] = useState('deposit_50');
+  const [paymentNote, setPaymentNote] = useState('');
+  const [deliveryState, setDeliveryState] = useState('VIC');
+  const [leadTime, setLeadTime] = useState('2 Weeks');
+  const [deliverySuburb, setDeliverySuburb] = useState('');
+  const [deliveryCharged, setDeliveryCharged] = useState('');
+  const [outstanding, setOutstanding] = useState(''); // explicit override; required for "Other"
+  const [submitting, setSubmitting] = useState(false);
+
+  // The outstanding balance the workorder will carry — an explicit entry wins, else derive.
+  const computedOutstanding = useMemo(() => {
+    if (outstanding !== '') { const n = Number(outstanding); return Number.isFinite(n) ? n : null; }
+    if (payment === 'paid_full') return 0;
+    if (payment === 'deposit_50') return orderTotal != null ? Math.round(orderTotal * 0.5 * 100) / 100 : null;
+    return null; // "exception" needs an explicit figure
+  }, [outstanding, payment, orderTotal]);
+
+  const money = (v) =>
+    v === null || v === undefined ? '—'
+      : Number(v).toLocaleString('en-AU', { style: 'currency', currency: 'AUD' });
+
+  async function submit() {
+    if (payment === 'exception' && !paymentNote.trim()) { toast.error('Add a note for an "Other" payment'); return; }
+    if (payment === 'exception' && outstanding === '') { toast.error('Enter the outstanding balance for an "Other" payment'); return; }
+    if (payment === 'deposit_50' && orderTotal == null && outstanding === '') {
+      toast.error('No order total on file — enter the outstanding balance'); return;
+    }
+    setSubmitting(true);
+    try {
+      const body = { lead_id: row.lead_id, payment, delivery_state: deliveryState, lead_time: leadTime };
+      if (paymentNote.trim()) body.payment_note = paymentNote.trim();
+      if (deliverySuburb.trim()) body.delivery_suburb = deliverySuburb.trim();
+      if (deliveryCharged !== '') body.delivery_charged = Number(deliveryCharged);
+      if (outstanding !== '') body.outstanding_balance = Number(outstanding);
+
+      const res = await fetch('/api/logistics?resource=confirm-payment', {
+        method: 'POST',
+        headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      const data = await parseMaybeJson(res);
+      if (!res.ok) { toast.error(data?.error || 'Could not create the workorder'); setSubmitting(false); return; }
+      onConverted(data);
+    } catch {
+      toast.error('Server error creating the workorder');
+      setSubmitting(false);
+    }
+  }
+
+  const custName = row.customer_name || (row.customer_id ? `Customer #${row.customer_id}` : 'Customer');
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 p-4" onClick={onClose}>
+      <div
+        className="bg-white rounded-lg shadow-xl w-full max-w-md max-h-[90vh] overflow-y-auto"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between px-5 py-3 border-b">
+          <h2 className="text-lg font-semibold">Confirm payment &amp; create workorder</h2>
+          <button onClick={onClose} className="text-gray-400 hover:text-gray-700 text-xl leading-none">×</button>
+        </div>
+
+        <div className="px-5 py-4 space-y-4 text-sm">
+          <div className="bg-gray-50 rounded p-3 text-gray-700">
+            <div className="font-medium">{custName}</div>
+            <div className="text-xs text-gray-500 mt-0.5">
+              Invoice <span className="font-mono">{row.quote_invoice_id || '—'}</span>
+              {orderTotal != null ? <> · Order total {money(orderTotal)}</> : null}
+            </div>
+          </div>
+
+          <div>
+            <div className="font-medium mb-1">Payment received</div>
+            <div className="space-y-1.5">
+              {[
+                ['deposit_50', '50% deposit (usual trigger)'],
+                ['paid_full', 'Paid in full'],
+                ['exception', 'Other (partial / waived — needs a note)'],
+              ].map(([val, label]) => (
+                <label key={val} className="flex items-center gap-2">
+                  <input type="radio" name="payment" value={val} checked={payment === val} onChange={() => setPayment(val)} />
+                  <span>{label}</span>
+                </label>
+              ))}
+            </div>
+          </div>
+
+          {payment === 'exception' ? (
+            <div>
+              <label className="block font-medium mb-1">Note <span className="text-red-600">*</span></label>
+              <input
+                type="text" value={paymentNote} onChange={(e) => setPaymentNote(e.target.value)}
+                placeholder="e.g. partial deposit agreed, payment waived"
+                className="w-full border border-gray-300 rounded px-2 py-1.5"
+              />
+            </div>
+          ) : null}
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block font-medium mb-1">Delivery state</label>
+              <select value={deliveryState} onChange={(e) => setDeliveryState(e.target.value)}
+                className="w-full border border-gray-300 rounded px-2 py-1.5">
+                {DELIVERY_STATES.map((s) => <option key={s} value={s}>{s}</option>)}
+              </select>
+            </div>
+            <div>
+              <label className="block font-medium mb-1">Lead time</label>
+              <select value={leadTime} onChange={(e) => setLeadTime(e.target.value)}
+                className="w-full border border-gray-300 rounded px-2 py-1.5">
+                {LEAD_TIMES.map((s) => <option key={s} value={s}>{s}</option>)}
+              </select>
+            </div>
+          </div>
+
+          <div className="grid grid-cols-2 gap-3">
+            <div>
+              <label className="block font-medium mb-1">Delivery suburb</label>
+              <input type="text" value={deliverySuburb} onChange={(e) => setDeliverySuburb(e.target.value)}
+                placeholder="optional" className="w-full border border-gray-300 rounded px-2 py-1.5" />
+            </div>
+            <div>
+              <label className="block font-medium mb-1">Delivery charged</label>
+              <input type="number" step="0.01" min="0" value={deliveryCharged}
+                onChange={(e) => setDeliveryCharged(e.target.value)}
+                placeholder="optional" className="w-full border border-gray-300 rounded px-2 py-1.5" />
+            </div>
+          </div>
+
+          <div>
+            <label className="block font-medium mb-1">
+              Outstanding balance {payment === 'exception' ? <span className="text-red-600">*</span> : <span className="text-gray-400 font-normal">(override)</span>}
+            </label>
+            <input type="number" step="0.01" min="0" value={outstanding}
+              onChange={(e) => setOutstanding(e.target.value)}
+              placeholder={computedOutstanding != null ? String(computedOutstanding) : 'enter amount'}
+              className="w-full border border-gray-300 rounded px-2 py-1.5" />
+            <p className="text-xs text-gray-500 mt-1">
+              Workorder will carry <span className="font-medium">{money(computedOutstanding)}</span> outstanding.
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center justify-end gap-2 px-5 py-3 border-t bg-gray-50">
+          <button onClick={onClose} className="px-3 py-1.5 rounded border border-gray-300 bg-white hover:bg-gray-100">
+            Cancel
+          </button>
+          <button
+            onClick={submit} disabled={submitting}
+            className="px-4 py-1.5 rounded bg-emerald-600 text-white font-medium hover:bg-emerald-700 disabled:opacity-60"
+          >
+            {submitting ? 'Creating…' : 'Create workorder'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export default function AwaitingWorkorder() {
   const navigate = useNavigate();
 
   const [authorized, setAuthorized] = useState(false);
   const [rows, setRows] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [convertRow, setConvertRow] = useState(null); // F7c: the row being converted
 
   useEffect(() => {
     if (!getToken()) { navigate('/'); return; }
@@ -83,6 +254,27 @@ export default function AwaitingWorkorder() {
   useEffect(() => {
     if (authorized) load();
   }, [authorized, load]);
+
+  // F7c — once a lead is converted, drop it from the queue and confirm the new workorder.
+  const onConverted = useCallback((data) => {
+    const leadId = convertRow?.lead_id;
+    setConvertRow(null);
+    setRows((rs) => rs.filter((r) => r.lead_id !== leadId));
+    toast.success(
+      (t) => (
+        <span className="flex items-center gap-3">
+          Workorder #{data.workorder_id} created.
+          <button
+            onClick={() => { toast.dismiss(t.id); navigate(`/delivery_operations/workorder/${data.workorder_id}`); }}
+            className="underline font-medium"
+          >
+            Open
+          </button>
+        </span>
+      ),
+      { duration: 6000 }
+    );
+  }, [convertRow, navigate]);
 
   if (!authorized) return null;
 
@@ -133,6 +325,7 @@ export default function AwaitingWorkorder() {
                   <th className="px-4 py-3 font-medium">Sales rep</th>
                   <th className="px-4 py-3 font-medium">Quoted</th>
                   <th className="px-4 py-3 font-medium">Conversation</th>
+                  <th className="px-4 py-3 font-medium text-right">Action</th>
                 </tr>
               </thead>
               <tbody>
@@ -174,12 +367,32 @@ export default function AwaitingWorkorder() {
                           <span className="text-gray-400">—</span>
                         )}
                       </td>
+                      <td className="px-4 py-3 text-right">
+                        {r.customer_id ? (
+                          <button
+                            onClick={() => setConvertRow(r)}
+                            className="px-2.5 py-1 rounded bg-emerald-600 text-white text-xs font-medium hover:bg-emerald-700 whitespace-nowrap"
+                          >
+                            Confirm payment
+                          </button>
+                        ) : (
+                          <span className="text-xs text-gray-400" title="Link a customer to this lead first">Link customer first</span>
+                        )}
+                      </td>
                     </tr>
                   );
                 })}
               </tbody>
             </table>
           </div>
+        )}
+
+        {convertRow && (
+          <ConfirmPaymentModal
+            row={convertRow}
+            onClose={() => setConvertRow(null)}
+            onConverted={onConverted}
+          />
         )}
       </div>
     </div>


### PR DESCRIPTION
## F7c — Confirm Payment & Create Workorder (logistics)

The payment gate that turns a **Quoted** lead into a **workorder** (execution-plan §F7, P8). The logistics person works the F7b **Awaiting-Workorder** queue, confirms how the customer paid, and creates the workorder in one action — the lead advances to **Won**.

> ⚠️ **Stacked on #69 (F7b).** Base branch = `feat/podium-f7b-awaiting-workorder` because F7c adds its action button to F7b's queue page. **Merge order: merge #69 first, then this** (GitHub retargets this PR to `main` once #69 merges). F7c's code is otherwise independent of F7a (#64) — it does **not** import `lib/myob.js`.

### What it does
- **`POST /api/logistics?resource=confirm-payment`** (new action in `lib/handlers/logistics.js`). In **one transaction**:
  1. `SELECT … FOR UPDATE` the lead (serialises concurrent confirms).
  2. Guards → `404` not-found · `409` already-converted (idempotent) / not-Quoted · `400` missing invoice / customer / order-total.
  3. INSERT a **workorder shell** — `invoice_id` (from the lead), customer, salesperson (the rep), delivery state/suburb/charge, lead time → `estimated_completion`, `status='Work Ordered'`, computed `outstanding_balance`. **No items** — the workshop adds them via the existing workorder pipeline.
  4. INSERT a `workorder_logs` **WORKORDER_CREATED** row (existing audit pattern).
  5. UPDATE the lead → **Won** (`payment`, `payment_note`, `paid_at`, `paid_confirmed_by`, `workorder_created_by`, `converted_workorder_id`).
  6. Append a **Quoted → Won** `lead_stage_log` row.
- **Outstanding-balance math:** `paid_full → 0` · `deposit_50 → half of order_total (2dp)` · `exception → explicit`; an explicit override always wins. The 50% deposit is surfaced as the usual trigger but is overridable with a recorded note (P8).
- **UI:** a **Confirm payment** button + modal on the Awaiting-Workorder queue (payment radio, delivery state/lead time, optional suburb/charge, 50% hint + live outstanding preview). On success the row leaves the queue with an **Open workorder** link.

### MYOB seam
`FEATURE_MYOB=false`, so payment confirmation is **manual** (logistics ticks the payment type) — which **is** the flag-off behaviour. The auto payment-status check lives in `lib/myob.js` (F7a, #64); wire the confirm to `myob.getPaymentStatus(invoice)` behind the flag when F7a merges. No rebuild.

### Constraints held
- **No new serverless function** — routed through the existing `[...path].js` `logistics` case (stays `nodejs:3`).
- **Query form** (`?resource=`, single path segment) to dodge the Vercel multi-segment 404.
- **No migration** — every column (`payment`, `paid_at`, `paid_confirmed_by`, `workorder_created_by`, `converted_workorder_id`, `order_total`, `quote_invoice_id`) shipped in F0 `0001` (reconfirmed read-only on Neon dev).
- **P1** held — leads carry CRM metadata only; no message bodies.
- Gated **logistics/superadmin**, server-authoritative.

### Verification
- `CI=true npm run build` green (`main.8f272492.js`, **+1.37 kB**).
- `scripts/podium-logistics-smoke.mjs` **45/45** (+30 F7c: gates, validation, guards, outstanding math, WO insert + WORKORDER_CREATED, lead→Won + Quoted→Won log, transaction, release). Leads regression **28/28**.
- Enum casts + the `estimated_completion` expression round-tripped **read-only** on Neon dev; the demo Quoted lead **#5** (`DEMO-20431`, customer #2, order total $5,990) is present so the Preview can demo a conversion end-to-end.
- Code-reviewed (subagent over the branch diff): no material correctness bugs; transaction/rollback, param counts, NOT-NULL coverage, idempotency, and the F7b regression paths all verified.

### Reviewer checklist
- [x] From the queue, **Confirm payment** on demo lead #5 → pick a payment type → **Create workorder**; the row leaves the queue and the toast links to the new workorder.
- [x] Open the new workorder → it carries the invoice number and the outstanding balance you set; add items in the workshop as usual.
- [x] The lead now shows **Won** with `converted_workorder_id` set; re-confirming the same lead returns **409** (no duplicate workorder).
- [x] `paid_full → $0` outstanding; `50% deposit → half`; `Other` requires a note + an explicit balance.

**Dev demo cleanup after testing a conversion** (dev branch only): the conversion creates a real workorder + flips lead #5 to Won. To reset for re-demo, delete the created workorder + its logs, then restore the lead:
`DELETE FROM workorder_logs WHERE workorder_id = <new_id>; DELETE FROM workorder WHERE workorder_id = <new_id>; DELETE FROM lead_stage_log WHERE lead_id = 5 AND to_stage = 'Won'; UPDATE leads SET stage='Quoted', converted_workorder_id=NULL, payment='none', paid_at=NULL, paid_confirmed_by=NULL, workorder_created_by=NULL WHERE lead_id = 5;`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
