### PR TITLE
F8a — Waitlist back-in-stock SMS (shared Grays number)

### DIFF
--- a/lib/handlers/collections.js
+++ b/lib/handlers/collections.js
@@ -1,5 +1,6 @@
 // /api/collections.js
 import { getClientWithTimezone } from '../db.js';
+import { notifyWaitlistBackInStock } from '../waitlistNotify.js'; // F8a
 
 // ---- Helpers ----
 const toInt = (v) => (v == null || v === '' ? null : parseInt(v, 10));
@@ -215,6 +216,10 @@ export default async function handler(req, res) {
               .map((it) => String(it.product_sku).toUpperCase())
           )];
 
+          // F8a: SKUs that transition FROM out-of-stock (<=0) TO in-stock (>0) this apply —
+          // i.e. genuinely "back in stock" — drive the waitlist SMS after the commit.
+          const backInStockSkus = [];
+
           if (affectedSkus.length) {
             const lockRes = await client.query(
               `SELECT sku, avg_cost, stock
@@ -243,6 +248,9 @@ export default async function handler(req, res) {
               const cur = stats.get(sku) || { avg_cost: null, stock: 0 };
               const nextAvg = computeAvgAfterAdding(cur.avg_cost, price, qty);
               const nextStock = Number(cur.stock || 0) + qty;
+
+              // F8a: record a real out→in-stock transition for the waitlist SMS.
+              if (Number(cur.stock || 0) <= 0 && nextStock > 0) backInStockSkus.push(sku);
 
               await client.query(
                 `UPDATE product
@@ -274,9 +282,20 @@ export default async function handler(req, res) {
           );
 
           await client.query('COMMIT');
+
+          // F8a: waitlist back-in-stock SMS — AFTER commit, BEST-EFFORT. Never throws, so
+          // a Podium/SMS failure can't undo the inventory we just applied. Mock-first.
+          let waitlistNotified = { notified: 0, skipped: 0, failed: 0 };
+          try {
+            waitlistNotified = await notifyWaitlistBackInStock(client, backInStockSkus, { collectionId: Number(id) });
+          } catch (notifyErr) {
+            console.error('waitlist notify (post-apply) failed:', notifyErr);
+          }
+
           return res.status(200).json({
             success: true,
             inventory_applied_at: done.rows[0].inventory_applied_at,
+            waitlistNotified,
           });
         } catch (e) {
           try { await client.query('ROLLBACK'); } catch {}

--- a/lib/podium.js
+++ b/lib/podium.js
@@ -561,6 +561,31 @@ export function sendMessage(userId, { conversationUid, body, channel, to, type =
 }
 
 /**
+ * Send an OUTBOUND SMS from the SHARED Grays number (P9) — for SYSTEM automations (F8:
+ * waitlist back-in-stock, delivery-booked, review request), NOT a 1:1 rep conversation.
+ * It is not tied to a rep's OAuth token or a conversation: it targets a phone number from
+ * the shared location number. Mock-first: request() short-circuits to the typed mock in
+ * mock mode, so this exercises end-to-end offline without creds (returns {status:'sent'}).
+ *
+ * VERIFY at live wiring: §15 pins only the per-rep `POST /v4/messages` "as a rep"; a
+ * location/system send from the shared number is UNPROVEN — it likely needs a
+ * location-scoped token (not a user token) and/or a different field shape. Isolate the
+ * live swap here (one function). Until then it's flag-gated by PODIUM_MOCK like every
+ * other Podium call.
+ */
+export function sendSystemSms({ to, body, channel = 'sms', locationUid } = {}) {
+  return request(null, 'POST', 'messages', {
+    body: {
+      to,
+      body,
+      type: 'text',
+      channel,
+      locationUid: locationUid || process.env.PODIUM_LOCATION_UID || undefined,
+    },
+  });
+}
+
+/**
  * GET /v4/message_templates — Podium's saved message templates (canned responses) a
  * rep inserts into the composer (F12). Cursor-paginated like other list endpoints.
  * VERIFY the live Podium endpoint/field names at wiring.

--- a/lib/waitlistNotify.js
+++ b/lib/waitlistNotify.js
@@ -67,11 +67,19 @@ export async function notifyWaitlistBackInStock(client, skus, opts = {}) {
     return out;
   }
 
+  // At-most-once by design: the mere EXISTENCE of the claim row gates re-sends, so a
+  // customer is never texted twice for the same waitlist entry — even across a reset +
+  // re-apply, and even if a send's bookkeeping later fails. The trade-off is that a text
+  // that fails outright is not auto-retried (a missed back-in-stock SMS is preferable to a
+  // duplicate for a convenience notification). A future opt-in retry sweeper over
+  // status IN ('pending','failed') could add at-least-once if the business wants it.
   for (const row of rows) {
     const refId = `waitlist_back_in_stock:${row.waitlist_id}`;
+    let logId = null;
+    let sent = false;
     try {
       // Claim the audit row first — the unique (source, reference_id) index makes this the
-      // idempotency gate: rowCount 0 ⇒ already handled ⇒ skip.
+      // idempotency gate: rowCount 0 ⇒ already claimed ⇒ skip.
       const claim = await client.query(
         `INSERT INTO integration_sync_log (source, direction, event_type, reference_id, status, payload)
          VALUES ('podium', 'outbound', 'waitlist.back_in_stock', $1, 'pending', $2)
@@ -85,7 +93,7 @@ export async function notifyWaitlistBackInStock(client, skus, opts = {}) {
         })]
       );
       if (!claim.rowCount) { out.skipped += 1; continue; }
-      const logId = claim.rows[0].id;
+      logId = claim.rows[0].id;
 
       const phone = (row.customer_phone || '').toString().trim();
       if (!phone) {
@@ -95,21 +103,30 @@ export async function notifyWaitlistBackInStock(client, skus, opts = {}) {
       }
 
       await sendSms({ to: phone, body: backInStockMessage(row.product_name) });
+      sent = true; // past this point the SMS is away — never relabel it 'failed'.
 
       // Mark sent + retire the waitlist row so it never re-fires.
       await client.query(`UPDATE integration_sync_log SET status = 'sent' WHERE id = $1`, [logId]);
       await client.query(`UPDATE waitlist SET status = 'Notified' WHERE waitlist_id = $1 AND status = 'Active'`, [row.waitlist_id]);
       out.notified += 1;
     } catch (err) {
-      out.failed += 1;
-      console.error(`waitlist notify: send failed for waitlist ${row.waitlist_id}`, err);
-      try {
-        await client.query(
-          `UPDATE integration_sync_log SET status = 'failed', error = $2
-            WHERE source = 'podium' AND reference_id = $1`,
-          [refId, String(err?.message || err).slice(0, 500)]
-        );
-      } catch { /* best-effort audit; ignore */ }
+      if (sent) {
+        // The SMS DID go out; only the post-send bookkeeping failed. Count it notified and
+        // keep the audit honest — the claim row still blocks any re-send (at-most-once).
+        out.notified += 1;
+        console.error(`waitlist notify: post-send bookkeeping failed for waitlist ${row.waitlist_id}`, err);
+      } else {
+        out.failed += 1;
+        console.error(`waitlist notify: send failed for waitlist ${row.waitlist_id}`, err);
+        if (logId) {
+          try {
+            await client.query(
+              `UPDATE integration_sync_log SET status = 'failed', error = $1 WHERE id = $2`,
+              [String(err?.message || err).slice(0, 500), logId]
+            );
+          } catch { /* best-effort audit; ignore */ }
+        }
+      }
     }
   }
   return out;

--- a/lib/waitlistNotify.js
+++ b/lib/waitlistNotify.js
@@ -1,0 +1,116 @@
+// lib/waitlistNotify.js — Waitlist back-in-stock SMS automation (feature F8a).
+//
+// When incoming stock is credited (the superadmin "apply inventory" action on a
+// collection), any customer sitting on the `waitlist` for a SKU that has just come back
+// into stock is texted from the SHARED Grays number (P9 — system notification, not a rep
+// 1:1). Today this is fully manual; F8a automates it (execution-plan §F8a).
+//
+// Design guarantees:
+//  - BEST-EFFORT / NON-BLOCKING: notify runs AFTER the inventory-apply transaction has
+//    committed and NEVER throws — an SMS or Podium failure must never roll back or block
+//    the inventory credit. All errors are swallowed + logged; the caller gets counts.
+//  - IDEMPOTENT: each waitlist row is claimed once via an integration_sync_log row with a
+//    unique reference_id (ON CONFLICT DO NOTHING on uq_sync_ref), and the waitlist row is
+//    flipped Active → Notified, so a re-apply (or a second collection with the same SKU)
+//    never double-texts the same person for the same waitlist entry.
+//  - P1: only ENVELOPE metadata (waitlist_id / customer_id / sku / collection_id) is
+//    logged — never the rendered SMS body.
+//  - Mock-first: sendSystemSms() short-circuits to the typed Podium mock when
+//    PODIUM_MOCK=true, so nothing actually sends until creds + PODIUM_MOCK=false.
+
+import { sendSystemSms } from './podium.js';
+
+/**
+ * The customer-facing SMS copy. On brand: phone 1300 769 556 primary; no "used /
+ * second-hand" language. Copy is a sensible default — flagged for human sign-off before
+ * live send (the send itself is gated behind PODIUM_MOCK=false, a human config flip).
+ */
+export function backInStockMessage(productName) {
+  const name = (productName && String(productName).trim()) || 'the item you were waiting for';
+  return `Good news from Grays Fitness! ${name} is back in stock. Call 1300 769 556 to secure yours — first in, first served.`;
+}
+
+/**
+ * Notify Active waitlist rows for the given SKUs that stock is back.
+ * @param {object} client  an OPEN pg client (used post-commit; each statement autocommits)
+ * @param {string[]} skus  SKUs that just transitioned back into stock
+ * @param {object} [opts]  { collectionId, send } — send lets the smoke inject a fake sender
+ * @returns {Promise<{notified:number, skipped:number, failed:number}>}
+ */
+export async function notifyWaitlistBackInStock(client, skus, opts = {}) {
+  const { collectionId = null, send } = opts;
+  const sendSms = send || sendSystemSms;
+  const out = { notified: 0, skipped: 0, failed: 0 };
+
+  const list = [...new Set((skus || []).map((s) => String(s).toUpperCase()).filter(Boolean))];
+  if (!list.length) return out;
+
+  // Active waitlist rows for these SKUs, with the customer's phone + the product name.
+  let rows = [];
+  try {
+    const r = await client.query(
+      `SELECT w.waitlist_id, w.customer_id, w.product_sku,
+              c.name  AS customer_name, c.phone AS customer_phone,
+              p.name  AS product_name
+         FROM waitlist w
+         JOIN customers c ON c.id = w.customer_id
+         LEFT JOIN product p ON upper(p.sku) = upper(w.product_sku)
+        WHERE w.status = 'Active'
+          AND upper(w.product_sku) = ANY($1)
+        ORDER BY w.waitlisted ASC, w.waitlist_id ASC`,
+      [list]
+    );
+    rows = r.rows || [];
+  } catch (err) {
+    // waitlist/customers/product absent (bare DB) or any query error — degrade silently.
+    if (err?.code !== '42P01') console.error('waitlist notify: lookup failed', err);
+    return out;
+  }
+
+  for (const row of rows) {
+    const refId = `waitlist_back_in_stock:${row.waitlist_id}`;
+    try {
+      // Claim the audit row first — the unique (source, reference_id) index makes this the
+      // idempotency gate: rowCount 0 ⇒ already handled ⇒ skip.
+      const claim = await client.query(
+        `INSERT INTO integration_sync_log (source, direction, event_type, reference_id, status, payload)
+         VALUES ('podium', 'outbound', 'waitlist.back_in_stock', $1, 'pending', $2)
+         ON CONFLICT (source, reference_id) WHERE reference_id IS NOT NULL DO NOTHING
+         RETURNING id`,
+        [refId, JSON.stringify({
+          waitlist_id: row.waitlist_id,
+          customer_id: row.customer_id,
+          sku: row.product_sku,
+          collection_id: collectionId,
+        })]
+      );
+      if (!claim.rowCount) { out.skipped += 1; continue; }
+      const logId = claim.rows[0].id;
+
+      const phone = (row.customer_phone || '').toString().trim();
+      if (!phone) {
+        await client.query(`UPDATE integration_sync_log SET status = 'skipped', error = 'no phone on customer' WHERE id = $1`, [logId]);
+        out.skipped += 1;
+        continue;
+      }
+
+      await sendSms({ to: phone, body: backInStockMessage(row.product_name) });
+
+      // Mark sent + retire the waitlist row so it never re-fires.
+      await client.query(`UPDATE integration_sync_log SET status = 'sent' WHERE id = $1`, [logId]);
+      await client.query(`UPDATE waitlist SET status = 'Notified' WHERE waitlist_id = $1 AND status = 'Active'`, [row.waitlist_id]);
+      out.notified += 1;
+    } catch (err) {
+      out.failed += 1;
+      console.error(`waitlist notify: send failed for waitlist ${row.waitlist_id}`, err);
+      try {
+        await client.query(
+          `UPDATE integration_sync_log SET status = 'failed', error = $2
+            WHERE source = 'podium' AND reference_id = $1`,
+          [refId, String(err?.message || err).slice(0, 500)]
+        );
+      } catch { /* best-effort audit; ignore */ }
+    }
+  }
+  return out;
+}

--- a/scripts/podium-waitlist-smoke.mjs
+++ b/scripts/podium-waitlist-smoke.mjs
@@ -1,0 +1,151 @@
+// scripts/podium-waitlist-smoke.mjs — offline smoke for F8a waitlist back-in-stock SMS.
+//
+// Exercises lib/waitlistNotify.js with an INJECTED fake pg client and (mostly) an injected
+// fake sender, so there is NO network, NO database, NO secrets:
+//
+//   node scripts/podium-waitlist-smoke.mjs
+//
+// Covers: no-SKU no-op; the Active-only + SKU-filtered lookup; the send + Notified flip +
+// integration_sync_log audit (with the ON CONFLICT idempotency claim and the
+// waitlist_back_in_stock:<id> reference_id); the already-claimed (conflict) → skip path;
+// the no-phone → skip path; the 42P01 (bare-DB) degrade; the BEST-EFFORT guarantee (a
+// throwing sender is caught, counted failed, and never propagates); SKU de-dup/uppercasing;
+// and one end-to-end pass through the REAL sendSystemSms in PODIUM_MOCK mode.
+
+process.env.PODIUM_MOCK = 'true'; // real sendSystemSms short-circuits to the typed mock
+
+const { notifyWaitlistBackInStock, backInStockMessage } = await import('../lib/waitlistNotify.js');
+
+let passed = 0;
+function check(name, cond, detail) {
+  if (!cond) throw new Error(`FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  passed += 1;
+  console.log(`  ✓ ${name}`);
+}
+
+// ---- Fake pg client (records queries, returns scripted results) ---------------
+function makeClient(scripts = []) {
+  const calls = [];
+  return {
+    calls,
+    async query(sql, params) {
+      calls.push({ sql, params });
+      for (const s of scripts) {
+        if (typeof s.match === 'function' ? s.match(sql) : s.match.test(sql)) {
+          if (s.throws) throw s.throws;
+          return s.result ?? { rowCount: 0, rows: [] };
+        }
+      }
+      return { rowCount: 0, rows: [] };
+    },
+  };
+}
+
+const SELECT_RE = /FROM waitlist w/i;
+const CLAIM_RE  = /INSERT INTO integration_sync_log/i;
+const LOG_UPD_RE = /UPDATE integration_sync_log/i;
+const WL_UPD_RE  = /UPDATE waitlist SET status = 'Notified'/i;
+
+const activeRow = (over = {}) => ({
+  waitlist_id: 1, customer_id: 26, product_sku: 'TM-95T',
+  customer_name: 'Demo Customer', customer_phone: '0400000000', product_name: '95T Treadmill',
+  ...over,
+});
+
+// A fresh-claim client: lookup returns rows; the audit INSERT returns an id (not a conflict).
+function okClient(rows) {
+  return makeClient([
+    { match: SELECT_RE, result: { rowCount: rows.length, rows } },
+    { match: CLAIM_RE, result: { rowCount: 1, rows: [{ id: 77 }] } },
+    { match: LOG_UPD_RE, result: { rowCount: 1, rows: [] } },
+    { match: WL_UPD_RE, result: { rowCount: 1, rows: [] } },
+  ]);
+}
+
+console.log('Waitlist back-in-stock (F8a) smoke — fake client, no DB\n');
+
+console.log('copy + no-op:');
+{
+  check('message names the product', backInStockMessage('95T Treadmill').includes('95T Treadmill'));
+  check('message falls back when no product name', /item you were waiting for/i.test(backInStockMessage('')));
+  check('message carries the sales phone 1300 769 556', backInStockMessage('X').includes('1300 769 556'));
+  const client = makeClient();
+  const out = await notifyWaitlistBackInStock(client, []);
+  check('no SKUs → no-op, no DB calls', out.notified === 0 && out.skipped === 0 && out.failed === 0 && client.calls.length === 0);
+}
+
+console.log('\nhappy path (send + Notified + audit):');
+{
+  const sent = [];
+  const client = okClient([activeRow()]);
+  const out = await notifyWaitlistBackInStock(client, ['tm-95t'], { collectionId: 12, send: async (m) => { sent.push(m); return { status: 'sent' }; } });
+  check('one row notified', out.notified === 1 && out.skipped === 0 && out.failed === 0, JSON.stringify(out));
+  check('SMS sent to the customer phone', sent.length === 1 && sent[0].to === '0400000000');
+  check('SMS body is the back-in-stock copy', /back in stock/i.test(sent[0].body));
+  const sel = client.calls.find((c) => SELECT_RE.test(c.sql));
+  check('lookup filters status = Active', !!sel && /w\.status = 'Active'/i.test(sel.sql));
+  check('lookup passes the uppercased SKU list', !!sel && Array.isArray(sel.params?.[0]) && sel.params[0].includes('TM-95T'));
+  const claim = client.calls.find((c) => CLAIM_RE.test(c.sql));
+  check('audit claim uses ON CONFLICT DO NOTHING', !!claim && /ON CONFLICT/i.test(claim.sql) && /DO NOTHING/i.test(claim.sql));
+  check('audit reference_id is per-waitlist-row', !!claim && (claim.params || []).includes('waitlist_back_in_stock:1'));
+  check('audit payload carries envelope only (no body)', !!claim && /"sku"/.test(claim.params?.[1] || '') && !/back in stock/i.test(claim.params?.[1] || ''));
+  check('log marked sent', client.calls.some((c) => LOG_UPD_RE.test(c.sql) && /'sent'/i.test(c.sql)));
+  check('waitlist row flipped to Notified', client.calls.some((c) => WL_UPD_RE.test(c.sql)));
+}
+
+console.log('\nde-dup + multiple rows:');
+{
+  const sent = [];
+  const client = okClient([activeRow({ waitlist_id: 1 }), activeRow({ waitlist_id: 2, customer_id: 27 })]);
+  const out = await notifyWaitlistBackInStock(client, ['TM-95T', 'tm-95t', ''], { send: async (m) => { sent.push(m); return {}; } });
+  check('two rows notified, duplicate/blank SKUs collapsed', out.notified === 2 && sent.length === 2);
+  const sel = client.calls.find((c) => SELECT_RE.test(c.sql));
+  check('SKU list de-duped to one entry', sel.params[0].length === 1);
+}
+
+console.log('\nidempotency (already claimed):');
+{
+  const sent = [];
+  const client = makeClient([
+    { match: SELECT_RE, result: { rowCount: 1, rows: [activeRow()] } },
+    { match: CLAIM_RE, result: { rowCount: 0, rows: [] } }, // conflict → already handled
+  ]);
+  const out = await notifyWaitlistBackInStock(client, ['TM-95T'], { send: async (m) => { sent.push(m); return {}; } });
+  check('conflicting claim → skipped, no send', out.skipped === 1 && out.notified === 0 && sent.length === 0);
+}
+
+console.log('\nno phone on customer:');
+{
+  const sent = [];
+  const client = okClient([activeRow({ customer_phone: null })]);
+  const out = await notifyWaitlistBackInStock(client, ['TM-95T'], { send: async (m) => { sent.push(m); return {}; } });
+  check('no-phone row → skipped, no send', out.skipped === 1 && out.notified === 0 && sent.length === 0);
+  check('log marked skipped with a reason', client.calls.some((c) => LOG_UPD_RE.test(c.sql) && /'skipped'/i.test(c.sql)));
+}
+
+console.log('\nbare-DB degrade (42P01):');
+{
+  const err = new Error('relation "waitlist" does not exist'); err.code = '42P01';
+  const client = makeClient([{ match: SELECT_RE, throws: err }]);
+  const out = await notifyWaitlistBackInStock(client, ['TM-95T']);
+  check('missing table → {0,0,0}, no throw', out.notified === 0 && out.skipped === 0 && out.failed === 0);
+}
+
+console.log('\nbest-effort (sender throws):');
+{
+  const client = okClient([activeRow()]);
+  const out = await notifyWaitlistBackInStock(client, ['TM-95T'], {
+    send: async () => { throw new Error('Podium 503'); },
+  });
+  check('send failure → counted failed, never throws', out.failed === 1 && out.notified === 0);
+  check('failure recorded on the audit row', client.calls.some((c) => LOG_UPD_RE.test(c.sql) && /'failed'/i.test(c.sql)));
+}
+
+console.log('\nend-to-end through the REAL sendSystemSms (mock mode):');
+{
+  const client = okClient([activeRow()]);
+  const out = await notifyWaitlistBackInStock(client, ['TM-95T']); // no injected send → real mock
+  check('real mock send path notifies without error', out.notified === 1 && out.failed === 0);
+}
+
+console.log(`\n✅ waitlist smoke: ${passed} checks passed`);

--- a/scripts/podium-waitlist-smoke.mjs
+++ b/scripts/podium-waitlist-smoke.mjs
@@ -141,6 +141,19 @@ console.log('\nbest-effort (sender throws):');
   check('failure recorded on the audit row', client.calls.some((c) => LOG_UPD_RE.test(c.sql) && /'failed'/i.test(c.sql)));
 }
 
+console.log('\npost-send bookkeeping failure (SMS already away):');
+{
+  // Send succeeds, but the follow-up "mark sent" UPDATE throws. The customer WAS texted,
+  // so it must count as notified (not failed) and the claim row still blocks any re-send.
+  const client = makeClient([
+    { match: SELECT_RE, result: { rowCount: 1, rows: [activeRow()] } },
+    { match: CLAIM_RE, result: { rowCount: 1, rows: [{ id: 5 }] } },
+    { match: /status = 'sent'/i, throws: new Error('db blip after send') },
+  ]);
+  const out = await notifyWaitlistBackInStock(client, ['TM-95T'], { send: async () => ({ status: 'sent' }) });
+  check('counts as notified, not failed', out.notified === 1 && out.failed === 0, JSON.stringify(out));
+}
+
 console.log('\nend-to-end through the REAL sendSystemSms (mock mode):');
 {
   const client = okClient([activeRow()]);


### PR DESCRIPTION
## F8a — Waitlist back-in-stock SMS (shared Grays number)

The first of the F8 outbound automations (execution-plan §F8a, P9). When a superadmin **applies incoming inventory** on a collection and a SKU comes **back into stock**, every customer sitting on the `waitlist` for that SKU is automatically texted from the **shared Grays number** — a job that's fully manual today.

> Independent of the F7 funnel work — branches off `main`, its own PR. Depends only on F2 (merged).

### What it does
- **`lib/handlers/collections.js` apply-inventory:** during the stock-credit loop it records SKUs that transition **out-of-stock (≤0) → in-stock (>0)**, then — **after `COMMIT`, best-effort** — calls the notifier. An SMS/Podium failure can **never** roll back or block the inventory credit (it runs post-commit and the notifier never throws).
- **`lib/waitlistNotify.js` (new) — `notifyWaitlistBackInStock(client, skus)`:** looks up **Active** waitlist rows for the restocked SKUs (with the customer phone + product name), sends the SMS, flips the row **Active → Notified**, and dedupes/audits via `integration_sync_log`.
- **`lib/podium.js` — `sendSystemSms({to, body})` (new):** a shared-number/system send seam for F8 automations (mock-first; the live location-scoped send is isolated here as a single VERIFY).

### Correctness guarantees
- **Inventory credit is never at risk** — notify is post-commit + non-throwing (double-guarded at the call site and inside the notifier).
- **Idempotent / never double-texts** — each waitlist row is claimed once via an `integration_sync_log` row with `reference_id = waitlist_back_in_stock:<id>` and `ON CONFLICT (source, reference_id) WHERE reference_id IS NOT NULL DO NOTHING` (matches the `uq_sync_ref` index exactly); the row also flips to `Notified`. Concurrent applies, a reset + re-apply, and a second collection with the same SKU all skip. **At-most-once by design** (a customer is never texted twice; a failed text is not auto-retried — the safer trade-off for a convenience SMS; a retry sweeper over `status IN ('pending','failed')` is a possible future opt-in).
- **P1 held** — only envelope metadata (`waitlist_id`, `customer_id`, `sku`, `collection_id`) is logged; the rendered SMS body never touches the DB.

### Constraints
- **No new serverless fn, no migration** (uses `waitlist` + `integration_sync_log` from F0 `0001`).
- **Mock-first** behind `PODIUM_MOCK` — **nothing actually sends** until creds + `PODIUM_MOCK=false`.
- **SMS copy is a default flagged for your sign-off** (see below) — the live send is a human config flip, so copy can be finalised before then.

### VERIFY at live wiring
`sendSystemSms` sends from the shared/location number, which **§15 does not pin** — the per-rep `POST /v4/messages` is documented, but a location/system send likely needs a **location-scoped token** (not a rep's user token) and possibly a different field shape. Isolated to one function; validate before flipping `PODIUM_MOCK=false`.

### Verification
- `scripts/podium-waitlist-smoke.mjs` **24/24** (copy, Active-only + SKU-filtered lookup, send + Notified + audit, idempotent conflict → skip, no-phone → skip, 42P01 degrade, best-effort throw, post-send-bookkeeping-fail → still notified, real mock send path).
- `CI=true npm run build` green.
- The notify SELECT round-tripped **read-only** on Neon dev — resolves the 9 Active waitlist rows with phone + product name. Dev not mutated.
- Code-reviewed (subagent over the diff): confirmed inventory-safety, idempotency (no double-text), P1, transaction correctness, mock-safety; one audit-accuracy fix applied, the at-most-once trade-off accepted on purpose.

### Copy for sign-off
> Good news from Grays Fitness! {Product name} is back in stock. Call 1300 769 556 to secure yours — first in, first served.

### Reviewer checklist
- [x] Approve / edit the SMS copy above.
- [x] Confirm at-most-once is the desired behaviour (never double-text; a failed text isn't auto-retried), or request a retry sweeper.
- [x] Confirm the trigger = a SKU going **from out-of-stock to in-stock** on apply-inventory (not every credit).
- [x] Sanity: applying inventory on a collection whose items include a currently-out-of-stock, waitlisted SKU returns `waitlistNotified` counts (mock — nothing sends).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
