### PR TITLE
F8c — Review request on completed + paid (Podium review invite)

### DIFF
--- a/lib/handlers/workorder.js
+++ b/lib/handlers/workorder.js
@@ -1,4 +1,5 @@
 import { getClientWithTimezone } from '../db.js';
+import { notifyReviewRequest } from '../reviewNotify.js'; // F8c
 
 /** Helpers **/
 function parseWeeks(label) {
@@ -464,6 +465,11 @@ export default async function handler(req, res) {
       }
       const beforeWO = currentWO.rows[0];
 
+      // F8c: did THIS request complete the workorder / clear its balance? Both are edges of
+      // the "completed + paid" review-request condition, evaluated after COMMIT.
+      let completedEventLogged = false;
+      let balanceChanged = false;
+
       // Capture completion counts BEFORE updates
       const countsBefore = await client.query(
         `SELECT COUNT(*) FILTER (WHERE status = 'Completed') AS done,
@@ -555,6 +561,7 @@ export default async function handler(req, res) {
         }
         if (outstanding_balance !== undefined && Number(outstanding_balance) !== Number(beforeWO.outstanding_balance)) {
           await logEvent(client, { workorder_id: id, event_type: 'PAYMENT_UPDATED', user_id: actorId });
+          balanceChanged = true; // F8c: may have just cleared the balance on a completed WO
         }
         if (important_flag !== undefined && beforeWO.important_flag !== !!important_flag) {
           await logEvent(client, { workorder_id: id, event_type: 'WORKORDER_FLAG_CHANGED', user_id: actorId });
@@ -784,6 +791,7 @@ export default async function handler(req, res) {
           await client.query(`UPDATE workorder SET status = 'Completed' WHERE workorder_id = $1`, [id]);
           await logEvent(client, { workorder_id: id, event_type: 'WORKORDER_STATUS_CHANGED', user_id: actorId });
           await logEvent(client, { workorder_id: id, event_type: 'WORKORDER_COMPLETED', user_id: actorId });
+          completedEventLogged = true; // F8c: same predicate as the WORKORDER_COMPLETED log
         }
 
         // Create delivery ONLY if transitioned this request or explicit override
@@ -837,6 +845,18 @@ export default async function handler(req, res) {
       }
 
       await client.query('COMMIT');
+
+      // F8c: review request — AFTER commit, BEST-EFFORT. Never throws, so a Podium failure
+      // can't undo the workorder update we just made. The notifier re-checks completed+paid
+      // from the DB and is at-most-once per workorder, so these two edges are just a cheap
+      // filter: the order usually completes first and is paid in full before dispatch.
+      if (completedEventLogged || balanceChanged) {
+        try {
+          await notifyReviewRequest(client, id);
+        } catch (notifyErr) {
+          console.error('review notify (post-update) failed:', notifyErr);
+        }
+      }
 
       // Return updated resource
       req.query.id = id;

--- a/lib/handlers/workorder.js
+++ b/lib/handlers/workorder.js
@@ -466,8 +466,11 @@ export default async function handler(req, res) {
       const beforeWO = currentWO.rows[0];
 
       // F8c: did THIS request complete the workorder / clear its balance? Both are edges of
-      // the "completed + paid" review-request condition, evaluated after COMMIT.
-      let completedEventLogged = false;
+      // the "completed + paid" review-request condition, evaluated after COMMIT. Bind these
+      // to the STATE TRANSITION, not to a particular log call — a workorder can reach
+      // 'Completed' either by its last item completing (section 3) or by an explicit status
+      // change (section 4), and only the former logs WORKORDER_COMPLETED.
+      let becameCompleted = false;
       let balanceChanged = false;
 
       // Capture completion counts BEFORE updates
@@ -791,7 +794,7 @@ export default async function handler(req, res) {
           await client.query(`UPDATE workorder SET status = 'Completed' WHERE workorder_id = $1`, [id]);
           await logEvent(client, { workorder_id: id, event_type: 'WORKORDER_STATUS_CHANGED', user_id: actorId });
           await logEvent(client, { workorder_id: id, event_type: 'WORKORDER_COMPLETED', user_id: actorId });
-          completedEventLogged = true; // F8c: same predicate as the WORKORDER_COMPLETED log
+          becameCompleted = true; // F8c: completed via its last item
         }
 
         // Create delivery ONLY if transitioned this request or explicit override
@@ -837,6 +840,7 @@ export default async function handler(req, res) {
       // 4) Apply explicit WO status only if it represents a change from the DB value at request start
       if (explicitStatusProvided && status !== beforeWO.status) {
         await client.query(`UPDATE workorder SET status = $1 WHERE workorder_id = $2`, [status, id]);
+        if (status === 'Completed') becameCompleted = true; // F8c: completed explicitly
         await logEvent(client, {
           workorder_id: id,
           event_type: 'WORKORDER_STATUS_CHANGED',
@@ -850,7 +854,7 @@ export default async function handler(req, res) {
       // can't undo the workorder update we just made. The notifier re-checks completed+paid
       // from the DB and is at-most-once per workorder, so these two edges are just a cheap
       // filter: the order usually completes first and is paid in full before dispatch.
-      if (completedEventLogged || balanceChanged) {
+      if (becameCompleted || balanceChanged) {
         try {
           await notifyReviewRequest(client, id);
         } catch (notifyErr) {

--- a/lib/reviewNotify.js
+++ b/lib/reviewNotify.js
@@ -14,6 +14,11 @@
 //  - ELIGIBILITY IS RE-CHECKED FROM THE DB, and an INELIGIBLE workorder is never claimed —
 //    the claim would otherwise poison the later, genuine completed+paid moment.
 //  - P1: only ENVELOPE metadata (workorder/customer/contact ids) is logged.
+//  - AT-MOST-ONCE, so an invite that fails outright is NOT auto-retried: the claim row
+//    persists with status 'failed'. That is the safer default for customer contact, but a
+//    review invite matters more to the business than a convenience SMS — if the failure
+//    rate ever justifies it, a sweeper over status IN ('pending','failed') is the escape
+//    hatch (same trade-off as, and deliberately consistent with, F8a).
 //  - Mock-first: requestReview() short-circuits to the typed Podium mock when
 //    PODIUM_MOCK=true, so nothing actually sends until creds + PODIUM_MOCK=false.
 
@@ -45,7 +50,6 @@ export async function notifyReviewRequest(client, workorderId, opts = {}) {
   try {
     const r = await client.query(
       `SELECT wo.workorder_id, wo.status, wo.outstanding_balance, wo.customer_id,
-              c.name  AS customer_name,
               c.phone AS customer_phone,
               c.podium_contact_id
          FROM workorder wo
@@ -63,8 +67,11 @@ export async function notifyReviewRequest(client, workorderId, opts = {}) {
 
   // Eligibility. Deliberately NOT claimed when ineligible — an early claim would block the
   // genuine invite later (e.g. completed today, balance paid tomorrow).
+  // `<= 0` so an overpayment/credit still counts as nothing-owing; the explicit null guard
+  // is defence in depth (the column is NOT NULL today, but Number(null) is 0, which would
+  // read as "paid in full" and burn the one claim we get).
   const completed = String(row.status) === 'Completed';
-  const paid = Number(row.outstanding_balance) === 0;
+  const paid = row.outstanding_balance != null && Number(row.outstanding_balance) <= 0;
   if (!completed || !paid) return out;
 
   const refId = `review_request:${row.workorder_id}`;

--- a/lib/reviewNotify.js
+++ b/lib/reviewNotify.js
@@ -1,0 +1,128 @@
+// lib/reviewNotify.js — Review-request automation (feature F8c).
+//
+// When a workorder is BOTH completed and paid in full, ask the customer for a Google
+// review via Podium's review-invite API (execution-plan §F8c, §15.4
+// `POST /v4/reviews/invites`). Podium composes and sends the invite itself — we only
+// nominate the contact — so unlike F8a/F8b there is no SMS copy of ours to sign off.
+//
+// Design guarantees (mirrors the F8a waitlist pattern):
+//  - BEST-EFFORT / NON-BLOCKING: runs AFTER the workorder transaction has committed and
+//    NEVER throws — a Podium failure must never roll back or block a workorder update.
+//  - IDEMPOTENT / AT-MOST-ONCE: each workorder is claimed once via an integration_sync_log
+//    row with a unique reference_id (ON CONFLICT DO NOTHING on uq_sync_ref), so a customer
+//    is never invited twice for the same order however many times the workorder is edited.
+//  - ELIGIBILITY IS RE-CHECKED FROM THE DB, and an INELIGIBLE workorder is never claimed —
+//    the claim would otherwise poison the later, genuine completed+paid moment.
+//  - P1: only ENVELOPE metadata (workorder/customer/contact ids) is logged.
+//  - Mock-first: requestReview() short-circuits to the typed Podium mock when
+//    PODIUM_MOCK=true, so nothing actually sends until creds + PODIUM_MOCK=false.
+
+import { requestReview } from './podium.js';
+
+/**
+ * Ask for a review if (and only if) the workorder is completed AND fully paid.
+ *
+ * Called from both edges of that condition — the workorder completing, and the balance
+ * reaching zero — because the canonical Grays flow pays the balance in full AFTER the
+ * workshop finishes and BEFORE dispatch, so "paid" is usually the LAST of the two to
+ * land. Whichever edge fires, the shared claim key keeps it at-most-once.
+ *
+ * @param {object} client       an OPEN pg client (used post-commit; statements autocommit)
+ * @param {number|string} workorderId
+ * @param {object} [opts]       { send } — send lets the smoke inject a fake sender
+ * @returns {Promise<{notified:number, skipped:number, failed:number}>}
+ */
+export async function notifyReviewRequest(client, workorderId, opts = {}) {
+  const { send } = opts;
+  const sendInvite = send || ((payload) => requestReview(null, payload));
+  const out = { notified: 0, skipped: 0, failed: 0 };
+
+  if (!workorderId) return out;
+
+  // Re-read the authoritative state post-commit: the request that triggered us may have
+  // changed the status, the balance, or neither.
+  let row = null;
+  try {
+    const r = await client.query(
+      `SELECT wo.workorder_id, wo.status, wo.outstanding_balance, wo.customer_id,
+              c.name  AS customer_name,
+              c.phone AS customer_phone,
+              c.podium_contact_id
+         FROM workorder wo
+         JOIN customers c ON c.id = wo.customer_id
+        WHERE wo.workorder_id = $1`,
+      [workorderId]
+    );
+    row = r.rowCount ? r.rows[0] : null;
+  } catch (err) {
+    // workorder/customers absent (bare DB) or any query error — degrade silently.
+    if (err?.code !== '42P01') console.error('review notify: lookup failed', err);
+    return out;
+  }
+  if (!row) return out;
+
+  // Eligibility. Deliberately NOT claimed when ineligible — an early claim would block the
+  // genuine invite later (e.g. completed today, balance paid tomorrow).
+  const completed = String(row.status) === 'Completed';
+  const paid = Number(row.outstanding_balance) === 0;
+  if (!completed || !paid) return out;
+
+  const refId = `review_request:${row.workorder_id}`;
+  let logId = null;
+  let sent = false;
+  try {
+    // Claim the audit row first — the unique (source, reference_id) index makes this the
+    // idempotency gate: rowCount 0 ⇒ already invited ⇒ skip.
+    const claim = await client.query(
+      `INSERT INTO integration_sync_log (source, direction, event_type, reference_id, status, payload)
+       VALUES ('podium', 'outbound', 'workorder.review_request', $1, 'pending', $2)
+       ON CONFLICT (source, reference_id) WHERE reference_id IS NOT NULL DO NOTHING
+       RETURNING id`,
+      [refId, JSON.stringify({
+        workorder_id: row.workorder_id,
+        customer_id: row.customer_id,
+        contact_uid: row.podium_contact_id || null,
+      })]
+    );
+    if (!claim.rowCount) { out.skipped += 1; return out; }
+    logId = claim.rows[0].id;
+
+    // Podium needs someone to invite: the linked contact (F4 bridge) is the durable
+    // reference; a raw phone number is the fallback for an unbridged customer.
+    const contactUid = (row.podium_contact_id || '').toString().trim();
+    const phone = (row.customer_phone || '').toString().trim();
+    if (!contactUid && !phone) {
+      await client.query(
+        `UPDATE integration_sync_log SET status = 'skipped', error = 'no podium contact or phone on customer' WHERE id = $1`,
+        [logId]
+      );
+      out.skipped += 1;
+      return out;
+    }
+
+    await sendInvite(contactUid ? { contactUid } : { channel: phone });
+    sent = true; // past this point the invite is away — never relabel it 'failed'.
+
+    await client.query(`UPDATE integration_sync_log SET status = 'sent' WHERE id = $1`, [logId]);
+    out.notified += 1;
+  } catch (err) {
+    if (sent) {
+      // The invite DID go out; only the post-send bookkeeping failed. Count it notified and
+      // keep the audit honest — the claim row still blocks any re-send (at-most-once).
+      out.notified += 1;
+      console.error(`review notify: post-send bookkeeping failed for workorder ${row.workorder_id}`, err);
+    } else {
+      out.failed += 1;
+      console.error(`review notify: invite failed for workorder ${row.workorder_id}`, err);
+      if (logId) {
+        try {
+          await client.query(
+            `UPDATE integration_sync_log SET status = 'failed', error = $1 WHERE id = $2`,
+            [String(err?.message || err).slice(0, 500), logId]
+          );
+        } catch { /* best-effort audit; ignore */ }
+      }
+    }
+  }
+  return out;
+}

--- a/scripts/podium-review-smoke.mjs
+++ b/scripts/podium-review-smoke.mjs
@@ -1,0 +1,174 @@
+// scripts/podium-review-smoke.mjs — offline smoke for F8c review-request automation.
+//
+// Exercises lib/reviewNotify.js with an INJECTED fake pg client and (mostly) an injected
+// fake sender, so there is NO network, NO database, NO secrets:
+//
+//   node scripts/podium-review-smoke.mjs
+//
+// Covers: the no-op guards; the completed+paid eligibility gate (and that an INELIGIBLE
+// workorder is never claimed, so a later genuine completion can still fire); the invite +
+// integration_sync_log audit (ON CONFLICT idempotency claim, review_request:<id>
+// reference_id, envelope-only payload); the already-claimed → skip path; contact
+// resolution (podium_contact_id preferred, phone fallback, neither → skip); the 42P01
+// (bare-DB) degrade; the BEST-EFFORT guarantee (a throwing sender is caught, counted
+// failed, never propagates); the post-send bookkeeping failure; and one end-to-end pass
+// through the REAL requestReview in PODIUM_MOCK mode.
+
+process.env.PODIUM_MOCK = 'true'; // real requestReview short-circuits to the typed mock
+
+const { notifyReviewRequest } = await import('../lib/reviewNotify.js');
+
+let passed = 0;
+function check(name, cond, detail) {
+  if (!cond) throw new Error(`FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  passed += 1;
+  console.log(`  ✓ ${name}`);
+}
+
+// ---- Fake pg client (records queries, returns scripted results) ---------------
+function makeClient(scripts = []) {
+  const calls = [];
+  return {
+    calls,
+    async query(sql, params) {
+      calls.push({ sql, params });
+      for (const s of scripts) {
+        if (typeof s.match === 'function' ? s.match(sql) : s.match.test(sql)) {
+          if (s.throws) throw s.throws;
+          return s.result ?? { rowCount: 0, rows: [] };
+        }
+      }
+      return { rowCount: 0, rows: [] };
+    },
+  };
+}
+
+const SELECT_RE = /FROM workorder wo/i;
+const CLAIM_RE = /INSERT INTO integration_sync_log/i;
+const LOG_UPD_RE = /UPDATE integration_sync_log/i;
+
+const eligibleRow = (over = {}) => ({
+  workorder_id: 42,
+  status: 'Completed',
+  outstanding_balance: 0,
+  customer_id: 26,
+  customer_name: 'Demo Customer',
+  customer_phone: '0400000000',
+  podium_contact_id: 'pod_con_abc',
+  ...over,
+});
+
+// A fresh-claim client: lookup returns the row; the audit INSERT returns an id (no conflict).
+function okClient(rows) {
+  return makeClient([
+    { match: SELECT_RE, result: { rowCount: rows.length, rows } },
+    { match: CLAIM_RE, result: { rowCount: 1, rows: [{ id: 91 }] } },
+    { match: LOG_UPD_RE, result: { rowCount: 1, rows: [] } },
+  ]);
+}
+
+console.log('Review request on completed + paid (F8c) smoke — fake client, no DB\n');
+
+console.log('no-op guards:');
+{
+  const client = makeClient();
+  const out = await notifyReviewRequest(client, null);
+  check('no workorder id → no-op, no DB calls', out.notified === 0 && out.skipped === 0 && out.failed === 0 && client.calls.length === 0);
+
+  const missing = makeClient([{ match: SELECT_RE, result: { rowCount: 0, rows: [] } }]);
+  const out2 = await notifyReviewRequest(missing, 999);
+  check('workorder not found → no-op, no claim', out2.notified === 0 && !missing.calls.some((c) => CLAIM_RE.test(c.sql)));
+}
+
+console.log('\nhappy path (invite + audit):');
+{
+  const sent = [];
+  const client = okClient([eligibleRow()]);
+  const out = await notifyReviewRequest(client, 42, { send: async (m) => { sent.push(m); return { status: 'sent' }; } });
+  check('one review invite sent', out.notified === 1 && out.skipped === 0 && out.failed === 0, JSON.stringify(out));
+  check('invite targets the podium contact uid', sent.length === 1 && sent[0].contactUid === 'pod_con_abc');
+  const claim = client.calls.find((c) => CLAIM_RE.test(c.sql));
+  check('audit claim uses ON CONFLICT DO NOTHING', !!claim && /ON CONFLICT/i.test(claim.sql) && /DO NOTHING/i.test(claim.sql));
+  check('audit reference_id is per-workorder', !!claim && (claim.params || []).includes('review_request:42'));
+  check('audit payload carries envelope only (no customer name)', !!claim && /"workorder_id"/.test(claim.params?.[1] || '') && !/Demo Customer/.test(claim.params?.[1] || ''));
+  check('log marked sent', client.calls.some((c) => LOG_UPD_RE.test(c.sql) && /'sent'/i.test(c.sql)));
+}
+
+console.log('\neligibility gate (completed AND paid):');
+{
+  const sent = [];
+  const notDone = okClient([eligibleRow({ status: 'Work Ordered' })]);
+  const out = await notifyReviewRequest(notDone, 42, { send: async (m) => { sent.push(m); return {}; } });
+  check('not completed → no send', out.notified === 0 && sent.length === 0);
+  check('not completed → NOT claimed (a later completion must still fire)', !notDone.calls.some((c) => CLAIM_RE.test(c.sql)));
+
+  const owing = okClient([eligibleRow({ outstanding_balance: 500 })]);
+  const out2 = await notifyReviewRequest(owing, 42, { send: async (m) => { sent.push(m); return {}; } });
+  check('balance outstanding → no send', out2.notified === 0 && sent.length === 0);
+  check('balance outstanding → NOT claimed (a later payment must still fire)', !owing.calls.some((c) => CLAIM_RE.test(c.sql)));
+
+  const paidLater = okClient([eligibleRow({ outstanding_balance: '0.00' })]);
+  const out3 = await notifyReviewRequest(paidLater, 42, { send: async (m) => { sent.push(m); return {}; } });
+  check('numeric-string balance 0.00 counts as paid', out3.notified === 1 && sent.length === 1);
+}
+
+console.log('\nidempotency (already claimed):');
+{
+  const sent = [];
+  const client = makeClient([
+    { match: SELECT_RE, result: { rowCount: 1, rows: [eligibleRow()] } },
+    { match: CLAIM_RE, result: { rowCount: 0, rows: [] } }, // conflict → already handled
+  ]);
+  const out = await notifyReviewRequest(client, 42, { send: async (m) => { sent.push(m); return {}; } });
+  check('conflicting claim → skipped, no second invite', out.skipped === 1 && out.notified === 0 && sent.length === 0);
+}
+
+console.log('\ncontact resolution:');
+{
+  const sent = [];
+  const phoneOnly = okClient([eligibleRow({ podium_contact_id: null })]);
+  const out = await notifyReviewRequest(phoneOnly, 42, { send: async (m) => { sent.push(m); return {}; } });
+  check('no contact uid but phone present → invite by phone channel', out.notified === 1 && sent[0].channel === '0400000000' && !sent[0].contactUid);
+
+  const sent2 = [];
+  const neither = okClient([eligibleRow({ podium_contact_id: null, customer_phone: null })]);
+  const out2 = await notifyReviewRequest(neither, 42, { send: async (m) => { sent2.push(m); return {}; } });
+  check('no contact uid and no phone → skipped, no send', out2.skipped === 1 && out2.notified === 0 && sent2.length === 0);
+  check('log marked skipped with a reason', neither.calls.some((c) => LOG_UPD_RE.test(c.sql) && /'skipped'/i.test(c.sql)));
+}
+
+console.log('\nbare-DB degrade (42P01):');
+{
+  const err = new Error('relation "workorder" does not exist'); err.code = '42P01';
+  const client = makeClient([{ match: SELECT_RE, throws: err }]);
+  const out = await notifyReviewRequest(client, 42);
+  check('missing table → {0,0,0}, no throw', out.notified === 0 && out.skipped === 0 && out.failed === 0);
+}
+
+console.log('\nbest-effort (sender throws):');
+{
+  const client = okClient([eligibleRow()]);
+  const out = await notifyReviewRequest(client, 42, { send: async () => { throw new Error('Podium 503'); } });
+  check('send failure → counted failed, never throws', out.failed === 1 && out.notified === 0);
+  check('failure recorded on the audit row', client.calls.some((c) => LOG_UPD_RE.test(c.sql) && /'failed'/i.test(c.sql)));
+}
+
+console.log('\npost-send bookkeeping failure (invite already away):');
+{
+  const client = makeClient([
+    { match: SELECT_RE, result: { rowCount: 1, rows: [eligibleRow()] } },
+    { match: CLAIM_RE, result: { rowCount: 1, rows: [{ id: 5 }] } },
+    { match: /status = 'sent'/i, throws: new Error('db blip after send') },
+  ]);
+  const out = await notifyReviewRequest(client, 42, { send: async () => ({ status: 'sent' }) });
+  check('counts as notified, not failed', out.notified === 1 && out.failed === 0, JSON.stringify(out));
+}
+
+console.log('\nend-to-end through the REAL requestReview (mock mode):');
+{
+  const client = okClient([eligibleRow()]);
+  const out = await notifyReviewRequest(client, 42); // no injected send → real mock
+  check('real mock invite path notifies without error', out.notified === 1 && out.failed === 0, JSON.stringify(out));
+}
+
+console.log(`\n✅ review smoke: ${passed} checks passed`);

--- a/scripts/podium-review-smoke.mjs
+++ b/scripts/podium-review-smoke.mjs
@@ -110,6 +110,19 @@ console.log('\neligibility gate (completed AND paid):');
   const paidLater = okClient([eligibleRow({ outstanding_balance: '0.00' })]);
   const out3 = await notifyReviewRequest(paidLater, 42, { send: async (m) => { sent.push(m); return {}; } });
   check('numeric-string balance 0.00 counts as paid', out3.notified === 1 && sent.length === 1);
+
+  // A credit/overpayment is still "nothing owing" — the customer has paid.
+  const credit = okClient([eligibleRow({ outstanding_balance: '-50.00' })]);
+  const out4 = await notifyReviewRequest(credit, 42, { send: async (m) => { sent.push(m); return {}; } });
+  check('credit balance (overpaid) counts as paid', out4.notified === 1, JSON.stringify(out4));
+
+  // Defence in depth: workorder.outstanding_balance is NOT NULL today, but Number(null)
+  // is 0 — a nullable balance must never read as "paid in full" and burn the claim.
+  const sent5 = [];
+  const nullBal = okClient([eligibleRow({ outstanding_balance: null })]);
+  const out5 = await notifyReviewRequest(nullBal, 42, { send: async (m) => { sent5.push(m); return {}; } });
+  check('null balance is NOT treated as paid', out5.notified === 0 && sent5.length === 0);
+  check('null balance → NOT claimed', !nullBal.calls.some((c) => CLAIM_RE.test(c.sql)));
 }
 
 console.log('\nidempotency (already claimed):');
@@ -129,6 +142,8 @@ console.log('\ncontact resolution:');
   const phoneOnly = okClient([eligibleRow({ podium_contact_id: null })]);
   const out = await notifyReviewRequest(phoneOnly, 42, { send: async (m) => { sent.push(m); return {}; } });
   check('no contact uid but phone present → invite by phone channel', out.notified === 1 && sent[0].channel === '0400000000' && !sent[0].contactUid);
+  const phoneClaim = phoneOnly.calls.find((c) => CLAIM_RE.test(c.sql));
+  check('P1: phone number is not written to the audit payload', !!phoneClaim && !/0400000000/.test(phoneClaim.params?.[1] || ''));
 
   const sent2 = [];
   const neither = okClient([eligibleRow({ podium_contact_id: null, customer_phone: null })]);


### PR DESCRIPTION
## F8c — Review request on completed + paid

When a workorder is **both completed and paid in full**, ask the customer for a Google review via Podium's review-invite API (`POST /v4/reviews/invites`, execution-plan §F8c / §15.4). Podium composes and sends the invite itself — we only nominate the contact — so **unlike F8a/F8b there is no SMS copy of ours to sign off**.

Branched fresh off `main` (`a671982`) — **not stacked**. F8a merged (#71), so `sendSystemSms`/the notify pattern it established are already on `main`.

### Scope

| | |
|---|---|
| **New** | `lib/reviewNotify.js` — `notifyReviewRequest(client, workorderId, opts)` |
| **Changed** | `lib/handlers/workorder.js` — post-commit best-effort hook on the PUT (+7 lines, 2 flags) |
| **Tests** | `scripts/podium-review-smoke.mjs` — 26 checks, fake pg client, no DB/network |
| **Migration** | **None** — `integration_sync_log` + `uq_sync_ref` ship in F0 `0001` (index re-verified on Neon dev) |
| **Functions** | **No new serverless fn** — `nodejs:5`, same as `main`'s current deployment (the count moved 3 → 5 when the #65 OAuth hotfix added two static entries; the commit body's "stays nodejs:3" is stale wording, the deploy stat is the truth) |
| **Frontend** | **None** — bundle hash unchanged (`main.fbdf5cb6.js`) |
| **Preview** | ✅ READY — `dpl_BkCcvgYwvznE8v29J9jUKVs4PtGZ` · https://grays-internal-1p14w3xjg-grays-supports-projects.vercel.app (branch alias is SSO-gated) |

### The one design decision worth your attention

The plan says *"on `WORKORDER_COMPLETED` and `outstanding_balance = 0`"*. Taken literally that would **almost never fire**: the Grays flow pays the balance in full **after** the workshop finishes and **before** dispatch, so the workorder is normally completed *while still owing*, and paid later.

So this fires on **both edges** of completed+paid — the workorder completing, **and** the balance reaching zero on an already-completed workorder. Whichever lands last wins, and the shared claim key keeps it at-most-once. This matches the backlog title ("review request on completed **+ paid**") rather than the literal event wording. **Flag if you disagree** — it's a one-line change to restrict it.

Deliberately **not** fired on every workorder edit: only a genuine *transition* triggers, so editing an old completed+paid order (dev has hundreds) never spams its customer a review invite.

### Safety properties

- **Best-effort** — runs *after* COMMIT, never throws, so a Podium failure can't roll back or block a workorder update.
- **At-most-once** — claims an `integration_sync_log` row on `uq_sync_ref` (`reference_id = review_request:<workorder_id>`) *before* sending; a customer is never invited twice for the same order. An outright send failure is **not** auto-retried (claim persists as `failed`) — same trade-off as F8a; a `status IN ('pending','failed')` sweeper is the escape hatch if that ever matters.
- **Ineligible ⇒ never claimed** — an early claim would poison the later genuine completed+paid moment.
- **P1 held** — audit payload is `{workorder_id, customer_id, contact_uid}`; no name, no phone. (Nothing to leak by construction: Podium writes the invite.)
- **Mock-first** — nothing sends until `PODIUM_MOCK=false` + live creds.

### Code review (dispatched over the full branch diff, before this PR)

Found one **real functional bug**, now fixed in `2457403`:

- **Important — explicit-completion path missed the trigger.** A workorder completed by an explicit `status: 'Completed'` (rather than by its last item completing) never fired: section 4 of the PUT sets the status independently and doesn't log `WORKORDER_COMPLETED`, so binding the flag to that log call inherited the gap. If the balance was already `0`, no later edge could fire either — the invite was lost *permanently*. Flag now tracks the **state transition** and is set on both paths (`becameCompleted`).
- **Minor — `paid` predicate hardened** to `!= null && <= 0`: an overpayment/credit counts as nothing-owing, and an explicit null guard stops `Number(null) === 0` reading as "paid in full" and burning the one claim.
- **Minor — dropped an unused `customer_name`** from the lookup (needless PII for a P1 module).
- **Rejected —** reviewer's alternative "drop the flags, call the notifier unconditionally after COMMIT". Correct that it removes the predicate risk, but it would fire an invite on **any** edit to **any** historical completed+paid workorder (a rep fixing a note on a 2024 order → review invite). The flags bind to the business event; the bug was in *which* paths set them, not in having them.
- **Noted for backlog, out of scope —** section 4's explicit-completion path logs no `WORKORDER_COMPLETED` **and creates no delivery**, unlike the item-driven path. Pre-existing inconsistency in the handler; either the path is vestigial or the event log has been under-reporting completions. Worth a separate look.

**Known gap:** the trigger predicate in `workorder.js` has no automated coverage — the monolithic handler builds its own pg client and isn't injectable (same limitation as F8a's `collections.js` hook). That is exactly where the bug above lived. Covered by the manual test below; a `deps.getClient` refactor (as `lib/handlers/leads.js` has) would close it properly.

### Test steps (Preview)

The Preview enforces Vercel SSO, and `PODIUM_MOCK=true` means no invite actually leaves — so this is verified by **audit row**, not by a text arriving.

1. Open a workorder that is **not** yet completed, on a customer **with a phone number**.
2. Set its outstanding balance to `0`, then complete it (move every item to `Completed`, or set the workorder status to `Completed` directly — **both paths should now work**).
3. Confirm the workorder saved normally and the page returned as usual (the automation must be invisible to the operator).
4. On the **Neon dev branch**, check the audit row:
   ```sql
   SELECT source, event_type, reference_id, status, payload, error
     FROM integration_sync_log
    WHERE event_type = 'workorder.review_request'
    ORDER BY id DESC LIMIT 5;
   ```
   Expect one row, `status = 'sent'`, `reference_id = review_request:<workorder_id>`, payload = ids only (no name/phone).
5. **Idempotency:** edit the same workorder again (e.g. change its notes, or re-save). Expect **no second row** and no change to the first.
6. **Ineligible:** repeat step 2 on a workorder with an outstanding balance > 0 → expect **no row at all** (not even `skipped`), so it can still fire once paid.

Offline, no DB needed: `node scripts/podium-review-smoke.mjs` → 26 checks.

### Reviewer checklist

- [ ] The **both-edges** trigger (completed *and* paid, whichever lands last) matches how you actually run the workshop → dispatch flow.
- [ ] Firing only on a *transition* (never on edits to historical paid+completed orders) is the behaviour you want.
- [ ] At-most-once is the right default for a review invite (a failed invite is **not** retried).
- [ ] Inviting an **unbridged** customer by raw phone is acceptable. **Note:** every completed+paid workorder on Neon dev currently has `podium_contact_id = NULL`, so the phone fallback — not the F4 contact bridge — is the path that will actually run today.
- [ ] Content: Podium writes the invite wording, so **the review-invite text is configured in Podium, not here**. Worth confirming what it says before `PODIUM_MOCK=false`.
- [ ] The out-of-scope handler inconsistency (section 4: no `WORKORDER_COMPLETED` log, no delivery) is worth its own ticket.

### VERIFY at live wiring

- `POST /v4/reviews/invites` is pinned in §15.4, but the **exact body shape** (`contactUid` vs `channel`) and whether a system/location-scoped token is required (rather than a rep's user token — we pass `userId = null`, P9) is **unproven** — the same open question F8a flagged for the shared-number send. Isolated to `requestReview` in `lib/podium.js`, one place.
- Needs the `write_reviews` scope (already in `DEFAULT_SCOPES`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
