### PR TITLE
F8b — Delivery-booked SMS, confirmed by logistics before it sends

### DIFF
--- a/lib/deliveryNotify.js
+++ b/lib/deliveryNotify.js
@@ -1,20 +1,114 @@
-// lib/deliveryNotify.js — Delivery-booked SMS automation (feature F8b).
+// lib/deliveryNotify.js — Delivery-booked SMS (feature F8b).
 //
-// When a delivery transitions INTO "Booked for Delivery" (delivery.js POST-as-booked or
-// PUT status change), the customer is texted from the SHARED Grays number (P9) that their
-// order is booked — with the delivery date when there is one. Automates a manual step
-// (execution-plan §F8b). Same design as F8a's waitlist notifier:
-//  - BEST-EFFORT / NON-BLOCKING: called AFTER the delivery transaction commits and NEVER
-//    throws, so a Podium/SMS failure can't undo or block the booking.
-//  - IDEMPOTENT / at-most-once: each delivery is claimed once via an integration_sync_log
-//    row (reference_id `delivery_booked:<delivery_id>`, ON CONFLICT DO NOTHING on
-//    uq_sync_ref). No `notified` column exists on delivery, so the claim IS the sole gate
-//    — a re-book after an un-book won't re-text (acceptable; never double-text a customer).
+// When a delivery is booked, the customer is texted from the SHARED Grays number (P9) that
+// their order is booked — with the delivery date when there is one (execution-plan §F8b).
+//
+// ⚠️ CONFIRMED BY A HUMAN, NOT AUTOMATIC (Nick, 17 Jul 2026). This originally fired
+// automatically the moment a delivery hit "Booked for Delivery". It no longer does:
+// booking now RETURNS a preview, the logistics user reads the exact text, and explicitly
+// sends or declines it. Nothing reaches a customer without someone clicking Send.
+//
+//   previewDeliveryBookedSms()  — read-only; what the confirmation panel shows. Never sends.
+//   notifyDeliveryBooked()      — the confirmed send ("Send text").
+//   declineDeliveryBookedSms()  — the recorded decline ("Don't send").
+//
+// Design:
+//  - BEST-EFFORT / NON-BLOCKING: never throws. A Podium/SMS failure can't undo the booking
+//    (the booking transaction has already committed by the time any of this runs).
+//  - AT-MOST-ONCE: each delivery is claimed via an integration_sync_log row (reference_id
+//    `delivery_booked:<delivery_id>` on uq_sync_ref). The gate is deliberately "was it
+//    SENT", not "was it claimed" — a DECLINED text was never sent, so it can still be sent
+//    later, while a row already marked 'sent' can never be reopened. That's what makes the
+//    confirmation panel safe: a double-click or a second confirm cannot double-text.
 //  - P1: only envelope metadata (delivery_id / customer_id / invoice_id) is logged, never
 //    the rendered SMS body.
 //  - Mock-first via sendSystemSms (short-circuits to the Podium mock when PODIUM_MOCK=true).
 
 import { sendSystemSms } from './podium.js';
+
+// The one place the claim/reclaim is expressed. ON CONFLICT ... DO UPDATE ... WHERE
+// status <> 'sent' is the atomic gate: rowCount 0 ⇒ already sent ⇒ refuse.
+const CLAIM_SQL = `
+  INSERT INTO integration_sync_log (source, direction, event_type, reference_id, status, payload)
+  VALUES ('podium', 'outbound', 'delivery.booked', $1, 'pending', $2)
+  ON CONFLICT (source, reference_id) WHERE reference_id IS NOT NULL
+  DO UPDATE SET status = 'pending', error = NULL
+  WHERE integration_sync_log.status <> 'sent'
+  RETURNING id`;
+
+const DELIVERY_SELECT = `
+  SELECT d.delivery_id, d.customer_id, d.invoice_id, d.delivery_status,
+         to_char(d.delivery_date, 'DD Mon YYYY') AS delivery_date,
+         c.name AS customer_name, c.phone AS customer_phone
+    FROM delivery d
+    JOIN customers c ON c.id = d.customer_id
+   WHERE d.delivery_id = $1`;
+
+/** Load the delivery + customer for a booking text. Returns null on any problem. */
+async function loadBooking(client, deliveryId) {
+  const id = Number(deliveryId);
+  if (!Number.isFinite(id)) return null;
+  try {
+    const r = await client.query(DELIVERY_SELECT, [id]);
+    return r.rows[0] || null;
+  } catch (err) {
+    if (err?.code !== '42P01') console.error('delivery notify: lookup failed', err);
+    return null;
+  }
+}
+
+/**
+ * What the confirmation panel shows before anything is sent. READ-ONLY: it must never
+ * claim or send, because the whole point is that the human decides afterwards.
+ * @returns {Promise<{eligible:boolean, delivery_id?:number, customer_name?:string,
+ *                    to?:string, body?:string, reason?:string}>}
+ */
+export async function previewDeliveryBookedSms(client, deliveryId) {
+  const row = await loadBooking(client, deliveryId);
+  if (!row) return { eligible: false, reason: 'Delivery not found' };
+  if (row.delivery_status !== 'Booked for Delivery') {
+    return { eligible: false, reason: `Delivery is ${row.delivery_status}, not booked` };
+  }
+  const to = (row.customer_phone || '').toString().trim();
+  if (!to) {
+    return { eligible: false, customer_name: row.customer_name, reason: 'No phone number on this customer' };
+  }
+  return {
+    eligible: true,
+    delivery_id: row.delivery_id,
+    customer_name: row.customer_name,
+    to,
+    body: deliveryBookedMessage({ invoiceId: row.invoice_id, deliveryDate: row.delivery_date }),
+  };
+}
+
+/**
+ * "Don't send" — record that a human declined the text. Nothing is sent. Audited (and
+ * attributed) so the Integrations log shows the text was a decision, not a failure.
+ * Because the claim gate is "was it sent", a declined text can still be sent later.
+ */
+export async function declineDeliveryBookedSms(client, deliveryId, opts = {}) {
+  const { actorId } = opts;
+  const out = { notified: 0, skipped: 0, failed: 0 };
+  const row = await loadBooking(client, deliveryId);
+  if (!row) return out;
+
+  try {
+    const claim = await client.query(CLAIM_SQL, [
+      `delivery_booked:${row.delivery_id}`,
+      JSON.stringify({ delivery_id: row.delivery_id, customer_id: row.customer_id, invoice_id: row.invoice_id }),
+    ]);
+    if (!claim.rowCount) { out.skipped += 1; return out; } // already sent — nothing to decline
+    await client.query(
+      `UPDATE integration_sync_log SET status = 'skipped', error = $1 WHERE id = $2`,
+      [`declined by ${actorId || 'unknown'}`, claim.rows[0].id]
+    );
+    out.skipped += 1;
+  } catch (err) {
+    console.error(`delivery notify: recording decline failed for delivery ${deliveryId}`, err);
+  }
+  return out;
+}
 
 /**
  * Customer-facing SMS copy. On brand: phone 1300 769 556 primary; no "used / second-hand".
@@ -30,37 +124,19 @@ export function deliveryBookedMessage({ invoiceId, deliveryDate } = {}) {
 }
 
 /**
- * Text the customer that their delivery is booked. Best-effort — NEVER throws.
+ * Send the booking text — the CONFIRMED send, i.e. a human clicked "Send text" on the
+ * confirmation panel. Best-effort — NEVER throws.
  * @param {object} client     an OPEN pg client (used post-commit; each statement autocommits)
- * @param {number} deliveryId the delivery that just became "Booked for Delivery"
- * @param {object} [opts]     { send } — lets the smoke inject a fake sender
- * @returns {Promise<{notified:number, skipped:number, failed:number}>}
+ * @param {number} deliveryId the booked delivery
+ * @param {object} [opts]     { send, actorId } — send lets the smoke inject a fake sender
+ * @returns {Promise<{notified:number, skipped:number, failed:number, alreadySent?:boolean}>}
  */
 export async function notifyDeliveryBooked(client, deliveryId, opts = {}) {
   const { send } = opts;
   const sendSms = send || sendSystemSms;
   const out = { notified: 0, skipped: 0, failed: 0 };
 
-  const id = Number(deliveryId);
-  if (!Number.isFinite(id)) return out;
-
-  // The delivery + its customer's phone + a formatted date.
-  let row = null;
-  try {
-    const r = await client.query(
-      `SELECT d.delivery_id, d.customer_id, d.invoice_id, d.delivery_status,
-              to_char(d.delivery_date, 'DD Mon YYYY') AS delivery_date,
-              c.name AS customer_name, c.phone AS customer_phone
-         FROM delivery d
-         JOIN customers c ON c.id = d.customer_id
-        WHERE d.delivery_id = $1`,
-      [id]
-    );
-    row = r.rows[0] || null;
-  } catch (err) {
-    if (err?.code !== '42P01') console.error('delivery notify: lookup failed', err);
-    return out;
-  }
+  const row = await loadBooking(client, deliveryId);
   if (!row) return out;
   // Defensive: only text for an actually-booked delivery.
   if (row.delivery_status !== 'Booked for Delivery') { out.skipped += 1; return out; }
@@ -69,19 +145,17 @@ export async function notifyDeliveryBooked(client, deliveryId, opts = {}) {
   let logId = null;
   let sent = false;
   try {
-    // Claim once — the unique (source, reference_id) index gates re-sends (at-most-once).
-    const claim = await client.query(
-      `INSERT INTO integration_sync_log (source, direction, event_type, reference_id, status, payload)
-       VALUES ('podium', 'outbound', 'delivery.booked', $1, 'pending', $2)
-       ON CONFLICT (source, reference_id) WHERE reference_id IS NOT NULL DO NOTHING
-       RETURNING id`,
-      [refId, JSON.stringify({
+    // Claim (or reclaim a declined/failed row). rowCount 0 ⇒ already 'sent' ⇒ refuse:
+    // this is what stops a double-click on the panel from double-texting.
+    const claim = await client.query(CLAIM_SQL, [
+      refId,
+      JSON.stringify({
         delivery_id: row.delivery_id,
         customer_id: row.customer_id,
         invoice_id: row.invoice_id,
-      })]
-    );
-    if (!claim.rowCount) { out.skipped += 1; return out; }
+      }),
+    ]);
+    if (!claim.rowCount) { out.skipped += 1; out.alreadySent = true; return out; }
     logId = claim.rows[0].id;
 
     const phone = (row.customer_phone || '').toString().trim();
@@ -99,10 +173,10 @@ export async function notifyDeliveryBooked(client, deliveryId, opts = {}) {
   } catch (err) {
     if (sent) {
       out.notified += 1;
-      console.error(`delivery notify: post-send bookkeeping failed for delivery ${id}`, err);
+      console.error(`delivery notify: post-send bookkeeping failed for delivery ${row.delivery_id}`, err);
     } else {
       out.failed += 1;
-      console.error(`delivery notify: send failed for delivery ${id}`, err);
+      console.error(`delivery notify: send failed for delivery ${row.delivery_id}`, err);
       if (logId) {
         try {
           await client.query(`UPDATE integration_sync_log SET status = 'failed', error = $1 WHERE id = $2`,

--- a/lib/deliveryNotify.js
+++ b/lib/deliveryNotify.js
@@ -1,0 +1,115 @@
+// lib/deliveryNotify.js — Delivery-booked SMS automation (feature F8b).
+//
+// When a delivery transitions INTO "Booked for Delivery" (delivery.js POST-as-booked or
+// PUT status change), the customer is texted from the SHARED Grays number (P9) that their
+// order is booked — with the delivery date when there is one. Automates a manual step
+// (execution-plan §F8b). Same design as F8a's waitlist notifier:
+//  - BEST-EFFORT / NON-BLOCKING: called AFTER the delivery transaction commits and NEVER
+//    throws, so a Podium/SMS failure can't undo or block the booking.
+//  - IDEMPOTENT / at-most-once: each delivery is claimed once via an integration_sync_log
+//    row (reference_id `delivery_booked:<delivery_id>`, ON CONFLICT DO NOTHING on
+//    uq_sync_ref). No `notified` column exists on delivery, so the claim IS the sole gate
+//    — a re-book after an un-book won't re-text (acceptable; never double-text a customer).
+//  - P1: only envelope metadata (delivery_id / customer_id / invoice_id) is logged, never
+//    the rendered SMS body.
+//  - Mock-first via sendSystemSms (short-circuits to the Podium mock when PODIUM_MOCK=true).
+
+import { sendSystemSms } from './podium.js';
+
+/**
+ * Customer-facing SMS copy. On brand: phone 1300 769 556 primary; no "used / second-hand".
+ * With a date it names the delivery date; without one (e.g. Customer Collect / date TBC) it
+ * says we'll be in touch. Copy is a default — flagged for human sign-off before live send.
+ */
+export function deliveryBookedMessage({ invoiceId, deliveryDate } = {}) {
+  const inv = invoiceId ? ` (invoice ${invoiceId})` : '';
+  if (deliveryDate && String(deliveryDate).trim()) {
+    return `Good news from Grays Fitness! Your order${inv} is booked for delivery on ${deliveryDate}. Questions? Call 1300 769 556.`;
+  }
+  return `Good news from Grays Fitness! Your order${inv} is booked — we'll be in touch to arrange your delivery. Questions? Call 1300 769 556.`;
+}
+
+/**
+ * Text the customer that their delivery is booked. Best-effort — NEVER throws.
+ * @param {object} client     an OPEN pg client (used post-commit; each statement autocommits)
+ * @param {number} deliveryId the delivery that just became "Booked for Delivery"
+ * @param {object} [opts]     { send } — lets the smoke inject a fake sender
+ * @returns {Promise<{notified:number, skipped:number, failed:number}>}
+ */
+export async function notifyDeliveryBooked(client, deliveryId, opts = {}) {
+  const { send } = opts;
+  const sendSms = send || sendSystemSms;
+  const out = { notified: 0, skipped: 0, failed: 0 };
+
+  const id = Number(deliveryId);
+  if (!Number.isFinite(id)) return out;
+
+  // The delivery + its customer's phone + a formatted date.
+  let row = null;
+  try {
+    const r = await client.query(
+      `SELECT d.delivery_id, d.customer_id, d.invoice_id, d.delivery_status,
+              to_char(d.delivery_date, 'DD Mon YYYY') AS delivery_date,
+              c.name AS customer_name, c.phone AS customer_phone
+         FROM delivery d
+         JOIN customers c ON c.id = d.customer_id
+        WHERE d.delivery_id = $1`,
+      [id]
+    );
+    row = r.rows[0] || null;
+  } catch (err) {
+    if (err?.code !== '42P01') console.error('delivery notify: lookup failed', err);
+    return out;
+  }
+  if (!row) return out;
+  // Defensive: only text for an actually-booked delivery.
+  if (row.delivery_status !== 'Booked for Delivery') { out.skipped += 1; return out; }
+
+  const refId = `delivery_booked:${row.delivery_id}`;
+  let logId = null;
+  let sent = false;
+  try {
+    // Claim once — the unique (source, reference_id) index gates re-sends (at-most-once).
+    const claim = await client.query(
+      `INSERT INTO integration_sync_log (source, direction, event_type, reference_id, status, payload)
+       VALUES ('podium', 'outbound', 'delivery.booked', $1, 'pending', $2)
+       ON CONFLICT (source, reference_id) WHERE reference_id IS NOT NULL DO NOTHING
+       RETURNING id`,
+      [refId, JSON.stringify({
+        delivery_id: row.delivery_id,
+        customer_id: row.customer_id,
+        invoice_id: row.invoice_id,
+      })]
+    );
+    if (!claim.rowCount) { out.skipped += 1; return out; }
+    logId = claim.rows[0].id;
+
+    const phone = (row.customer_phone || '').toString().trim();
+    if (!phone) {
+      await client.query(`UPDATE integration_sync_log SET status = 'skipped', error = 'no phone on customer' WHERE id = $1`, [logId]);
+      out.skipped += 1;
+      return out;
+    }
+
+    await sendSms({ to: phone, body: deliveryBookedMessage({ invoiceId: row.invoice_id, deliveryDate: row.delivery_date }) });
+    sent = true; // SMS is away — never relabel 'failed' past here.
+
+    await client.query(`UPDATE integration_sync_log SET status = 'sent' WHERE id = $1`, [logId]);
+    out.notified += 1;
+  } catch (err) {
+    if (sent) {
+      out.notified += 1;
+      console.error(`delivery notify: post-send bookkeeping failed for delivery ${id}`, err);
+    } else {
+      out.failed += 1;
+      console.error(`delivery notify: send failed for delivery ${id}`, err);
+      if (logId) {
+        try {
+          await client.query(`UPDATE integration_sync_log SET status = 'failed', error = $1 WHERE id = $2`,
+            [String(err?.message || err).slice(0, 500), logId]);
+        } catch { /* best-effort audit; ignore */ }
+      }
+    }
+  }
+  return out;
+}

--- a/lib/deliveryNotify.js
+++ b/lib/deliveryNotify.js
@@ -26,14 +26,24 @@
 
 import { sendSystemSms } from './podium.js';
 
-// The one place the claim/reclaim is expressed. ON CONFLICT ... DO UPDATE ... WHERE
-// status <> 'sent' is the atomic gate: rowCount 0 ⇒ already sent ⇒ refuse.
+// The one place the claim/reclaim is expressed. rowCount 0 ⇒ refuse.
+//
+// The reclaim predicate is EXACTLY 'skipped' — i.e. only a text a human explicitly
+// declined may be claimed again. It is deliberately not `<> 'sent'`:
+//   • 'pending' means a send is IN FLIGHT (the claim autocommits before the Podium call,
+//     so a concurrent confirm or a double-click would see 'pending' and send a SECOND
+//     text — the one thing this must never do).
+//   • 'failed' means Podium rejected it, but it may still have queued the message; the
+//     sibling F8a makes the same call (a missed text beats a duplicate). Not retried.
+// So 'pending', 'failed' and 'sent' are all terminal, and only 'skipped' reopens.
+// Consequence, accepted knowingly: a crash between claim and send strands a 'pending' row
+// that can never be texted — recoverable only by deleting that row (see the F10 runbook).
 const CLAIM_SQL = `
   INSERT INTO integration_sync_log (source, direction, event_type, reference_id, status, payload)
   VALUES ('podium', 'outbound', 'delivery.booked', $1, 'pending', $2)
   ON CONFLICT (source, reference_id) WHERE reference_id IS NOT NULL
   DO UPDATE SET status = 'pending', error = NULL
-  WHERE integration_sync_log.status <> 'sent'
+  WHERE integration_sync_log.status = 'skipped'
   RETURNING id`;
 
 const DELIVERY_SELECT = `
@@ -92,13 +102,21 @@ export async function declineDeliveryBookedSms(client, deliveryId, opts = {}) {
   const out = { notified: 0, skipped: 0, failed: 0 };
   const row = await loadBooking(client, deliveryId);
   if (!row) return out;
+  // Only a booked delivery has a text to decline (mirrors the send path's guard).
+  if (row.delivery_status !== 'Booked for Delivery') { out.skipped += 1; return out; }
 
   try {
     const claim = await client.query(CLAIM_SQL, [
       `delivery_booked:${row.delivery_id}`,
-      JSON.stringify({ delivery_id: row.delivery_id, customer_id: row.customer_id, invoice_id: row.invoice_id }),
+      JSON.stringify({
+        delivery_id: row.delivery_id,
+        customer_id: row.customer_id,
+        invoice_id: row.invoice_id,
+        declined_by: actorId || null,
+      }),
     ]);
-    if (!claim.rowCount) { out.skipped += 1; return out; } // already sent — nothing to decline
+    // rowCount 0 ⇒ already sent / in flight / failed — there is nothing left to decline.
+    if (!claim.rowCount) { out.skipped += 1; return out; }
     await client.query(
       `UPDATE integration_sync_log SET status = 'skipped', error = $1 WHERE id = $2`,
       [`declined by ${actorId || 'unknown'}`, claim.rows[0].id]
@@ -132,7 +150,7 @@ export function deliveryBookedMessage({ invoiceId, deliveryDate } = {}) {
  * @returns {Promise<{notified:number, skipped:number, failed:number, alreadySent?:boolean}>}
  */
 export async function notifyDeliveryBooked(client, deliveryId, opts = {}) {
-  const { send } = opts;
+  const { send, actorId } = opts;
   const sendSms = send || sendSystemSms;
   const out = { notified: 0, skipped: 0, failed: 0 };
 
@@ -153,6 +171,9 @@ export async function notifyDeliveryBooked(client, deliveryId, opts = {}) {
         delivery_id: row.delivery_id,
         customer_id: row.customer_id,
         invoice_id: row.invoice_id,
+        // Who pressed Send. The whole point of gating this endpoint on a real login is to
+        // be able to record this — envelope metadata, so P1 still holds.
+        confirmed_by: actorId || null,
       }),
     ]);
     if (!claim.rowCount) { out.skipped += 1; out.alreadySent = true; return out; }

--- a/lib/handlers/delivery.js
+++ b/lib/handlers/delivery.js
@@ -1,5 +1,13 @@
 import { getClientWithTimezone } from '../db.js';
-import { notifyDeliveryBooked } from '../deliveryNotify.js'; // F8b
+// F8b: the delivery-booked text is CONFIRMED BY A HUMAN (Nick, 17 Jul 2026) — booking
+// returns a preview, and the SMS only goes when logistics explicitly confirms it via
+// POST /api/delivery?resource=booking-sms. Nothing here sends automatically.
+import {
+  previewDeliveryBookedSms,
+  notifyDeliveryBooked,
+  declineDeliveryBookedSms,
+} from '../deliveryNotify.js';
+import { getAuthUser } from '../rbac.js';
 
 const CUSTOMER_COLLECT_ID = 15;
 
@@ -23,6 +31,48 @@ export default async function handler(req, res) {
   const client = await getClientWithTimezone();
 
   try {
+    // ---- F8b: the delivery-booked text confirmation -------------------------------
+    // POST /api/delivery?resource=booking-sms&id=<delivery_id>  { action: 'send'|'skip' }
+    // Dispatched BEFORE the create path so `resource` can't fall through to it.
+    //
+    // Unlike the rest of this handler (legacy, ungated, identifies the actor from a body
+    // field), this one REQUIRES a valid login token: it texts a customer, so the actor
+    // must be real and attributable. Safe to gate because its only caller is new UI that
+    // sends the token. Not role-gated beyond authentication — the `logistics` role isn't
+    // assigned to anyone yet, and gating on it would lock out the admins who book
+    // deliveries today. Tighten once roles are rolled out (F9).
+    if ((req.query?.resource || '') === 'booking-sms') {
+      if (method !== 'POST') {
+        res.setHeader('Allow', ['POST']);
+        return res.status(405).json({ error: 'Method not allowed for booking-sms' });
+      }
+      const auth = getAuthUser(req);
+      if (!auth) return res.status(401).json({ error: 'Not authenticated' });
+      if (!id) return res.status(400).json({ error: 'Missing delivery_id' });
+
+      const action = String(body?.action || '');
+      if (action !== 'send' && action !== 'skip') {
+        return res.status(400).json({ error: "action must be 'send' or 'skip'" });
+      }
+
+      if (action === 'skip') {
+        const outcome = await declineDeliveryBookedSms(client, id, { actorId: auth.id });
+        return res.status(200).json({ message: 'No text sent', outcome });
+      }
+
+      const outcome = await notifyDeliveryBooked(client, id, { actorId: auth.id });
+      if (outcome.alreadySent) {
+        return res.status(409).json({ error: 'That text has already been sent', outcome });
+      }
+      if (outcome.failed) {
+        return res.status(502).json({ error: 'Podium would not accept the text — nothing was sent', outcome });
+      }
+      if (!outcome.notified) {
+        return res.status(409).json({ error: 'The text could not be sent (delivery not booked, or no phone)', outcome });
+      }
+      return res.status(200).json({ message: 'Text sent', outcome });
+    }
+
     if (method === 'GET') {
       if (id) {
         // Single delivery with customer, removalist, and WO summary (items_text, outstanding_balance)
@@ -258,13 +308,15 @@ export default async function handler(req, res) {
 
       await client.query('COMMIT');
 
-      // F8b: delivery-booked SMS — AFTER commit, BEST-EFFORT (never blocks/undoes the booking).
+      // F8b: created straight as booked → offer the text, don't send it. Best-effort:
+      // a preview failure must never fail the creation the caller just made.
+      let booking_sms = null;
       if (r.rows[0].delivery_status === 'Booked for Delivery') {
-        try { await notifyDeliveryBooked(client, r.rows[0].delivery_id); }
-        catch (e) { console.error('delivery-booked notify (post-create) failed:', e); }
+        try { booking_sms = await previewDeliveryBookedSms(client, r.rows[0].delivery_id); }
+        catch (e) { console.error('delivery-booked preview (post-create) failed:', e); }
       }
 
-      return res.status(201).json({ message: 'Delivery created', delivery_id: r.rows[0].delivery_id });
+      return res.status(201).json({ message: 'Delivery created', delivery_id: r.rows[0].delivery_id, booking_sms });
     }
 
     if (method === 'PUT') {
@@ -385,13 +437,16 @@ export default async function handler(req, res) {
 
       await client.query('COMMIT');
 
-      // F8b: delivery-booked SMS — AFTER commit, BEST-EFFORT (never blocks/undoes the booking).
+      // F8b: just became booked → return the text for confirmation. NOT sent here — the
+      // UI shows it to logistics, who send or decline. Best-effort: a preview failure must
+      // never fail the booking that has already committed.
+      let booking_sms = null;
       if (becameBooked) {
-        try { await notifyDeliveryBooked(client, id); }
-        catch (e) { console.error('delivery-booked notify (post-update) failed:', e); }
+        try { booking_sms = await previewDeliveryBookedSms(client, id); }
+        catch (e) { console.error('delivery-booked preview (post-update) failed:', e); }
       }
 
-      return res.status(200).json({ message: 'Delivery updated' });
+      return res.status(200).json({ message: 'Delivery updated', booking_sms });
     }
 
     if (method === 'DELETE') {

--- a/lib/handlers/delivery.js
+++ b/lib/handlers/delivery.js
@@ -1,4 +1,5 @@
 import { getClientWithTimezone } from '../db.js';
+import { notifyDeliveryBooked } from '../deliveryNotify.js'; // F8b
 
 const CUSTOMER_COLLECT_ID = 15;
 
@@ -257,6 +258,12 @@ export default async function handler(req, res) {
 
       await client.query('COMMIT');
 
+      // F8b: delivery-booked SMS — AFTER commit, BEST-EFFORT (never blocks/undoes the booking).
+      if (r.rows[0].delivery_status === 'Booked for Delivery') {
+        try { await notifyDeliveryBooked(client, r.rows[0].delivery_id); }
+        catch (e) { console.error('delivery-booked notify (post-create) failed:', e); }
+      }
+
       return res.status(201).json({ message: 'Delivery created', delivery_id: r.rows[0].delivery_id });
     }
 
@@ -366,6 +373,7 @@ export default async function handler(req, res) {
       );
 
       // ===== selective logging =====
+      const becameBooked = delivery_status !== undefined && delivery_status !== prevStatus && delivery_status === 'Booked for Delivery';
       if (delivery_status !== undefined && delivery_status !== prevStatus) {
         if (delivery_status === 'Booked for Delivery') {
           await logEvent(client, { workorder_id: woid, event_type: 'DELIVERY_BOOKED', user_id: actorId });
@@ -376,6 +384,13 @@ export default async function handler(req, res) {
       }
 
       await client.query('COMMIT');
+
+      // F8b: delivery-booked SMS — AFTER commit, BEST-EFFORT (never blocks/undoes the booking).
+      if (becameBooked) {
+        try { await notifyDeliveryBooked(client, id); }
+        catch (e) { console.error('delivery-booked notify (post-update) failed:', e); }
+      }
+
       return res.status(200).json({ message: 'Delivery updated' });
     }
 

--- a/scripts/podium-delivery-notify-smoke.mjs
+++ b/scripts/podium-delivery-notify-smoke.mjs
@@ -10,7 +10,12 @@
 
 process.env.PODIUM_MOCK = 'true';
 
-const { notifyDeliveryBooked, deliveryBookedMessage } = await import('../lib/deliveryNotify.js');
+const {
+  notifyDeliveryBooked,
+  deliveryBookedMessage,
+  previewDeliveryBookedSms,
+  declineDeliveryBookedSms,
+} = await import('../lib/deliveryNotify.js');
 
 let passed = 0;
 function check(name, cond, detail) {
@@ -82,7 +87,10 @@ console.log('\nhappy path:');
   const sel = client.calls.find((c) => SELECT_RE.test(c.sql));
   check('lookup joins delivery + customer', !!sel && /JOIN customers c/i.test(sel.sql));
   const claim = client.calls.find((c) => CLAIM_RE.test(c.sql));
-  check('claim uses ON CONFLICT DO NOTHING', !!claim && /ON CONFLICT/i.test(claim.sql) && /DO NOTHING/i.test(claim.sql));
+  // The claim is an upsert, NOT DO NOTHING: a declined text was never sent, so it must
+  // stay sendable — while an already-'sent' row can never be reopened. See the
+  // confirmation-panel section below.
+  check('claim reclaims anything not already sent', !!claim && /ON CONFLICT/i.test(claim.sql) && /DO UPDATE/i.test(claim.sql) && /status <> 'sent'/i.test(claim.sql));
   check('reference_id is per-delivery', !!claim && (claim.params || []).includes('delivery_booked:42'));
   check('payload is envelope-only (no body)', !!claim && /"invoice_id"/.test(claim.params?.[1] || '') && !/booked for delivery/i.test(claim.params?.[1] || ''));
   check('marked sent', client.calls.some((c) => LOG_UPD_RE.test(c.sql) && /'sent'/i.test(c.sql)));
@@ -102,7 +110,7 @@ console.log('\nedge cases:');
     { match: CLAIM_RE, result: { rowCount: 0, rows: [] } }, // conflict
   ]);
   const out = await notifyDeliveryBooked(client, 42, { send: async (m) => { sent.push(m); return {}; } });
-  check('conflict → skipped, no send (idempotent)', out.skipped === 1 && sent.length === 0);
+  check('already-sent row → skipped, no second send (at-most-once)', out.skipped === 1 && sent.length === 0);
 }
 {
   const err = new Error('relation "delivery" does not exist'); err.code = '42P01';
@@ -128,6 +136,75 @@ console.log('\nedge cases:');
   const client = okClient(bookedRow());
   const out = await notifyDeliveryBooked(client, 42); // real mock send
   check('real mock send path notifies', out.notified === 1 && out.failed === 0);
+}
+
+// ---------------------------------------------------------------------------
+// Confirmation panel (Nick, 17 Jul 2026): logistics must approve the text before
+// it goes. The SMS is no longer sent automatically on booking — the booking flow
+// PREVIEWS it, and a human explicitly sends or declines.
+// ---------------------------------------------------------------------------
+
+console.log('\npreview (what the confirmation panel shows) — reads only, never claims:');
+{
+  const client = makeClient([{ match: SELECT_RE, result: { rowCount: 1, rows: [bookedRow()] } }]);
+  const p = await previewDeliveryBookedSms(client, 42);
+  check('eligible when booked with a phone', p.eligible === true);
+  check('previews the EXACT body that will be sent', p.body === deliveryBookedMessage({ invoiceId: 'INV-900', deliveryDate: '20 Jul 2026' }));
+  check('surfaces the number it would text', p.to === '0400000000');
+  check('names the customer so the panel can say who', p.customer_name === 'Demo Customer');
+  check('previewing NEVER claims or sends', !client.calls.some((c) => CLAIM_RE.test(c.sql)));
+
+  const noPhone = makeClient([{ match: SELECT_RE, result: { rowCount: 1, rows: [bookedRow({ customer_phone: null })] } }]);
+  const p2 = await previewDeliveryBookedSms(noPhone, 42);
+  check('no phone → ineligible with a reason the panel can show', p2.eligible === false && /phone/i.test(p2.reason));
+
+  const notBooked = makeClient([{ match: SELECT_RE, result: { rowCount: 1, rows: [bookedRow({ delivery_status: 'To Be Booked' })] } }]);
+  check('not booked → ineligible', (await previewDeliveryBookedSms(notBooked, 42)).eligible === false);
+
+  const missing = makeClient([{ match: SELECT_RE, result: { rowCount: 0, rows: [] } }]);
+  check('unknown delivery → ineligible, no throw', (await previewDeliveryBookedSms(missing, 999)).eligible === false);
+
+  const err = new Error('no table'); err.code = '42P01';
+  const bare = makeClient([{ match: SELECT_RE, throws: err }]);
+  check('bare DB → ineligible, no throw', (await previewDeliveryBookedSms(bare, 42)).eligible === false);
+}
+
+console.log('\ndecline ("Don\'t send") — records the decision, sends nothing:');
+{
+  const sent = [];
+  const client = okClient(bookedRow());
+  const out = await declineDeliveryBookedSms(client, 42, { actorId: 'BR', send: async (m) => { sent.push(m); } });
+  check('nothing is sent', sent.length === 0 && out.skipped === 1);
+  const claim = client.calls.find((c) => CLAIM_RE.test(c.sql));
+  check('the decision is audited under the same reference', (claim.params || []).includes('delivery_booked:42'));
+  check('recorded as skipped, attributed to the person who declined',
+    client.calls.some((c) => LOG_UPD_RE.test(c.sql) && /'skipped'/i.test(c.sql) && (c.params || []).some((p) => String(p).includes('BR'))));
+}
+
+console.log('\nnever text twice — even with a human in the loop:');
+{
+  // The claim is now an upsert that REFUSES to reopen a row already marked 'sent'
+  // (rowCount 0), so a double-click or a second confirm can't double-text.
+  const sent = [];
+  const client = makeClient([
+    { match: SELECT_RE, result: { rowCount: 1, rows: [bookedRow()] } },
+    { match: CLAIM_RE, result: { rowCount: 0, rows: [] } }, // already 'sent'
+  ]);
+  const out = await notifyDeliveryBooked(client, 42, { send: async (m) => { sent.push(m); } });
+  check('already sent → no second text', sent.length === 0 && out.notified === 0);
+  check('reports alreadySent so the UI can say so', out.alreadySent === true);
+
+  const claim = client.calls.find((c) => CLAIM_RE.test(c.sql));
+  check('claim refuses to reopen a sent row', /DO UPDATE/i.test(claim.sql) && /status <> 'sent'/i.test(claim.sql));
+}
+
+console.log('\na declined text can still be sent later (it was never sent):');
+{
+  const sent = [];
+  const client = okClient(bookedRow()); // claim upsert succeeds (row was 'skipped')
+  const out = await notifyDeliveryBooked(client, 42, { actorId: 'BR', send: async (m) => { sent.push(m); } });
+  check('reclaiming a declined row sends the first text', out.notified === 1 && sent.length === 1);
+  check('at-most-once still holds — the gate is "was it SENT", not "was it claimed"', out.alreadySent !== true);
 }
 
 console.log(`\n✅ delivery-booked smoke: ${passed} checks passed`);

--- a/scripts/podium-delivery-notify-smoke.mjs
+++ b/scripts/podium-delivery-notify-smoke.mjs
@@ -1,0 +1,133 @@
+// scripts/podium-delivery-notify-smoke.mjs — offline smoke for F8b delivery-booked SMS.
+//
+//   node scripts/podium-delivery-notify-smoke.mjs
+//
+// Exercises lib/deliveryNotify.js with an INJECTED fake pg client and (mostly) an injected
+// fake sender — no network, no DB, no secrets. Covers: copy (with/without date); invalid id
+// no-op; not-found no-op; not-booked → skip; send + audit-sent + envelope-only payload; the
+// ON CONFLICT idempotency claim + reference_id; no-phone → skip; conflict → skip; 42P01
+// degrade; best-effort throw; post-send-bookkeeping-fail → still notified; real mock send.
+
+process.env.PODIUM_MOCK = 'true';
+
+const { notifyDeliveryBooked, deliveryBookedMessage } = await import('../lib/deliveryNotify.js');
+
+let passed = 0;
+function check(name, cond, detail) {
+  if (!cond) throw new Error(`FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  passed += 1;
+  console.log(`  ✓ ${name}`);
+}
+
+function makeClient(scripts = []) {
+  const calls = [];
+  return {
+    calls,
+    async query(sql, params) {
+      calls.push({ sql, params });
+      for (const s of scripts) {
+        if (typeof s.match === 'function' ? s.match(sql) : s.match.test(sql)) {
+          if (s.throws) throw s.throws;
+          return s.result ?? { rowCount: 0, rows: [] };
+        }
+      }
+      return { rowCount: 0, rows: [] };
+    },
+  };
+}
+
+const SELECT_RE = /FROM delivery d/i;
+const CLAIM_RE  = /INSERT INTO integration_sync_log/i;
+const LOG_UPD_RE = /UPDATE integration_sync_log/i;
+
+const bookedRow = (over = {}) => ({
+  delivery_id: 42, customer_id: 26, invoice_id: 'INV-900',
+  delivery_status: 'Booked for Delivery', delivery_date: '20 Jul 2026',
+  customer_name: 'Demo Customer', customer_phone: '0400000000',
+  ...over,
+});
+
+function okClient(row) {
+  return makeClient([
+    { match: SELECT_RE, result: { rowCount: row ? 1 : 0, rows: row ? [row] : [] } },
+    { match: CLAIM_RE, result: { rowCount: 1, rows: [{ id: 55 }] } },
+    { match: LOG_UPD_RE, result: { rowCount: 1, rows: [] } },
+  ]);
+}
+
+console.log('Delivery-booked (F8b) smoke — fake client, no DB\n');
+
+console.log('copy + guards:');
+{
+  check('copy names the delivery date', deliveryBookedMessage({ invoiceId: 'INV-900', deliveryDate: '20 Jul 2026' }).includes('20 Jul 2026'));
+  check('copy without a date says we\'ll be in touch', /in touch/i.test(deliveryBookedMessage({ invoiceId: 'INV-900' })));
+  check('copy carries the sales phone', deliveryBookedMessage({}).includes('1300 769 556'));
+  const c1 = makeClient();
+  check('invalid id → no-op', (await notifyDeliveryBooked(c1, 'nope')).notified === 0 && c1.calls.length === 0);
+  const c2 = okClient(null);
+  const out2 = await notifyDeliveryBooked(c2, 42);
+  check('not found → no-op', out2.notified === 0 && out2.skipped === 0);
+  const c3 = okClient(bookedRow({ delivery_status: 'To Be Booked' }));
+  const out3 = await notifyDeliveryBooked(c3, 42);
+  check('not booked → skipped, no send', out3.skipped === 1 && out3.notified === 0 && !c3.calls.some((c) => CLAIM_RE.test(c.sql)));
+}
+
+console.log('\nhappy path:');
+{
+  const sent = [];
+  const client = okClient(bookedRow());
+  const out = await notifyDeliveryBooked(client, 42, { send: async (m) => { sent.push(m); return { status: 'sent' }; } });
+  check('one notified', out.notified === 1 && out.skipped === 0 && out.failed === 0, JSON.stringify(out));
+  check('SMS to the customer phone with the booked copy', sent.length === 1 && sent[0].to === '0400000000' && /booked for delivery/i.test(sent[0].body));
+  const sel = client.calls.find((c) => SELECT_RE.test(c.sql));
+  check('lookup joins delivery + customer', !!sel && /JOIN customers c/i.test(sel.sql));
+  const claim = client.calls.find((c) => CLAIM_RE.test(c.sql));
+  check('claim uses ON CONFLICT DO NOTHING', !!claim && /ON CONFLICT/i.test(claim.sql) && /DO NOTHING/i.test(claim.sql));
+  check('reference_id is per-delivery', !!claim && (claim.params || []).includes('delivery_booked:42'));
+  check('payload is envelope-only (no body)', !!claim && /"invoice_id"/.test(claim.params?.[1] || '') && !/booked for delivery/i.test(claim.params?.[1] || ''));
+  check('marked sent', client.calls.some((c) => LOG_UPD_RE.test(c.sql) && /'sent'/i.test(c.sql)));
+}
+
+console.log('\nedge cases:');
+{
+  const sent = [];
+  const client = okClient(bookedRow({ customer_phone: null }));
+  const out = await notifyDeliveryBooked(client, 42, { send: async (m) => { sent.push(m); return {}; } });
+  check('no phone → skipped, no send', out.skipped === 1 && sent.length === 0 && client.calls.some((c) => LOG_UPD_RE.test(c.sql) && /'skipped'/i.test(c.sql)));
+}
+{
+  const sent = [];
+  const client = makeClient([
+    { match: SELECT_RE, result: { rowCount: 1, rows: [bookedRow()] } },
+    { match: CLAIM_RE, result: { rowCount: 0, rows: [] } }, // conflict
+  ]);
+  const out = await notifyDeliveryBooked(client, 42, { send: async (m) => { sent.push(m); return {}; } });
+  check('conflict → skipped, no send (idempotent)', out.skipped === 1 && sent.length === 0);
+}
+{
+  const err = new Error('relation "delivery" does not exist'); err.code = '42P01';
+  const client = makeClient([{ match: SELECT_RE, throws: err }]);
+  const out = await notifyDeliveryBooked(client, 42);
+  check('42P01 → {0,0,0}, no throw', out.notified === 0 && out.failed === 0);
+}
+{
+  const client = okClient(bookedRow());
+  const out = await notifyDeliveryBooked(client, 42, { send: async () => { throw new Error('Podium 503'); } });
+  check('send failure → failed, never throws', out.failed === 1 && out.notified === 0 && client.calls.some((c) => LOG_UPD_RE.test(c.sql) && /'failed'/i.test(c.sql)));
+}
+{
+  const client = makeClient([
+    { match: SELECT_RE, result: { rowCount: 1, rows: [bookedRow()] } },
+    { match: CLAIM_RE, result: { rowCount: 1, rows: [{ id: 9 }] } },
+    { match: /status = 'sent'/i, throws: new Error('db blip after send') },
+  ]);
+  const out = await notifyDeliveryBooked(client, 42, { send: async () => ({}) });
+  check('post-send bookkeeping fail → notified, not failed', out.notified === 1 && out.failed === 0, JSON.stringify(out));
+}
+{
+  const client = okClient(bookedRow());
+  const out = await notifyDeliveryBooked(client, 42); // real mock send
+  check('real mock send path notifies', out.notified === 1 && out.failed === 0);
+}
+
+console.log(`\n✅ delivery-booked smoke: ${passed} checks passed`);

--- a/scripts/podium-delivery-notify-smoke.mjs
+++ b/scripts/podium-delivery-notify-smoke.mjs
@@ -87,10 +87,10 @@ console.log('\nhappy path:');
   const sel = client.calls.find((c) => SELECT_RE.test(c.sql));
   check('lookup joins delivery + customer', !!sel && /JOIN customers c/i.test(sel.sql));
   const claim = client.calls.find((c) => CLAIM_RE.test(c.sql));
-  // The claim is an upsert, NOT DO NOTHING: a declined text was never sent, so it must
-  // stay sendable — while an already-'sent' row can never be reopened. See the
-  // confirmation-panel section below.
-  check('claim reclaims anything not already sent', !!claim && /ON CONFLICT/i.test(claim.sql) && /DO UPDATE/i.test(claim.sql) && /status <> 'sent'/i.test(claim.sql));
+  // The claim is an upsert rather than DO NOTHING so that a DECLINED text stays sendable —
+  // but ONLY a declined one. See "never text twice" below for why the predicate is
+  // exactly 'skipped' and not `<> 'sent'`.
+  check('claim only reclaims an explicitly declined row', !!claim && /ON CONFLICT/i.test(claim.sql) && /DO UPDATE/i.test(claim.sql) && /status = 'skipped'/i.test(claim.sql));
   check('reference_id is per-delivery', !!claim && (claim.params || []).includes('delivery_booked:42'));
   check('payload is envelope-only (no body)', !!claim && /"invoice_id"/.test(claim.params?.[1] || '') && !/booked for delivery/i.test(claim.params?.[1] || ''));
   check('marked sent', client.calls.some((c) => LOG_UPD_RE.test(c.sql) && /'sent'/i.test(c.sql)));
@@ -171,40 +171,57 @@ console.log('\npreview (what the confirmation panel shows) — reads only, never
 
 console.log('\ndecline ("Don\'t send") — records the decision, sends nothing:');
 {
-  const sent = [];
+  // NB: declineDeliveryBookedSms takes NO sender — asserting "nothing was sent" against an
+  // injected sender here would be a check that cannot fail. The real guarantee is that the
+  // decline path issues no send at all, so assert on what it DOES: claim + mark skipped.
   const client = okClient(bookedRow());
-  const out = await declineDeliveryBookedSms(client, 42, { actorId: 'BR', send: async (m) => { sent.push(m); } });
-  check('nothing is sent', sent.length === 0 && out.skipped === 1);
+  const out = await declineDeliveryBookedSms(client, 42, { actorId: 'BR' });
+  check('decline records a skip', out.skipped === 1 && out.notified === 0);
   const claim = client.calls.find((c) => CLAIM_RE.test(c.sql));
   check('the decision is audited under the same reference', (claim.params || []).includes('delivery_booked:42'));
+  check('the decliner is recorded in the envelope', /"declined_by":"BR"/.test(claim.params?.[1] || ''));
   check('recorded as skipped, attributed to the person who declined',
     client.calls.some((c) => LOG_UPD_RE.test(c.sql) && /'skipped'/i.test(c.sql) && (c.params || []).some((p) => String(p).includes('BR'))));
+  check('a decline never marks the row sent', !client.calls.some((c) => LOG_UPD_RE.test(c.sql) && /'sent'/i.test(c.sql)));
+
+  const notBooked = okClient(bookedRow({ delivery_status: 'Delivery Completed' }));
+  const out2 = await declineDeliveryBookedSms(notBooked, 42, { actorId: 'BR' });
+  check('nothing to decline on an unbooked delivery → no claim', out2.skipped === 1 && !notBooked.calls.some((c) => CLAIM_RE.test(c.sql)));
 }
 
-console.log('\nnever text twice — even with a human in the loop:');
+console.log('\nnever text twice — the gate the confirmation panel depends on:');
 {
-  // The claim is now an upsert that REFUSES to reopen a row already marked 'sent'
-  // (rowCount 0), so a double-click or a second confirm can't double-text.
-  const sent = [];
+  // ⚠️ The reclaim predicate is EXACTLY 'skipped'. `<> 'sent'` would look equivalent and
+  // is NOT: the claim autocommits as 'pending' BEFORE the Podium round-trip, so a second
+  // confirm (double-click, two users, a retry after a timeout) would see 'pending',
+  // reclaim, and send a SECOND text to the customer. Only an explicitly declined text
+  // may be reopened.
+  const claimSql = (client) => client.calls.find((c) => CLAIM_RE.test(c.sql)).sql;
+
   const client = makeClient([
     { match: SELECT_RE, result: { rowCount: 1, rows: [bookedRow()] } },
-    { match: CLAIM_RE, result: { rowCount: 0, rows: [] } }, // already 'sent'
+    { match: CLAIM_RE, result: { rowCount: 0, rows: [] } }, // predicate didn't match
   ]);
+  const sent = [];
   const out = await notifyDeliveryBooked(client, 42, { send: async (m) => { sent.push(m); } });
-  check('already sent → no second text', sent.length === 0 && out.notified === 0);
+  check('claim refused → no text', sent.length === 0 && out.notified === 0);
   check('reports alreadySent so the UI can say so', out.alreadySent === true);
 
-  const claim = client.calls.find((c) => CLAIM_RE.test(c.sql));
-  check('claim refuses to reopen a sent row', /DO UPDATE/i.test(claim.sql) && /status <> 'sent'/i.test(claim.sql));
+  const sql = claimSql(client);
+  check('only a DECLINED row can be reclaimed', /DO UPDATE/i.test(sql) && /status = 'skipped'/i.test(sql));
+  check('an in-flight (pending) or failed row is NOT reclaimable — no double-text', !/status <> 'sent'/i.test(sql));
 }
 
 console.log('\na declined text can still be sent later (it was never sent):');
 {
   const sent = [];
   const client = okClient(bookedRow()); // claim upsert succeeds (row was 'skipped')
-  const out = await notifyDeliveryBooked(client, 42, { actorId: 'BR', send: async (m) => { sent.push(m); } });
+  const out = await notifyDeliveryBooked(client, 42, { actorId: 'GS', send: async (m) => { sent.push(m); } });
   check('reclaiming a declined row sends the first text', out.notified === 1 && sent.length === 1);
-  check('at-most-once still holds — the gate is "was it SENT", not "was it claimed"', out.alreadySent !== true);
+  check('not reported as alreadySent', out.alreadySent !== true);
+  const claim = client.calls.find((c) => CLAIM_RE.test(c.sql));
+  check('the sender is attributed (why the endpoint demands a login)', /"confirmed_by":"GS"/.test(claim.params?.[1] || ''));
+  check('the envelope still carries no message body (P1)', !/booked for delivery/i.test(claim.params?.[1] || ''));
 }
 
 console.log(`\n✅ delivery-booked smoke: ${passed} checks passed`);

--- a/src/pages/delivery_operations/to-be-booked.js
+++ b/src/pages/delivery_operations/to-be-booked.js
@@ -12,11 +12,15 @@ const ORDERED_STATES = ['VIC', 'NSW', 'QLD', 'ACT', 'WA', 'SA', 'TAS', 'NT'];
  * F8b (Nick, 17 Jul 2026): booking a delivery no longer texts the customer automatically.
  * This panel shows logistics the EXACT text first; nothing is sent until they choose.
  *
- * Deliberately not dismissible by backdrop or Esc — the booking has already saved, the row
- * is about to leave this list, and this is the only moment the decision can be made. Both
- * outcomes are recorded, so "Don't send" is a real answer, not a way to duck the question.
+ * Send and Don't-send are both recorded, so the panel asks a real question rather than
+ * letting the decision drift. It is NOT modal-with-no-exit though: "Decide later" always
+ * closes it client-side without touching the server. That escape hatch is deliberate —
+ * both real buttons call a login-gated endpoint, so without it an expired session (the
+ * login token lasts 1h; the SPA session slides on activity) would leave the operator
+ * locked in an unclosable dialog with the page unusable. A page you can't use is worse
+ * than a question you can defer.
  */
-function BookingSmsPanel({ sms, busy, onSend, onSkip }) {
+function BookingSmsPanel({ sms, busy, onSend, onSkip, onDismiss }) {
   if (!sms) return null;
   const eligible = sms.eligible !== false;
   return createPortal(
@@ -52,9 +56,18 @@ function BookingSmsPanel({ sms, busy, onSend, onSkip }) {
           )}
         </div>
 
-        <div className="flex justify-end gap-2 border-t border-gray-200 px-5 py-3">
+        <div className="flex items-center justify-end gap-2 border-t border-gray-200 px-5 py-3">
           {eligible ? (
             <>
+              {/* Always available, never touches the server — the way out if the session
+                  has expired or the API is down. Leaves no record: no text is sent. */}
+              <button
+                type="button"
+                onClick={onDismiss}
+                className="mr-auto text-sm text-gray-500 underline hover:text-gray-700"
+              >
+                Decide later
+              </button>
               <button
                 type="button"
                 onClick={onSkip}
@@ -74,11 +87,13 @@ function BookingSmsPanel({ sms, busy, onSend, onSkip }) {
               </button>
             </>
           ) : (
+            // Nothing can be sent, so there is nothing to decline — a pure client-side
+            // dismiss. (Recording this as "declined by …" would misreport a missing phone
+            // number as a human decision.)
             <button
               type="button"
-              onClick={onSkip}
-              disabled={busy}
-              className="rounded border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-60"
+              onClick={onDismiss}
+              className="rounded border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50"
             >
               Close
             </button>
@@ -430,9 +445,26 @@ export default function ToBeBookedDeliveriesPage() {
         }
       );
       const data = await res.json().catch(() => ({}));
+
+      // The login token lasts 1h while the SPA session slides on activity, so a long
+      // shift CAN outlive the token. Say so and get out of the way — never trap the
+      // operator in a dialog whose only buttons need the server.
+      if (res.status === 401) {
+        toast.error('Your session has expired — sign in again to send the text');
+        setBookingSms(null);
+        navigate('/');
+        return;
+      }
+      // Already sent (e.g. a double-click, or someone else confirmed it). Nothing to do —
+      // closing with "No text sent" here would be a lie.
+      if (res.status === 409 && data?.outcome?.alreadySent) {
+        toast('That text was already sent', { icon: 'ℹ️' });
+        setBookingSms(null);
+        return;
+      }
       if (!res.ok) {
         toast.error(data?.error || 'Could not send the text');
-        return; // keep the panel open so the decision isn't silently lost
+        return; // keep the panel open — the decision hasn't been made yet
       }
       toast.success(action === 'send' ? 'Text sent to the customer' : 'No text sent');
       setBookingSms(null);
@@ -441,7 +473,7 @@ export default function ToBeBookedDeliveriesPage() {
     } finally {
       setSmsBusy(false);
     }
-  }, [bookingSms]);
+  }, [bookingSms, navigate]);
 
   const saveWorkorderPayment = useCallback(async (workorder_id, newOutstanding) => {
     if (!workorder_id) return;
@@ -921,6 +953,7 @@ export default function ToBeBookedDeliveriesPage() {
         busy={smsBusy}
         onSend={() => resolveBookingSms('send')}
         onSkip={() => resolveBookingSms('skip')}
+        onDismiss={() => setBookingSms(null)}
       />
     </div>
   );

--- a/src/pages/delivery_operations/to-be-booked.js
+++ b/src/pages/delivery_operations/to-be-booked.js
@@ -3,9 +3,92 @@ import { createPortal } from 'react-dom';
 import { useNavigate, useLocation } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import DeliveryTabs from '../../components/DeliveryTabs';
+import { authHeaders } from '../../utils/auth';
 
 const EDITABLE_STATUSES = ['To Be Booked', 'Booked for Delivery'];
 const ORDERED_STATES = ['VIC', 'NSW', 'QLD', 'ACT', 'WA', 'SA', 'TAS', 'NT'];
+
+/**
+ * F8b (Nick, 17 Jul 2026): booking a delivery no longer texts the customer automatically.
+ * This panel shows logistics the EXACT text first; nothing is sent until they choose.
+ *
+ * Deliberately not dismissible by backdrop or Esc — the booking has already saved, the row
+ * is about to leave this list, and this is the only moment the decision can be made. Both
+ * outcomes are recorded, so "Don't send" is a real answer, not a way to duck the question.
+ */
+function BookingSmsPanel({ sms, busy, onSend, onSkip }) {
+  if (!sms) return null;
+  const eligible = sms.eligible !== false;
+  return createPortal(
+    <div className="fixed inset-0 z-[100] flex items-center justify-center bg-black/40 p-4">
+      <div className="w-full max-w-lg rounded-lg bg-white shadow-xl">
+        <div className="border-b border-gray-200 px-5 py-3">
+          <h2 className="text-lg font-semibold text-gray-900">
+            {eligible ? 'Send booking confirmation text?' : 'No text can be sent'}
+          </h2>
+          <p className="mt-0.5 text-sm text-gray-600">
+            The delivery is booked. {eligible ? 'Nothing has been sent yet.' : ''}
+          </p>
+        </div>
+
+        <div className="px-5 py-4">
+          {eligible ? (
+            <>
+              <div className="mb-3 text-sm text-gray-700">
+                To <span className="font-medium">{sms.customer_name || 'the customer'}</span>{' '}
+                on <span className="font-mono">{sms.to}</span>
+              </div>
+              <div className="rounded-md border border-gray-200 bg-gray-50 p-3 text-sm text-gray-800 whitespace-pre-wrap">
+                {sms.body}
+              </div>
+              <p className="mt-3 text-xs text-gray-500">
+                Sent from the shared Grays number. It can only be sent once.
+              </p>
+            </>
+          ) : (
+            <div className="rounded-md border border-amber-300 bg-amber-50 px-3 py-2 text-sm text-amber-900">
+              {sms.reason || 'This delivery is not eligible for a booking text.'}
+            </div>
+          )}
+        </div>
+
+        <div className="flex justify-end gap-2 border-t border-gray-200 px-5 py-3">
+          {eligible ? (
+            <>
+              <button
+                type="button"
+                onClick={onSkip}
+                disabled={busy}
+                className="rounded border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-60"
+              >
+                Don’t send
+              </button>
+              <button
+                type="button"
+                onClick={onSend}
+                disabled={busy}
+                className="rounded px-4 py-2 text-sm font-medium text-white disabled:opacity-60"
+                style={{ backgroundColor: '#B50B1D' }}
+              >
+                {busy ? 'Sending…' : 'Send text'}
+              </button>
+            </>
+          ) : (
+            <button
+              type="button"
+              onClick={onSkip}
+              disabled={busy}
+              className="rounded border border-gray-300 bg-white px-4 py-2 text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-60"
+            >
+              Close
+            </button>
+          )}
+        </div>
+      </div>
+    </div>,
+    document.body
+  );
+}
 
 // Row navigation helpers
 const useRowNav = (navigate) => {
@@ -139,6 +222,9 @@ export default function ToBeBookedDeliveriesPage() {
   const [search, setSearch] = useState('');
   const [savingIds, setSavingIds] = useState(new Set());
   const [savingWO, setSavingWO] = useState(new Set());
+  // F8b: the pending booking-text decision (null = no panel open).
+  const [bookingSms, setBookingSms] = useState(null);
+  const [smsBusy, setSmsBusy] = useState(false);
 
   const currentUserId = useMemo(() => {
     try {
@@ -301,6 +387,10 @@ export default function ToBeBookedDeliveriesPage() {
       const data = await res.json().catch(() => ({}));
       if (!res.ok) throw new Error(data?.error || 'Save failed');
 
+      // F8b: the booking just saved and the server handed back the text it WOULD send.
+      // Ask before anything goes out.
+      if (data?.booking_sms) setBookingSms({ ...data.booking_sms, delivery_id: deliveryId });
+
       setDeliveries((list) => {
         if ('delivery_status' in patch && patch.delivery_status !== 'To Be Booked') {
           return list.filter((r) => r.delivery_id !== deliveryId);
@@ -322,6 +412,36 @@ export default function ToBeBookedDeliveriesPage() {
       });
     }
   }, [currentUserId]);
+
+  // F8b: resolve the booking-text decision. `action` is 'send' or 'skip'; both are
+  // recorded, and the panel only closes once the server has answered — so a failed send
+  // can't be mistaken for a sent one.
+  const resolveBookingSms = useCallback(async (action) => {
+    const deliveryId = bookingSms?.delivery_id;
+    if (!deliveryId) { setBookingSms(null); return; }
+    setSmsBusy(true);
+    try {
+      const res = await fetch(
+        `/api/delivery?resource=booking-sms&id=${encodeURIComponent(deliveryId)}`,
+        {
+          method: 'POST',
+          headers: authHeaders({ 'Content-Type': 'application/json' }),
+          body: JSON.stringify({ action }),
+        }
+      );
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        toast.error(data?.error || 'Could not send the text');
+        return; // keep the panel open so the decision isn't silently lost
+      }
+      toast.success(action === 'send' ? 'Text sent to the customer' : 'No text sent');
+      setBookingSms(null);
+    } catch {
+      toast.error('Server error — the text was not sent');
+    } finally {
+      setSmsBusy(false);
+    }
+  }, [bookingSms]);
 
   const saveWorkorderPayment = useCallback(async (workorder_id, newOutstanding) => {
     if (!workorder_id) return;
@@ -794,6 +914,14 @@ export default function ToBeBookedDeliveriesPage() {
       </div>
 
       <DeliveryTabs />
+
+      {/* F8b: nothing is texted to a customer until this is answered. */}
+      <BookingSmsPanel
+        sms={bookingSms}
+        busy={smsBusy}
+        onSend={() => resolveBookingSms('send')}
+        onSkip={() => resolveBookingSms('skip')}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## F8b — Delivery-booked SMS, confirmed by logistics

> ⚠️ **Retarget this PR's base to `main` before merging.** It currently targets `feat/podium-f8a-waitlist-sms`, which you merged on 16 Jul — **merging as-is would land this in that dead branch and it would never reach `main` or production.** F8a is already in `main`, so the diff is unchanged by the retarget. (I left this for you rather than editing your PR.)

### What changed (17 Jul 2026, at Nick's request)

**Before:** booking a delivery **automatically texted the customer**.
**Now:** booking shows a confirmation panel with the exact text. **Nothing reaches a customer until someone clicks Send.**

```
Send booking confirmation text?
The delivery is booked. Nothing has been sent yet.

To Rebecca Struve on 0425 784 594

  Good news from Grays Fitness! Your order (invoice INV-900) is booked
  for delivery on 20 Jul 2026. Questions? Call 1300 769 556.

Sent from the shared Grays number. It can only be sent once.

  Decide later            [ Don't send ]  [ Send text ]
```

Both **Send** and **Don't send** are recorded, so the Integrations log shows a decision rather than a silent gap.

### How it works

| | |
|---|---|
| `previewDeliveryBookedSms()` | **read-only** — what the panel shows. Never claims, never sends |
| `notifyDeliveryBooked()` | the **confirmed** send |
| `declineDeliveryBookedSms()` | "Don't send", recorded and attributed |
| `POST /api/delivery?resource=booking-sms&id=<id>` | `{action:'send'\|'skip'}`. **Requires a login token** — it texts a customer, so the actor must be real and attributable |
| Booking response | now returns `booking_sms` (the preview) instead of firing the SMS |

The endpoint is gated on **authentication only**, not the `logistics` role: that role isn't assigned to anyone yet, so gating on it would lock out the admins who actually book deliveries today. Worth tightening once roles are rolled out (F9).

### Code review — it caught two Critical faults

**1. My first version reopened a double-text window — the one thing this must never do.**

I used `WHERE status <> 'sent'` to let a *declined* text still be sent later. That looks equivalent to "don't re-send" and isn't: the claim autocommits as `'pending'` **before** the Podium round-trip, so for the whole network call the row reads `'pending'`, which satisfies `<> 'sent'`. A double-click, a second logistics user, or a retry after a timeout would reclaim it and **send the customer a second text**. Same for `'failed'` — Podium may have queued it anyway.

Now the predicate is exactly `= 'skipped'`: **only an explicitly declined text can be reopened.** `pending`/`failed`/`sent` are terminal, matching F8a's stated trade-off (a missed text beats a duplicate). **Verified on Postgres:** `pending` → refused, `sent` → refused, `skipped` → reopens.

*Accepted, documented consequence:* a crash between claim and send strands a `'pending'` row that can only be cleared by deleting it (the F10 runbook covers exactly this).

**2. The panel could brick the page.** The login token lasts 1h; the SPA session slides on activity — so a normal shift outlives the token. Both buttons call the gated endpoint, and the panel had no other exit, so a 401 left the operator in an **unclosable dialog on an unusable page** (worst for the workshop kiosk user, which never logs out). Now there's a **"Decide later"** escape that never touches the server, plus an explicit 401 path that says the session expired and routes to login.

Also fixed: the send was authenticated but **not attributed** (`actorId` was passed and never read — undercutting the whole reason for gating it); a 409 already-sent left the only exit as "Don't send", which would have toasted the lie *"No text sent"*; and the "no phone number" panel's Close was recording it as *"declined by <user>"*. One test **literally could not fail** — it asserted nothing was sent via a sender argument the decline path doesn't take. Tests 36 → 42, and the predicate is now pinned with a check that `<> 'sent'` is **not** used.

### Known gaps — disclosed, not silently shipped

- **"Decide later", a refresh, or a closed tab** leaves the delivery booked with no text and **no audit row**, and the panel only appears from a booking response — so the question can't be re-asked. The obvious follow-up is a re-entry point ("Send booking text" on the booked/schedule list), which would also give the resend-after-decline path a home.
- **`completed-deliveries.js`** can move a delivery back to *Booked for Delivery*; the server returns `booking_sms` but that page ignores it, so no panel and no text (it previously auto-sent). Low frequency; not wired here to keep this change to the booking path.

### Test steps (Preview)

1. **Delivery Operations → To Be Booked.** Pick a row with a carrier and date, on a customer **with a phone number**.
2. Set status → **Booked for Delivery**. The row saves and **the panel appears** — read the exact text, the customer and the number.
3. **Don't send** → toast "No text sent". On Neon dev:
   ```sql
   SELECT reference_id, status, error, payload FROM integration_sync_log
    WHERE event_type = 'delivery.booked' ORDER BY id DESC LIMIT 5;
   ```
   Expect `status='skipped'`, `error='declined by <your id>'`, and `declined_by` in the payload.
4. Repeat on another delivery and press **Send text** → toast "Text sent". (`PODIUM_MOCK=true`, so **nothing actually leaves** — the audit row is the proof.) Expect `status='sent'` and `confirmed_by` in the payload.
5. **Never-twice:** try to send the same one again → it refuses (already sent).
6. A customer **with no phone** → the panel says why, and Close records nothing.

Offline, no DB: `node scripts/podium-delivery-notify-smoke.mjs` → 42 checks.

### Reviewer checklist

- [ ] **Retarget the base to `main`** (see the top).
- [ ] The panel wording and the SMS copy are right — **this copy still needs your sign-off** before `PODIUM_MOCK=false`.
- [ ] Confirm-per-booking is the workflow you want (vs. a "send all" or a per-carrier default).
- [ ] "Decide later" leaving no record is acceptable, and the re-entry point is a follow-up rather than a blocker.
- [ ] Authentication-only (not `logistics`-role) on the send endpoint is right for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
