### PR TITLE
F9 — RBAC: gate user administration (register/users were unauthenticated) + wire granted_by

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -2,7 +2,7 @@
 import { compare, hash } from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import { getClientWithTimezone } from '../lib/db.js';
-import { getRolesForUser, syncUserRoles, sanitizeRoles, primaryRole } from '../lib/rbac.js';
+import { getRolesForUser, syncUserRoles, sanitizeRoles, primaryRole, requireRoles } from '../lib/rbac.js';
 // Formerly standalone /api functions (workorder/delivery/collections/winnings),
 // relocated under lib/handlers/ and routed here so they don't each consume one of the
 // Vercel Hobby plan's 12 Serverless-Function slots. Their handler logic is unchanged;
@@ -416,6 +416,13 @@ async function handleAuth(req, res, action) {
 
     if (action === 'register') {
       if (req.method !== 'POST') return methodNotAllowed(res, ['POST']);
+
+      // F9: creating a user (and choosing its roles) is a superadmin action. Server-
+      // authoritative — without this an unauthenticated caller could POST themselves a
+      // superadmin account, which would make every other role gate decorative.
+      const gate = requireRoles(req, ['superadmin']);
+      if (!gate.ok) return res.status(gate.status).json({ error: gate.error });
+
       const { id, name, email, password } = req.body;
 
       const existing = await client.query('SELECT 1 FROM users WHERE email = $1', [email]);
@@ -433,7 +440,7 @@ async function handleAuth(req, res, action) {
         'INSERT INTO users (id, name, email, password, access) VALUES ($1,$2,$3,$4,$5)',
         [id, name, email, hashed, primary]
       );
-      await syncUserRoles(client, id, roles, null); // granted_by unknown (no acting-admin identity here)
+      await syncUserRoles(client, id, roles, gate.auth.id); // F9: granted_by = the acting admin
       return res.status(200).json({ message: 'User registered successfully', roles });
     }
 
@@ -463,6 +470,24 @@ async function handleAuth(req, res, action) {
   } finally {
     client.release();
   }
+}
+
+/**
+ * F9 lockout guard: would removing superadmin from (or deleting) user `id` leave the
+ * portal with NO superadmin at all? That state is unrecoverable through the UI — user
+ * administration is superadmin-gated, so nobody could ever grant it back without direct
+ * SQL. Uses users.access (always populated; primaryRole puts superadmin first, so any
+ * superadmin-holder mirrors to access='superadmin') rather than user_roles, so it also
+ * works on a DB that hasn't run the F0 migration.
+ */
+async function wouldOrphanSuperadmin(client, id) {
+  const target = await client.query('SELECT access FROM users WHERE id = $1', [id]);
+  if (!target.rowCount || target.rows[0].access !== 'superadmin') return false;
+  const others = await client.query(
+    `SELECT count(*)::int AS n FROM users WHERE access = 'superadmin' AND id <> $1`,
+    [id]
+  );
+  return others.rows[0].n === 0;
 }
 
 /* ---------- USERS ---------- */
@@ -501,6 +526,10 @@ async function handleUsers(req, res) {
     }
 
     if (method === 'PUT') {
+      // F9: editing a user's roles is a superadmin action (see the register gate).
+      const gate = requireRoles(req, ['superadmin']);
+      if (!gate.ok) return res.status(gate.status).json({ error: gate.error });
+
       const { id, name, email, password, access } = body;
       if (!id) return res.status(400).json({ error: 'User ID is required' });
       // F0b: role set from the multi-select; users.access mirrors the primary role.
@@ -508,19 +537,41 @@ async function handleUsers(req, res) {
       if (!roles.length && access) roles = sanitizeRoles([access]);
       if (!roles.length) roles = ['staff'];
       const primary = primaryRole(roles);
+
+      // F9: never demote the last superadmin — including yourself. The UI renders role
+      // checkboxes for every row, so this is one click away, and the current JWT keeps
+      // working for up to an hour afterwards, hiding the damage until the next login.
+      if (primary !== 'superadmin' && (await wouldOrphanSuperadmin(client, id))) {
+        return res.status(409).json({
+          error: 'Cannot remove the last superadmin — grant superadmin to another user first',
+        });
+      }
+
       await client.query(
         `UPDATE users
            SET name=$1, email=$2, password=$3, access=$4
          WHERE id=$5`,
         [name, email, password, primary, id]
       );
-      await syncUserRoles(client, id, roles, null);
+      await syncUserRoles(client, id, roles, gate.auth.id); // F9: granted_by = the acting admin
       return res.status(200).json({ message: 'User updated successfully', roles });
     }
 
     if (method === 'DELETE') {
+      // F9: deleting a user is a superadmin action.
+      const gate = requireRoles(req, ['superadmin']);
+      if (!gate.ok) return res.status(gate.status).json({ error: gate.error });
+
       const { id } = body;
       if (!id) return res.status(400).json({ error: 'User ID is required' });
+
+      // F9: same lockout guard as the demotion path (see wouldOrphanSuperadmin).
+      if (await wouldOrphanSuperadmin(client, id)) {
+        return res.status(409).json({
+          error: 'Cannot delete the last superadmin — grant superadmin to another user first',
+        });
+      }
+
       await client.query('DELETE FROM users WHERE id = $1', [id]);
       return res.status(200).json({ message: 'User deleted successfully' });
     }

--- a/db/PRODUCTION_MIGRATION_RUNBOOK.md
+++ b/db/PRODUCTION_MIGRATION_RUNBOOK.md
@@ -89,3 +89,28 @@ Use only if Ops must reach Production before Podium. Slightly messier ledger (00
 | 0003_customer_type (+seed) | Ops G1 | ✅ applied + recorded | ✅ 10 Jul 2026 (seed: 568 rows) |
 | 0004_delivery_type | Ops G2 | ✅ applied + recorded | ✅ 10 Jul 2026 |
 | 0005_product_lots | Ops G3 | ✅ applied + recorded | ✅ 10 Jul 2026 |
+| 0006_user_roles_granted_by_fk | Podium F9 | ✅ applied 17 Jul 2026 (up + down both verified) | ⛔ **required before merging the F9 PR** |
+
+> **0006 is not optional if F9 ships.** F9 starts writing `user_roles.granted_by` (it was
+> always NULL before). The original FK has no `ON DELETE` clause, so once an admin has
+> granted a role, deleting that admin raises `23503` and `DELETE /api/users` fails with a
+> 500. `0006` switches the FK to `ON DELETE SET NULL` (keeps the grant, clears the
+> attribution). Per rule 5, run it on Production **before** merging the F9 PR.
+
+## ⚠️ Bootstrap: a database with no users cannot create one (F9, 17 Jul 2026)
+
+F9 gates `POST /api/register` to superadmin, and there is **no seeded superadmin** in any
+migration. On an EMPTY `users` table that is a deadlock: no user → no login → no token →
+no superadmin → registration is 401 forever.
+
+Production and every Neon branch cloned from it already have users, so this affects only a
+genuinely fresh database. It is deliberately **not** solved with an "open registration
+when there are no users" code path — that is a hole waiting to be re-opened. Instead,
+seed the first superadmin directly:
+
+```sql
+-- bcrypt the password out-of-band, then:
+INSERT INTO users (id, name, email, password, access)
+VALUES ('GS', 'Grays Support', 'support@graysfitness.com.au', '<bcrypt-hash>', 'superadmin');
+INSERT INTO user_roles (user_id, role, granted_by) VALUES ('GS', 'superadmin', NULL);
+```

--- a/db/PRODUCTION_MIGRATION_RUNBOOK.md
+++ b/db/PRODUCTION_MIGRATION_RUNBOOK.md
@@ -89,13 +89,18 @@ Use only if Ops must reach Production before Podium. Slightly messier ledger (00
 | 0003_customer_type (+seed) | Ops G1 | ✅ applied + recorded | ✅ 10 Jul 2026 (seed: 568 rows) |
 | 0004_delivery_type | Ops G2 | ✅ applied + recorded | ✅ 10 Jul 2026 |
 | 0005_product_lots | Ops G3 | ✅ applied + recorded | ✅ 10 Jul 2026 |
-| 0006_user_roles_granted_by_fk | Podium F9 | ✅ applied 17 Jul 2026 (up + down both verified) | ⛔ **required before merging the F9 PR** |
+| 0006_user_roles_granted_by_fk | Podium F9 | ✅ applied 17 Jul 2026 (up + down both verified) | ✅ **17 Jul 2026** (backup branch `backup-pre-0006-granted-by-fk-2026-07-17`) |
 
 > **0006 is not optional if F9 ships.** F9 starts writing `user_roles.granted_by` (it was
 > always NULL before). The original FK has no `ON DELETE` clause, so once an admin has
 > granted a role, deleting that admin raises `23503` and `DELETE /api/users` fails with a
 > 500. `0006` switches the FK to `ON DELETE SET NULL` (keeps the grant, clears the
-> attribution). Per rule 5, run it on Production **before** merging the F9 PR.
+> attribution). Per rule 5 it was run on Production **before** the F9 PR merged.
+>
+> **Applied to Production 17 Jul 2026** via `npm run migrate` (Nick-directed), after
+> branching Production to `backup-pre-0006-granted-by-fk-2026-07-17`. Verified after:
+> `user_roles_granted_by_fkey` is `ON DELETE SET NULL`; `user_roles_user_id_fkey` still
+> `ON DELETE CASCADE`; 18 users / 18 role rows unchanged (the migration moves no data).
 
 ## ⚠️ Bootstrap: a database with no users cannot create one (F9, 17 Jul 2026)
 

--- a/db/migrations/0006_user_roles_granted_by_fk.sql
+++ b/db/migrations/0006_user_roles_granted_by_fk.sql
@@ -1,0 +1,20 @@
+-- 0006_user_roles_granted_by_fk.sql — F9
+--
+-- user_roles.granted_by references users(id) with no ON DELETE clause (i.e. NO ACTION).
+-- That was harmless while granted_by was always NULL, but F9 starts populating it with
+-- the acting admin's id — at which point deleting a user who has ever granted a role to
+-- someone else raises a 23503 foreign-key violation and DELETE /api/users fails.
+--
+-- The audit intent is "keep the grant, forget the grantor": ON DELETE SET NULL preserves
+-- the user_roles row (the grantee keeps their role) and simply clears the attribution.
+-- Enforced in the DB so every delete path is covered, not just the one handler.
+--
+-- Additive + idempotent + reversible: only the FK's delete action changes; no data moves.
+-- (user_roles.user_id keeps its existing ON DELETE CASCADE — deleting a user still
+-- removes that user's own roles.)
+
+ALTER TABLE user_roles DROP CONSTRAINT IF EXISTS user_roles_granted_by_fkey;
+
+ALTER TABLE user_roles
+  ADD CONSTRAINT user_roles_granted_by_fkey
+  FOREIGN KEY (granted_by) REFERENCES users(id) ON DELETE SET NULL;

--- a/db/migrations/0006_user_roles_granted_by_fk_down.sql
+++ b/db/migrations/0006_user_roles_granted_by_fk_down.sql
@@ -1,0 +1,11 @@
+-- 0006_user_roles_granted_by_fk_down.sql — reverse 0006.
+--
+-- Restores the original FK (no ON DELETE clause = NO ACTION). Note that reverting
+-- re-introduces the failure this migration fixes: deleting a user who has granted a role
+-- will raise 23503 again. Only roll back alongside the F9 code that populates granted_by.
+
+ALTER TABLE user_roles DROP CONSTRAINT IF EXISTS user_roles_granted_by_fkey;
+
+ALTER TABLE user_roles
+  ADD CONSTRAINT user_roles_granted_by_fkey
+  FOREIGN KEY (granted_by) REFERENCES users(id);

--- a/lib/rbac.js
+++ b/lib/rbac.js
@@ -106,3 +106,26 @@ export function getAuthUser(req) {
     return null;
   }
 }
+
+/**
+ * The standard server-side gate (F9). One place to ask "is this caller allowed?", so the
+ * 401-vs-403 distinction and the fail-closed behaviour can't drift between handlers.
+ *
+ * Fails CLOSED: a missing, malformed, forged or expired token — or an unconfigured
+ * JWT_SECRET — is 401, never a pass. A genuine user without one of `wanted` is 403.
+ *
+ *   const gate = requireRoles(req, ['superadmin']);
+ *   if (!gate.ok) return res.status(gate.status).json({ error: gate.error });
+ *   // gate.auth.id — the acting user, e.g. for granted_by / audit trails
+ *
+ * @returns {{ok:true, auth:{id:string,email:string,roles:string[]}}
+ *          | {ok:false, status:401|403, error:string}}
+ */
+export function requireRoles(req, wanted) {
+  const auth = getAuthUser(req);
+  if (!auth) return { ok: false, status: 401, error: 'Authentication required' };
+  if (!hasAnyRole(auth.roles, wanted)) {
+    return { ok: false, status: 403, error: `Requires one of: ${(wanted || []).join(', ')}` };
+  }
+  return { ok: true, auth };
+}

--- a/scripts/podium-rbac-smoke.mjs
+++ b/scripts/podium-rbac-smoke.mjs
@@ -1,0 +1,139 @@
+// scripts/podium-rbac-smoke.mjs — offline smoke for the F9 RBAC gate.
+//
+// Covers lib/rbac.js's server-authoritative gate — the piece F9 uses to lock the
+// user-administration endpoints down to superadmin — plus the granted_by wiring F0b
+// deferred to F9. No network, no database, no secrets:
+//
+//   node scripts/podium-rbac-smoke.mjs
+//
+// requireRoles() is the single place a handler asks "is this caller allowed?", so it is
+// worth real coverage: it must FAIL CLOSED (401) on a missing/forged/expired token or an
+// unconfigured JWT_SECRET, 403 a genuine user who lacks the role, and pass a multi-role
+// user (P10 — one user can hold sales AND logistics AND superadmin).
+
+process.env.JWT_SECRET = 'test-secret-for-rbac-smoke';
+
+const jwt = (await import('jsonwebtoken')).default;
+const { requireRoles, syncUserRoles, hasAnyRole, primaryRole, sanitizeRoles } = await import('../lib/rbac.js');
+
+let passed = 0;
+function check(name, cond, detail) {
+  if (!cond) throw new Error(`FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  passed += 1;
+  console.log(`  ✓ ${name}`);
+}
+
+const reqWith = (token) => ({ headers: token ? { authorization: `Bearer ${token}` } : {} });
+const tokenFor = (roles, opts = {}) =>
+  jwt.sign({ id: 'GS', email: 'a@b.c', roles }, process.env.JWT_SECRET, opts);
+
+console.log('F9 RBAC gate smoke — no DB, no network\n');
+
+console.log('fails closed:');
+{
+  const r1 = requireRoles({ headers: {} }, ['superadmin']);
+  check('no Authorization header → 401', r1.ok === false && r1.status === 401);
+
+  const r2 = requireRoles(reqWith('not-a-jwt'), ['superadmin']);
+  check('malformed token → 401', r2.ok === false && r2.status === 401);
+
+  const forged = jwt.sign({ id: 'XX', roles: ['superadmin'] }, 'the-wrong-secret');
+  const r3 = requireRoles(reqWith(forged), ['superadmin']);
+  check('token signed with the wrong secret → 401 (not 403)', r3.ok === false && r3.status === 401);
+
+  const expired = tokenFor(['superadmin'], { expiresIn: -10 });
+  const r4 = requireRoles(reqWith(expired), ['superadmin']);
+  check('expired token → 401', r4.ok === false && r4.status === 401);
+
+  const saved = process.env.JWT_SECRET;
+  delete process.env.JWT_SECRET;
+  const r5 = requireRoles(reqWith(jwt.sign({ id: 'GS', roles: ['superadmin'] }, saved)), ['superadmin']);
+  check('JWT_SECRET unset → 401, never open', r5.ok === false && r5.status === 401);
+  process.env.JWT_SECRET = saved;
+}
+
+console.log('\nauthorises:');
+{
+  const r1 = requireRoles(reqWith(tokenFor(['staff'])), ['superadmin']);
+  check('authenticated but wrong role → 403 (not 401)', r1.ok === false && r1.status === 403);
+  check('403 carries an error message', typeof r1.error === 'string' && r1.error.length > 0);
+
+  const r2 = requireRoles(reqWith(tokenFor(['superadmin'])), ['superadmin']);
+  check('right role → ok', r2.ok === true);
+  check('ok exposes the acting user id (for granted_by / audit)', r2.auth?.id === 'GS');
+
+  // P10: a role SET, not a single value.
+  const multi = reqWith(tokenFor(['sales', 'logistics']));
+  check('multi-role user passes a sales gate', requireRoles(multi, ['sales', 'superadmin']).ok === true);
+  check('multi-role user passes a logistics gate', requireRoles(multi, ['logistics', 'superadmin']).ok === true);
+  check('multi-role user still 403s on a gate it lacks', requireRoles(multi, ['superadmin']).ok === false);
+
+  check('role match is case-insensitive', requireRoles(reqWith(tokenFor(['SuperAdmin'])), ['superadmin']).ok === true);
+
+  const noRoles = requireRoles(reqWith(tokenFor([])), ['superadmin']);
+  check('valid token with an empty role set → 403', noRoles.ok === false && noRoles.status === 403);
+}
+
+console.log('\ngranted_by wiring (F0b deferred this to F9):');
+{
+  const calls = [];
+  const client = { async query(sql, params) { calls.push({ sql, params }); return { rowCount: 1, rows: [] }; } };
+
+  await syncUserRoles(client, 'BR', ['sales', 'logistics'], 'GS');
+  const inserts = calls.filter((c) => /INSERT INTO user_roles/i.test(c.sql));
+  check('one INSERT per role', inserts.length === 2, `got ${inserts.length}`);
+  check('granted_by carries the acting admin id', inserts.every((c) => c.params[2] === 'GS'));
+  check('roles are wrapped in a transaction', calls.some((c) => /BEGIN/i.test(c.sql)) && calls.some((c) => /COMMIT/i.test(c.sql)));
+  check('the old set is cleared first (idempotent replace)', /DELETE FROM user_roles/i.test(calls[1].sql));
+
+  const calls2 = [];
+  const client2 = { async query(sql, params) { calls2.push({ sql, params }); return { rowCount: 1, rows: [] }; } };
+  await syncUserRoles(client2, 'BR', ['sales'], undefined);
+  const ins2 = calls2.find((c) => /INSERT INTO user_roles/i.test(c.sql));
+  check('no acting admin → granted_by null, never undefined', ins2.params[2] === null);
+
+  // A DB that hasn't run the F0 migration must not break user admin.
+  const err = new Error('relation "user_roles" does not exist'); err.code = '42P01';
+  const bare = { async query(sql) { if (/user_roles/i.test(sql)) throw err; return { rowCount: 0, rows: [] }; } };
+  check('missing user_roles table → false, no throw', (await syncUserRoles(bare, 'BR', ['sales'], 'GS')) === false);
+}
+
+console.log('\ngate is actually WIRED IN (not just sound in isolation):');
+{
+  // Everything above proves requireRoles works; none of it would fail if the gate were
+  // deleted from the router — and the gate IS the feature. The handler builds its own pg
+  // client (see backlog F21), so until that's injectable these static assertions are the
+  // cheapest honest guard against the wiring being dropped.
+  const fs = await import('node:fs/promises');
+  const url = await import('node:url');
+  const routerPath = url.fileURLToPath(new URL('../api/[...path].js', import.meta.url));
+  const src = await fs.readFile(routerPath, 'utf8');
+
+  check('router imports requireRoles', /import\s*\{[^}]*requireRoles[^}]*\}\s*from\s*'\.\.\/lib\/rbac\.js'/.test(src));
+
+  const registerBlock = src.slice(src.indexOf("action === 'register'"), src.indexOf("action === 'change-password'"));
+  check('register action gates on superadmin', /requireRoles\(req,\s*\['superadmin'\]\)/.test(registerBlock));
+  check('register passes the acting admin as granted_by', /syncUserRoles\(client,\s*id,\s*roles,\s*gate\.auth\.id\)/.test(registerBlock));
+
+  const usersBlock = src.slice(src.indexOf('async function handleUsers'));
+  const gateCount = (usersBlock.match(/requireRoles\(req,\s*\['superadmin'\]\)/g) || []).length;
+  check('users PUT and DELETE both gate on superadmin', gateCount === 2, `found ${gateCount}`);
+  check('users PUT passes the acting admin as granted_by', /syncUserRoles\(client,\s*id,\s*roles,\s*gate\.auth\.id\)/.test(usersBlock));
+  check('the last superadmin cannot be orphaned', /wouldOrphanSuperadmin/.test(usersBlock) && /409/.test(usersBlock));
+
+  // Documents a DELIBERATE decision: GET /api/users stays ungated because
+  // create_workorder.js + the workorder detail page fetch it token-less for dropdowns.
+  // If someone gates reads, these pages must start sending authHeaders() first.
+  check('GET /api/users is deliberately left ungated (see the F9 report)',
+    !/method === 'GET'[\s\S]{0,400}requireRoles/.test(usersBlock));
+}
+
+console.log('\nrole helpers (used by the nav + gates):');
+{
+  check('hasAnyRole is true when one of many matches', hasAnyRole(['staff', 'sales'], ['sales', 'superadmin']) === true);
+  check('hasAnyRole is false when none match', hasAnyRole(['staff'], ['sales', 'superadmin']) === false);
+  check('primaryRole picks the highest privilege', primaryRole(['sales', 'superadmin']) === 'superadmin');
+  check('sanitizeRoles drops unknown roles', sanitizeRoles(['sales', 'hacker']).join(',') === 'sales');
+}
+
+console.log(`\n✅ rbac smoke: ${passed} checks passed`);

--- a/src/pages/register.js
+++ b/src/pages/register.js
@@ -3,10 +3,15 @@ import { useNavigate } from 'react-router-dom';
 import BackButton from '../components/backbutton';
 import HomeButton from '../components/homebutton';
 import toast from 'react-hot-toast';
+import { authHeaders, getToken, getRoles, hasAnyRole } from '../utils/auth';
 
 // F0b: single-user-multi-role. Keep in sync with lib/rbac.js ROLES (precedence order).
 // users.access mirrors the primary (highest-precedence) role server-side.
 const ROLES = ['superadmin', 'admin', 'logistics', 'sales', 'staff', 'technician', 'workshop'];
+
+// F9: user administration (create/edit/delete + role assignment) is superadmin-only.
+// This check is DISPLAY-ONLY — the server re-verifies every write against the login JWT.
+const ADMIN_ROLES = ['superadmin'];
 
 function RoleCheckboxes({ selected, onToggle }) {
   const set = new Set(selected || []);
@@ -38,20 +43,22 @@ export default function Register() {
   });
   const [users, setUsers] = useState([]);
   const [loadingUsers, setLoadingUsers] = useState(false);
+  const [authorized, setAuthorized] = useState(false);
 
   const navigate = useNavigate();
 
+  // F9: superadmin-only. Reads the role SET signed into the login JWT (P10) rather than
+  // the single localStorage `user.access`, so an admin who holds superadmin alongside
+  // other roles is judged on the same set the server gates on. Display-only — every
+  // write is re-checked server-side against the JWT.
   useEffect(() => {
-    const stored = localStorage.getItem('user');
-    if (!stored) {
-      navigate('/');
+    if (!getToken()) { navigate('/'); return; }
+    if (!hasAnyRole(getRoles(), ADMIN_ROLES)) {
+      toast.error('User administration is for superadmins');
+      navigate('/dashboard');
       return;
     }
-    const u = JSON.parse(stored);
-    if (u?.access !== 'superadmin') {
-      toast.error('Insufficient permissions');
-      navigate('/dashboard');
-    }
+    setAuthorized(true);
   }, [navigate]);
 
   const handleChange = (e) =>
@@ -82,7 +89,7 @@ export default function Register() {
     try {
       const res = await fetch('/api/register', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify(formData),
       });
 
@@ -111,7 +118,7 @@ export default function Register() {
   const fetchUsers = async () => {
     setLoadingUsers(true);
     try {
-      const res = await fetch('/api/users');
+      const res = await fetch('/api/users', { headers: authHeaders() });
       if (!res.ok) throw new Error('Failed to fetch users');
       const data = await res.json();
       // Ensure every row has a roles array (falls back to [access]).
@@ -148,7 +155,7 @@ export default function Register() {
     try {
       const res = await fetch('/api/users', {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify(row),
       });
 
@@ -167,8 +174,11 @@ export default function Register() {
   };
 
   useEffect(() => {
-    if (activeTab === 'update') fetchUsers();
-  }, [activeTab]);
+    if (authorized && activeTab === 'update') fetchUsers();
+  }, [authorized, activeTab]);
+
+  // Don't paint the user-admin UI before the role check has passed (mirrors /leads).
+  if (!authorized) return null;
 
   return (
     <>


### PR DESCRIPTION
## F9 — RBAC: gate user administration, wire `granted_by`

> ⛔ **This PR needs migration `0006` run on Production BEFORE it merges** (runbook rule 5). See *Migration* below — it is not optional if this ships.

### What I found

**F9's stated scope was already done.** Gating `/inbox`, `/leads` and the logistics queue via `hasAnyRole`, nav per role, the 30-minute session timeout with the kiosk excluded, and the sales-only "Connect my Podium account" card were all delivered incrementally by F3/F5/F7b/F1. Verified criterion by criterion (evidence in the Notion report), rather than rebuilt.

**What wasn't done is the hole underneath all of it:** user administration had **no server-side gate**.

```
POST   /api/register    → no token required
PUT    /api/users       → no token required   (roles = whatever you send)
DELETE /api/users       → no token required
```

Anyone who could reach the app could create themselves a superadmin account, or grant themselves `sales` + `logistics` — which makes every other role gate decorative. The `/register` page did have a client-side guard, but a client guard is not a gate: the endpoints were open directly.

### Scope

| | |
|---|---|
| **New** | `lib/rbac.js` → `requireRoles(req, wanted)` — the standard gate |
| **Gated** | `register` action + users `PUT`/`DELETE` → superadmin, server-authoritative |
| **Wired** | `granted_by` = the acting admin (closes F0b's explicit "wire it in F9" deferral) |
| **Guard** | `wouldOrphanSuperadmin()` → 409 rather than lose the last superadmin |
| **Migration** | `0006_user_roles_granted_by_fk.sql` (+ `_down`) — **applied to Neon dev, up and down both verified** |
| **Frontend** | `register.js` — send `authHeaders()`, use the JWT-roles guard, no UI flash |
| **Tests** | `scripts/podium-rbac-smoke.mjs` — **31 checks, the repo's first coverage of `lib/rbac.js`** |
| **Functions** | No new serverless fn (`nodejs:5`, same as `main`) |
| **Preview** | ✅ READY — `dpl_5A1CuLcuCVCPKkTo3nAXK2RsBpLN` · https://grays-internal-lj2gfa4z5-grays-supports-projects.vercel.app (SSO-gated) |

### Migration `0006` — why it's mandatory

`user_roles.granted_by` has an FK to `users(id)` with **no `ON DELETE` clause**. That was harmless while the column was always NULL (all 23 rows on dev are). But F9 starts populating it — and from then on, **deleting an admin who has ever granted a role raises `23503` and `DELETE /api/users` 500s.**

`0006` switches it to `ON DELETE SET NULL`: keep the grant, clear the attribution. Enforced in the DB so every delete path is covered. Applied to the **dev** branch only; **run it on Production before merging** (runbook rule 5).

### The lockout guard

`PUT /api/users` let a superadmin submit their own row with `roles: ['staff']` — and the UI renders role checkboxes for every row **including your own**. Since user admin is now superadmin-gated, demoting the last superadmin would be **unrecoverable without direct SQL**, and the stale JWT would keep working for up to an hour, hiding the damage until next login. Now a 409 on both the demotion and deletion paths.

### Code review — it caught two things I got wrong

A reviewer subagent ran over the diff. It was right on both counts and both are fixed:

- **The FK regression above.** I switched `granted_by` on without checking the constraint's `ON DELETE` behaviour — my own change would have broken user deletion. Found, verified against dev (`confdeltype = 'a'` = NO ACTION), fixed with `0006`.
- **`/register` already had a guard** (a `localStorage user.access` check) that I hadn't read before editing. My first pass claimed it had none and added a *second* guard — two toasts, two redirects. Now there is exactly one: the JWT-roles guard, which is the better of the two (it reads the same signed role **set** the server gates on, per P10, rather than a single client-stored value). The commit message was corrected before push.
- Also from the review: the last-superadmin guard, the bootstrap deadlock (documented), the render flash (`authorized` state), and static assertions proving the gate is **wired in** — my tests proved `requireRoles` was sound but would all still have passed if I'd deleted every call to it. I verified the new assertions genuinely fail when the gate is removed.

### Deliberate scope decision — `GET /api/users` stays ungated

`create_workorder.js`, the workorder detail page and `register.js` all fetch it **without a token** for name/technician dropdowns. Gating reads would break three pages, so it's out of scope here.

Be clear-eyed about what that defers, though — both **pre-existing**, neither touched by this PR:
- `SELECT u.*` returns **every user's bcrypt hash** to any unauthenticated caller.
- `PUT /api/users` writes `password` **raw/unhashed** — it only works because `register.js` round-trips the hash it read from that GET.

Backlogged as **F23** with the cheap first move: column-list the SELECT (one line, non-breaking, keeps the dropdowns working, ships independently of any gating decision).

### Bootstrap (documented, not coded)

Gating `register` means a **database with no users at all** can't create one: no user → no login → no token → no superadmin → 401 forever. Production and every Neon branch cloned from it have users, so this is theoretical here. Deliberately **not** solved with an "open registration when there are no users" code path — that's a hole waiting to be re-opened. Seed SQL is documented in `db/PRODUCTION_MIGRATION_RUNBOOK.md` instead.

### Test steps

**No lockout risk — please sanity-check this first:**
1. Log in as your superadmin → `/register` still loads, lists users, and Update still saves. (It now sends your login token; it previously sent none.)
2. A non-superadmin (or logged-out) visiting `/register` → bounced to `/dashboard` (or `/`) with **one** toast, no flash of the admin UI.

**The gate is real (this is the point of the PR):**
3. From a terminal, unauthenticated:
   ```bash
   curl -X POST https://<preview>/api/register \
     -H 'Content-Type: application/json' \
     -d '{"id":"ZZ","name":"attacker","email":"z@z.com","password":"x","roles":["superadmin"]}'
   ```
   Expect **401** (before this PR: a new superadmin account). Same for `PUT`/`DELETE /api/users`.
   *(Note: the Preview is SSO-gated, so run this against a local `vercel dev` or after merge — see below.)*

**Attribution:**
4. Create or edit a user, then on Neon dev:
   ```sql
   SELECT user_id, role, granted_by FROM user_roles ORDER BY user_id;
   ```
   New/changed rows carry **your** 2-char id in `granted_by`. Pre-existing rows stay NULL — this attributes new grants, it doesn't backfill history.

**Lockout guard:**
5. Try removing `superadmin` from your own row while you're the only superadmin → **409**, no change.

Offline, no DB: `node scripts/podium-rbac-smoke.mjs` → 31 checks.

### Reviewer checklist

- [ ] **Run `0006` on Production before merging** (back up / branch Production first, per the runbook).
- [ ] You can still administer users as superadmin (step 1) — this is the one thing that would hurt if I got it wrong.
- [ ] Superadmin-only is the right gate for creating/editing/deleting users. (Should `admin` hold any of this? Currently it must not.)
- [ ] 409 on last-superadmin demotion/deletion is the behaviour you want.
- [ ] Leaving `GET /api/users` ungated for now is acceptable — **and F23 (the bcrypt-hash leak) gets prioritised.** That one is arguably more urgent than what this PR fixes.
- [ ] The bootstrap trade-off (documented seed SQL, no open-registration path) is the right call.

### Note on verification

The Preview enforces Vercel SSO, so the unauthenticated `curl` in step 3 can't be run against it headlessly — the 401/403 behaviour is proven by the 31-check smoke (including fail-closed on missing/forged/expired tokens) plus the wiring assertions, not by hitting the Preview. Flagging that honestly rather than implying an end-to-end check I didn't run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
