### PR TITLE
F10 — Integrations observability (surface integration_sync_log) + ops runbook

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -13,6 +13,7 @@ import collectionsHandler from '../lib/handlers/collections.js';
 import winningsHandler from '../lib/handlers/winnings.js';
 import leadsHandler from '../lib/handlers/leads.js';
 import logisticsHandler from '../lib/handlers/logistics.js';
+import integrationsHandler from '../lib/handlers/integrations.js';
 import lotsHandler from '../lib/handlers/lots.js';
 import { buildJourney } from '../lib/customerJourney.js';
 
@@ -99,6 +100,10 @@ export default async function handler(req, res) {
       // multi-segment routing). JWT-gated to logistics/superadmin.
       case 'logistics':
         return logisticsHandler(req, res, parts.slice(1));
+      // Integration observability (F10) — the superadmin read of integration_sync_log.
+      // Same query-form convention as `logistics`. JWT-gated to superadmin.
+      case 'integrations':
+        return integrationsHandler(req, res, parts.slice(1));
       case 'delivery':
         return deliveryHandler(req, res);
       case 'collections':

--- a/docs/PODIUM_OPS_RUNBOOK.md
+++ b/docs/PODIUM_OPS_RUNBOOK.md
@@ -1,0 +1,117 @@
+# Podium integration — ops runbook
+
+What to do when the Podium integration misbehaves. Written for whoever is on the tools,
+not for whoever wrote the code.
+
+**Start here:** `/integrations` (superadmin only) — the Integrations page lists every
+message the portal has sent through Podium and every event it has received, newest first.
+The tiles at the top are the alert: **if `Failed` is red, something needs a human.**
+
+> **The one thing to understand:** automated messages are sent **at most once**. If a send
+> fails, it is **not** retried — the row is marked `failed` and that is the end of it. So a
+> failed row means *that customer never got their message*, and someone has to decide
+> whether to contact them by hand. This is deliberate: never double-texting a customer was
+> judged more important than guaranteeing delivery of a convenience message.
+
+---
+
+## 1. Reading the log
+
+| Column | Meaning |
+|---|---|
+| **Event** | Which automation: waitlist back-in-stock, delivery booked, or review request. |
+| **Direction** | `outbound` = we sent it. `inbound` = Podium told us something (a webhook). |
+| **Reference** | The thing it's about, e.g. `review_request:42` = workorder 42. This is also the **de-dupe key** — one row per reference, forever. |
+| **Status** | `sent` (away), `failed` (never sent, not retried), `pending` (claimed but the outcome wasn't recorded — see §4), `skipped` (deliberately not sent — usually no phone number on the customer). |
+| **Detail** | The error, and the envelope (ids/SKUs). **Never message text** — Podium is the system of record for conversations. |
+
+## 2. "A customer says they never got their text"
+
+1. `/integrations` → search their reference (e.g. `delivery_booked:1234`) or filter by event.
+2. **No row at all** → the automation never fired. Either the trigger didn't happen (the
+   delivery was never moved to *Booked for Delivery*; the workorder isn't both completed
+   **and** fully paid), or Podium is still in mock mode (§6).
+3. **`skipped`** → read the reason. Almost always *no phone on the customer* — fix the
+   customer record; the automation will **not** re-fire for that reference.
+4. **`failed`** → read the error, then **contact the customer manually**. It will not retry.
+5. **`sent`** → we handed it to Podium. Check the conversation in Podium itself for the
+   delivery receipt; the problem is downstream of us.
+
+## 3. "Everything is failing at once"
+
+Almost always the Podium token or credentials, not the automations.
+
+1. Check the errors on the failed rows — `401`/`unauthorized` points at auth.
+2. **Token refresh:** access tokens live **10 hours** and refresh automatically (within a
+   5-minute skew, plus one forced refresh on a 401). If refresh itself is failing, the rep
+   must re-link (§5). The shared-number/system sends (waitlist, delivery, review) do **not**
+   use a rep's token — see the VERIFY note in `lib/podium.js` `sendSystemSms`.
+3. Confirm `PODIUM_MOCK`, `PODIUM_CLIENT_ID/SECRET`, `PODIUM_API_VERSION` and
+   `PODIUM_LOCATION_UID` are set on the right Vercel environment.
+4. `PODIUM_API_VERSION` **must be pinned** to a dated version. Unset = Podium's latest =
+   breaking changes arrive unannounced.
+
+## 4. Rows stuck on `pending`
+
+A `pending` row was claimed but never resolved — the process died between claiming and
+recording the outcome. The message may or may not have gone out; **assume it did not**, and
+check with the customer before re-sending by hand.
+
+Because the claim row is the de-dupe gate, a `pending` row **blocks** that reference from
+ever being retried. If you are certain the message never sent and you want the automation to
+fire again, delete that one row (superadmin, with care):
+
+```sql
+-- Confirm what you're about to delete FIRST.
+SELECT * FROM integration_sync_log WHERE reference_id = 'delivery_booked:1234';
+DELETE FROM integration_sync_log WHERE reference_id = 'delivery_booked:1234' AND status = 'pending';
+```
+
+The next trigger for that reference will then re-claim and re-send.
+
+## 5. A rep needs to re-link their Podium account
+
+Each salesperson authorises their own Podium account (their replies must show as *them*).
+
+1. The rep opens **Settings** → **Connect my Podium account** (the card only shows to users
+   holding the `sales` role) → completes Podium's consent screen.
+2. That stores their token and their `podium_user_id`, which is what maps portal
+   assignment ⇄ Podium assignment.
+3. To verify: Settings shows the account as connected. If assignment sync looks wrong for
+   one rep specifically, re-linking them is the first thing to try.
+
+## 6. Nothing is being sent at all (expected today)
+
+The integration is **mock-first**: while `PODIUM_MOCK=true` (or no `PODIUM_CLIENT_ID` is
+set), every Podium call is served by a local mock and **nothing reaches a real customer**.
+The automations still run end-to-end and still write their audit rows, which is exactly what
+makes them reviewable on a Preview.
+
+Going live is a config change, not a code change: set the credentials and
+`PODIUM_MOCK=false`. **Before you do**, confirm the outbound SMS copy has been signed off
+and check the review-invite wording in Podium's own settings (Podium composes that one, not
+us).
+
+## 7. Webhook re-registration
+
+The webhook subscription is **per location/organisation** and is created with an admin
+location-scoped token, not a rep's.
+
+- Register/re-register: `scripts/podium-webhook-register.mjs` (needs `PODIUM_MOCK=false`,
+  live credentials, and `PODIUM_WEBHOOK_SECRET`).
+- The receiver **fails closed**: with no `PODIUM_WEBHOOK_SECRET` set it returns 503 and
+  processes nothing, because it cannot verify the signature.
+- The same secret must be set on the Vercel environment receiving the calls.
+- Inbound events are de-duped on Podium's event id, so a replay is harmless.
+- Podium retries for ~10 days, so a receiver outage is recoverable — fix it and the queue
+  drains.
+
+## 8. Where things live
+
+| | |
+|---|---|
+| Audit log | `integration_sync_log` — surfaced at `/integrations` |
+| Podium calls | `lib/podium.js` (one place; mock in `lib/podium.mock.js`) |
+| Automations | `lib/waitlistNotify.js`, `lib/deliveryNotify.js`, `lib/reviewNotify.js` |
+| Webhook receiver | `api/podium/webhook.js` + `lib/podiumWebhook.js` |
+| OAuth | `lib/podiumOAuth.js` + `api/podium/oauth/*` |

--- a/lib/handlers/integrations.js
+++ b/lib/handlers/integrations.js
@@ -1,0 +1,125 @@
+// lib/handlers/integrations.js — Integration observability (feature F10).
+//
+// `integration_sync_log` is the audit trail every Podium integration writes to: the F2
+// webhook receiver dedupes inbound events on it, and the F8 automations (waitlist
+// back-in-stock, delivery-booked, review-request) claim + record every outbound send
+// there. Until now nothing SURFACED it — a failed customer SMS was invisible unless you
+// opened a SQL console. This is the superadmin-facing read of that table (execution-plan
+// §F10), plus the health summary that answers the only question ops actually has:
+// "is anything failing?"
+//
+// Routed through the api/[...path].js catch-all as an `integrations` case (NO new file
+// under api/ — Vercel Hobby function cap). Front-end calls the QUERY form
+// (`?resource=sync-log`) because Vercel platform-404s multi-segment paths into the
+// catch-all (F6/F7a/F7b all hit this); the path form is accepted too.
+//
+// Read-only. Gated to superadmin via the login JWT (getAuthUser + hasAnyRole) — the
+// server is the authority, the nav link is only cosmetic.
+//
+// P1: this READS the audit log, which by construction holds envelope metadata only —
+// ids, SKUs, event types. No message body was ever written there (F2/F8 guarantee it),
+// so surfacing `payload` cannot leak chat content.
+
+import { getClientWithTimezone } from '../db.js';
+import { getAuthUser, hasAnyRole } from '../rbac.js';
+
+const ALLOWED_ROLES = ['superadmin'];
+
+const DEFAULT_LIMIT = 100;
+const MAX_LIMIT = 200;
+
+/** Clamp the caller's limit: junk → default, absurd → MAX (never an unbounded scan). */
+export function resolveLimit(raw) {
+  const n = Number.parseInt(raw, 10);
+  if (!Number.isFinite(n) || n <= 0) return DEFAULT_LIMIT;
+  return Math.min(n, MAX_LIMIT);
+}
+
+// sub = the path segments AFTER "integrations" (e.g. ['sync-log']).
+// deps.getClient lets the offline smoke inject a fake pg client (default = real pool).
+export default async function handler(req, res, sub = [], deps = {}) {
+  const auth = getAuthUser(req);
+  if (!auth) return res.status(401).json({ error: 'Not authenticated' });
+  if (!hasAnyRole(auth.roles, ALLOWED_ROLES)) {
+    return res.status(403).json({ error: 'Requires the superadmin role to view integrations' });
+  }
+
+  const seg = Array.isArray(sub) ? sub[0] : undefined;
+  const resource = (seg || req.query?.resource || '').toString();
+
+  if (req.method !== 'GET') {
+    res.setHeader('Allow', ['GET']);
+    return res.status(405).json({ error: 'Method not allowed for this integrations route' });
+  }
+  if (resource !== 'sync-log') {
+    return res.status(404).json({ error: 'Unknown integrations resource' });
+  }
+
+  const { source, status, event_type: eventType, q } = req.query || {};
+
+  // Build the filter once; both the list and the summary run over the SAME predicate, so
+  // the tiles always describe the rows on screen rather than the whole table.
+  const where = [];
+  const params = [];
+  if (source) { params.push(String(source)); where.push(`source = $${params.length}`); }
+  if (status) { params.push(String(status)); where.push(`status = $${params.length}`); }
+  if (eventType) { params.push(String(eventType)); where.push(`event_type = $${params.length}`); }
+  if (q) {
+    // Reference/error free-text. Bound as a parameter — never interpolated.
+    params.push(`%${String(q)}%`);
+    where.push(`(reference_id ILIKE $${params.length} OR error ILIKE $${params.length})`);
+  }
+  const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
+
+  const getClient = deps.getClient || getClientWithTimezone;
+  const client = await getClient();
+  try {
+    // Health tiles. Ops only ever needs "how many are broken" — a failed row means a
+    // customer did NOT get their text (F8 is at-most-once, so nothing retries it).
+    const summaryRes = await client.query(
+      `SELECT count(*) AS total,
+              count(*) FILTER (WHERE status = 'sent')    AS sent,
+              count(*) FILTER (WHERE status = 'failed')  AS failed,
+              count(*) FILTER (WHERE status = 'pending') AS pending,
+              count(*) FILTER (WHERE status = 'skipped') AS skipped
+         FROM integration_sync_log
+         ${whereSql}`,
+      params
+    );
+    const s = summaryRes.rows[0] || {};
+    const summary = {
+      total: Number(s.total || 0),
+      sent: Number(s.sent || 0),
+      failed: Number(s.failed || 0),
+      pending: Number(s.pending || 0),
+      skipped: Number(s.skipped || 0),
+    };
+
+    const limit = resolveLimit(req.query?.limit);
+    const rowsRes = await client.query(
+      `SELECT id, source, direction, event_type, reference_id, status, payload, error, created_at
+         FROM integration_sync_log
+         ${whereSql}
+        ORDER BY id DESC
+        LIMIT $${params.length + 1}`,
+      [...params, limit]
+    );
+
+    return res.status(200).json({ rows: rowsRes.rows, summary, limit });
+  } catch (err) {
+    // integration_sync_log absent (a DB that hasn't run the F0 migration) — degrade to an
+    // empty page rather than 500 the ops screen.
+    if (err?.code === '42P01') {
+      return res.status(200).json({
+        rows: [],
+        summary: { total: 0, sent: 0, failed: 0, pending: 0, skipped: 0 },
+        limit: resolveLimit(req.query?.limit),
+        unavailable: true,
+      });
+    }
+    console.error('Integrations API error:', err);
+    return res.status(500).json({ error: 'Server error' });
+  } finally {
+    client.release();
+  }
+}

--- a/lib/handlers/integrations.js
+++ b/lib/handlers/integrations.js
@@ -11,9 +11,9 @@
 //   • F2 webhook receiver — INBOUND, dedupes on the Podium event uid:
 //       'received' (insert default) → 'processed' | 'failed'
 //   • F8a waitlist back-in-stock — OUTBOUND: 'pending' → 'sent' | 'failed' | 'skipped'
-//   • F8b delivery-booked (`delivery.booked`) and F8c review-request
-//     (`workorder.review_request`) use the same outbound pattern — both are on OPEN PRs
-//     (#72, #73) and land here once merged; today only F8a and the webhook write.
+//   • F8b delivery-booked (`delivery.booked`) uses the same outbound pattern and lands
+//     here once PR #72 merges; today only F8a and the webhook write.
+//     (F8c review-request was scrapped on 17 Jul — sales send those themselves.)
 //
 // Routed through the api/[...path].js catch-all as an `integrations` case (NO new file
 // under api/ — Vercel Hobby function cap). Front-end calls the QUERY form

--- a/lib/handlers/integrations.js
+++ b/lib/handlers/integrations.js
@@ -1,12 +1,19 @@
 // lib/handlers/integrations.js — Integration observability (feature F10).
 //
-// `integration_sync_log` is the audit trail every Podium integration writes to: the F2
-// webhook receiver dedupes inbound events on it, and the F8 automations (waitlist
-// back-in-stock, delivery-booked, review-request) claim + record every outbound send
-// there. Until now nothing SURFACED it — a failed customer SMS was invisible unless you
-// opened a SQL console. This is the superadmin-facing read of that table (execution-plan
-// §F10), plus the health summary that answers the only question ops actually has:
-// "is anything failing?"
+// `integration_sync_log` is the audit trail every Podium integration writes to. Until now
+// nothing SURFACED it — a failed customer SMS was invisible unless you opened a SQL
+// console. This is the superadmin-facing read of that table (execution-plan §F10), plus
+// the health summary that answers the only question ops actually has: "is anything
+// failing?"
+//
+// Writers, and their status vocabularies (they differ by direction — the summary counts
+// BOTH, or the tiles wouldn't add up to the total):
+//   • F2 webhook receiver — INBOUND, dedupes on the Podium event uid:
+//       'received' (insert default) → 'processed' | 'failed'
+//   • F8a waitlist back-in-stock — OUTBOUND: 'pending' → 'sent' | 'failed' | 'skipped'
+//   • F8b delivery-booked (`delivery.booked`) and F8c review-request
+//     (`workorder.review_request`) use the same outbound pattern — both are on OPEN PRs
+//     (#72, #73) and land here once merged; today only F8a and the webhook write.
 //
 // Routed through the api/[...path].js catch-all as an `integrations` case (NO new file
 // under api/ — Vercel Hobby function cap). Front-end calls the QUERY form
@@ -35,6 +42,11 @@ export function resolveLimit(raw) {
   return Math.min(n, MAX_LIMIT);
 }
 
+/** Escape LIKE metacharacters so user text matches literally (paired with ESCAPE '\'). */
+export function escapeLike(s) {
+  return String(s).replace(/([\\%_])/g, '\\$1');
+}
+
 // sub = the path segments AFTER "integrations" (e.g. ['sync-log']).
 // deps.getClient lets the offline smoke inject a fake pg client (default = real pool).
 export default async function handler(req, res, sub = [], deps = {}) {
@@ -57,34 +69,52 @@ export default async function handler(req, res, sub = [], deps = {}) {
 
   const { source, status, event_type: eventType, q } = req.query || {};
 
-  // Build the filter once; both the list and the summary run over the SAME predicate, so
-  // the tiles always describe the rows on screen rather than the whole table.
-  const where = [];
-  const params = [];
-  if (source) { params.push(String(source)); where.push(`source = $${params.length}`); }
-  if (status) { params.push(String(status)); where.push(`status = $${params.length}`); }
-  if (eventType) { params.push(String(eventType)); where.push(`event_type = $${params.length}`); }
+  // The BASE predicate (everything except status) drives the SUMMARY; the list adds the
+  // status filter on top. Keeping status out of the summary is deliberate: the tiles are
+  // also the filter buttons, so if status narrowed them too, clicking "Failed" would zero
+  // out every other tile and destroy the health picture the user opened the page for.
+  const baseWhere = [];
+  const baseParams = [];
+  if (source) { baseParams.push(String(source)); baseWhere.push(`source = $${baseParams.length}`); }
+  if (eventType) { baseParams.push(String(eventType)); baseWhere.push(`event_type = $${baseParams.length}`); }
   if (q) {
-    // Reference/error free-text. Bound as a parameter — never interpolated.
-    params.push(`%${String(q)}%`);
-    where.push(`(reference_id ILIKE $${params.length} OR error ILIKE $${params.length})`);
+    // Reference/error free-text. Bound as a parameter — never interpolated. `%` and `_`
+    // are escaped so a literal underscore in a reference (they're full of them, e.g.
+    // waitlist_back_in_stock:12) matches itself instead of any character.
+    baseParams.push(`%${escapeLike(String(q))}%`);
+    baseWhere.push(`(reference_id ILIKE $${baseParams.length} ESCAPE '\\' OR error ILIKE $${baseParams.length} ESCAPE '\\')`);
   }
-  const whereSql = where.length ? `WHERE ${where.join(' AND ')}` : '';
+  const baseWhereSql = baseWhere.length ? `WHERE ${baseWhere.join(' AND ')}` : '';
+
+  // The LIST predicate = base + status.
+  const listWhere = [...baseWhere];
+  const listParams = [...baseParams];
+  if (status) { listParams.push(String(status)); listWhere.push(`status = $${listParams.length}`); }
+  const listWhereSql = listWhere.length ? `WHERE ${listWhere.join(' AND ')}` : '';
 
   const getClient = deps.getClient || getClientWithTimezone;
   const client = await getClient();
   try {
     // Health tiles. Ops only ever needs "how many are broken" — a failed row means a
     // customer did NOT get their text (F8 is at-most-once, so nothing retries it).
+    //
+    // Both directions are counted, because both write here with DIFFERENT vocabularies:
+    //   outbound (F8 automations): pending → sent | failed | skipped
+    //   inbound  (F2 webhook):     received → processed | failed
+    // Counting only the outbound four would leave every inbound row inside `total` but
+    // in no bucket, so the tiles wouldn't add up to Total. `other` catches any status a
+    // future writer invents, so Total always reconciles.
     const summaryRes = await client.query(
       `SELECT count(*) AS total,
-              count(*) FILTER (WHERE status = 'sent')    AS sent,
-              count(*) FILTER (WHERE status = 'failed')  AS failed,
-              count(*) FILTER (WHERE status = 'pending') AS pending,
-              count(*) FILTER (WHERE status = 'skipped') AS skipped
+              count(*) FILTER (WHERE status = 'sent')      AS sent,
+              count(*) FILTER (WHERE status = 'failed')    AS failed,
+              count(*) FILTER (WHERE status = 'pending')   AS pending,
+              count(*) FILTER (WHERE status = 'skipped')   AS skipped,
+              count(*) FILTER (WHERE status = 'received')  AS received,
+              count(*) FILTER (WHERE status = 'processed') AS processed
          FROM integration_sync_log
-         ${whereSql}`,
-      params
+         ${baseWhereSql}`,
+      baseParams
     );
     const s = summaryRes.rows[0] || {};
     const summary = {
@@ -93,27 +123,41 @@ export default async function handler(req, res, sub = [], deps = {}) {
       failed: Number(s.failed || 0),
       pending: Number(s.pending || 0),
       skipped: Number(s.skipped || 0),
+      received: Number(s.received || 0),
+      processed: Number(s.processed || 0),
     };
+    summary.other = Math.max(0, summary.total - (summary.sent + summary.failed + summary.pending
+      + summary.skipped + summary.received + summary.processed));
 
     const limit = resolveLimit(req.query?.limit);
     const rowsRes = await client.query(
       `SELECT id, source, direction, event_type, reference_id, status, payload, error, created_at
          FROM integration_sync_log
-         ${whereSql}
+         ${listWhereSql}
         ORDER BY id DESC
-        LIMIT $${params.length + 1}`,
-      [...params, limit]
+        LIMIT $${listParams.length + 1}`,
+      [...listParams, limit]
     );
 
-    return res.status(200).json({ rows: rowsRes.rows, summary, limit });
+    // `matching` = how many rows the LIST filter actually matches (the summary is
+    // status-agnostic, so it can't answer this). The page needs it to say "showing the
+    // most recent 100 of 1,234" rather than silently truncating.
+    const matchingRes = await client.query(
+      `SELECT count(*) AS n FROM integration_sync_log ${listWhereSql}`,
+      listParams
+    );
+    const matching = Number(matchingRes.rows[0]?.n || 0);
+
+    return res.status(200).json({ rows: rowsRes.rows, summary, limit, matching });
   } catch (err) {
     // integration_sync_log absent (a DB that hasn't run the F0 migration) — degrade to an
     // empty page rather than 500 the ops screen.
     if (err?.code === '42P01') {
       return res.status(200).json({
         rows: [],
-        summary: { total: 0, sent: 0, failed: 0, pending: 0, skipped: 0 },
+        summary: { total: 0, sent: 0, failed: 0, pending: 0, skipped: 0, received: 0, processed: 0, other: 0 },
         limit: resolveLimit(req.query?.limit),
+        matching: 0,
         unavailable: true,
       });
     }

--- a/scripts/podium-integrations-smoke.mjs
+++ b/scripts/podium-integrations-smoke.mjs
@@ -13,6 +13,7 @@
 process.env.JWT_SECRET = 'test-secret-for-integrations-smoke';
 
 const jwt = (await import('jsonwebtoken')).default;
+const { deepStrictEqual } = await import('node:assert/strict');
 const handler = (await import('../lib/handlers/integrations.js')).default;
 
 let passed = 0;
@@ -46,9 +47,15 @@ const LOG_ROW = (over = {}) => ({
   error: null, created_at: '2026-07-17T01:00:00.000Z', ...over,
 });
 
-// Scripted client: LIST_RE returns rows, SUMMARY_RE returns status counts.
-const LIST_RE = /FROM integration_sync_log/i;
-const SUMMARY_RE = /count\(\*\)/i;
+// NB: every query hits integration_sync_log, so match on what's UNIQUE to each —
+// the summary has count(*) FILTER, the list has LIMIT, the matching-count has count(*)
+// without a FILTER. Getting this wrong once already masked a real assertion.
+const ANY_RE = /FROM integration_sync_log/i;
+const LIST_RE = /LIMIT/i;
+const SUMMARY_RE = /FILTER \(WHERE status/i;
+const COUNT_RE = (sql) => /count\(\*\) AS n/i.test(sql);
+const pickList = (client) => client.calls.find((c) => LIST_RE.test(c.sql));
+const pickSummary = (client) => client.calls.find((c) => SUMMARY_RE.test(c.sql));
 function makeClient(scripts = []) {
   const calls = [];
   return {
@@ -134,14 +141,54 @@ console.log('\nfilters are parameterised (never string-interpolated):');
     resource: 'sync-log', status: 'failed', source: 'podium',
     event_type: 'workorder.review_request', q: "review_request:42'; DROP TABLE users;--",
   }), res, [], deps(client));
-  // NB: pick the LIST query specifically — the summary query legitimately contains the
-  // literal 'failed' inside its count(*) FILTER, which would mask an interpolation bug.
-  const list = client.calls.find((c) => LIST_RE.test(c.sql) && /LIMIT/i.test(c.sql));
-  check('status filter is a bound param', list.params.includes('failed') && !/status = 'failed'/.test(list.sql));
-  check('source filter is a bound param', list.params.includes('podium') && !/'podium'/.test(list.sql));
-  check('event_type filter is a bound param', list.params.includes('workorder.review_request'));
+  // NB: pick the LIST query specifically — the summary legitimately contains the literal
+  // 'failed' inside its count(*) FILTER, which would mask an interpolation bug.
+  const list = pickList(client);
+  // Position-blind `includes` would pass even if the placeholders were transposed, and
+  // $n numbering is the whole point — assert the exact params, in order.
+  deepStrictEqual(list.params, ['podium', 'workorder.review_request', "%review\\_request:42'; DROP TABLE users;--%", 'failed', 100]);
+  check('list params bind source, event_type, q, status, limit in $1..$5 order', true);
+  check('placeholders are sequential $1..$5', /source = \$1/.test(list.sql) && /event_type = \$2/.test(list.sql) && /\$3 ESCAPE/.test(list.sql) && /status = \$4/.test(list.sql) && /LIMIT \$5/.test(list.sql));
+  check('no filter value is interpolated into the SQL text', !/'podium'/.test(list.sql) && !/status = 'failed'/.test(list.sql));
   check('a SQL-injection attempt stays in params, never in the SQL text', !/DROP TABLE/i.test(list.sql));
-  check('reference search uses a bound LIKE pattern', list.params.some((p) => String(p).includes('DROP TABLE')));
+  check('LIKE metacharacters in user text are escaped', list.params[2].includes('review\\_request'));
+}
+
+console.log('\nthe tiles keep telling the truth while you filter:');
+{
+  // The health tiles ARE the status filter buttons. If the summary were narrowed by
+  // `status` too, clicking "Failed" would zero every other tile and destroy the health
+  // picture the page exists to show. The summary must stay status-agnostic.
+  const client = makeClient([
+    { match: SUMMARY_RE, result: { rowCount: 1, rows: [{ total: '6', sent: '3', failed: '1', pending: '1', skipped: '1', received: '0', processed: '0' }] } },
+    { match: LIST_RE, result: { rowCount: 1, rows: [LOG_ROW({ status: 'failed' })] } },
+  ]);
+  const res = resSpy();
+  await handler(reqFor(['superadmin'], { resource: 'sync-log', status: 'failed', source: 'podium' }), res, [], deps(client));
+
+  const summary = pickSummary(client);
+  check('summary is NOT narrowed by status', !summary.params.includes('failed') && !/status = \$/.test(summary.sql));
+  check('summary still applies the non-status filters', summary.params.includes('podium'));
+  check('so the other tiles survive a status filter', res.out.body.summary.sent === 3 && res.out.body.summary.total === 6);
+  check('while the rows ARE narrowed', pickList(client).params.includes('failed'));
+
+  // Inbound rows (F2 webhook) use received/processed — counting only the outbound four
+  // would leave them inside `total` but in no bucket, so the tiles wouldn't add up.
+  check('summary counts the inbound statuses too', /FILTER \(WHERE status = 'received'\)/.test(summary.sql) && /FILTER \(WHERE status = 'processed'\)/.test(summary.sql));
+  check('`other` reconciles total against the known buckets', res.out.body.summary.other === 0);
+}
+
+console.log('\ntruncation is surfaced, not silent:');
+{
+  const client = makeClient([
+    { match: SUMMARY_RE, result: { rowCount: 1, rows: [{ total: '1234', sent: '1234' }] } },
+    { match: LIST_RE, result: { rowCount: 1, rows: [LOG_ROW()] } },
+    { match: COUNT_RE, result: { rowCount: 1, rows: [{ n: '1234' }] } },
+  ]);
+  const res = resSpy();
+  await handler(reqFor(['superadmin'], { resource: 'sync-log' }), res, [], deps(client));
+  check('returns `matching` so the page can say "100 of 1,234"', res.out.body.matching === 1234);
+  check('returns the effective limit', res.out.body.limit === 100);
 }
 
 console.log('\nlimit:');

--- a/scripts/podium-integrations-smoke.mjs
+++ b/scripts/podium-integrations-smoke.mjs
@@ -1,0 +1,172 @@
+// scripts/podium-integrations-smoke.mjs — offline smoke for F10 (Integrations observability).
+//
+// Exercises lib/handlers/integrations.js with an INJECTED fake pg client (deps.getClient)
+// and fake req/res, so there is NO network, NO database, NO secrets:
+//
+//   node scripts/podium-integrations-smoke.mjs
+//
+// Covers: the superadmin gate (401/403); method + resource routing; the newest-first
+// listing; the status/source/event_type/reference filters (all PARAMETERISED — a filter
+// value must never reach the SQL text); the limit cap; the health summary that powers the
+// failure alert; and the 42P01 (bare-DB) degrade.
+
+process.env.JWT_SECRET = 'test-secret-for-integrations-smoke';
+
+const jwt = (await import('jsonwebtoken')).default;
+const handler = (await import('../lib/handlers/integrations.js')).default;
+
+let passed = 0;
+function check(name, cond, detail) {
+  if (!cond) throw new Error(`FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  passed += 1;
+  console.log(`  ✓ ${name}`);
+}
+
+// ---- fakes -------------------------------------------------------------------
+const tokenFor = (roles) => jwt.sign({ id: 'GS', email: 'a@b.c', roles }, process.env.JWT_SECRET);
+const reqFor = (roles, query = {}, method = 'GET') => ({
+  method,
+  query,
+  headers: roles ? { authorization: `Bearer ${tokenFor(roles)}` } : {},
+});
+
+function resSpy() {
+  const out = { statusCode: null, body: null, headers: {} };
+  return {
+    out,
+    setHeader(k, v) { out.headers[k] = v; },
+    status(code) { out.statusCode = code; return this; },
+    json(body) { out.body = body; return this; },
+  };
+}
+
+const LOG_ROW = (over = {}) => ({
+  id: 9, source: 'podium', direction: 'outbound', event_type: 'workorder.review_request',
+  reference_id: 'review_request:42', status: 'sent', payload: { workorder_id: 42 },
+  error: null, created_at: '2026-07-17T01:00:00.000Z', ...over,
+});
+
+// Scripted client: LIST_RE returns rows, SUMMARY_RE returns status counts.
+const LIST_RE = /FROM integration_sync_log/i;
+const SUMMARY_RE = /count\(\*\)/i;
+function makeClient(scripts = []) {
+  const calls = [];
+  return {
+    calls,
+    released: 0,
+    async query(sql, params) {
+      calls.push({ sql, params });
+      for (const s of scripts) {
+        if (typeof s.match === 'function' ? s.match(sql) : s.match.test(sql)) {
+          if (s.throws) throw s.throws;
+          return s.result ?? { rowCount: 0, rows: [] };
+        }
+      }
+      return { rowCount: 0, rows: [] };
+    },
+    release() { this.released += 1; },
+  };
+}
+const deps = (client) => ({ getClient: async () => client });
+
+console.log('F10 Integrations observability smoke — fake client, no DB\n');
+
+console.log('gate (superadmin-only ops page):');
+{
+  const res1 = resSpy();
+  await handler(reqFor(null, { resource: 'sync-log' }), res1, [], deps(makeClient()));
+  check('no token → 401', res1.out.statusCode === 401);
+
+  const res2 = resSpy();
+  await handler(reqFor(['sales'], { resource: 'sync-log' }), res2, [], deps(makeClient()));
+  check('sales user → 403 (ops page, not a sales tool)', res2.out.statusCode === 403);
+
+  const res3 = resSpy();
+  await handler(reqFor(['logistics'], { resource: 'sync-log' }), res3, [], deps(makeClient()));
+  check('logistics user → 403', res3.out.statusCode === 403);
+
+  const client = makeClient([{ match: LIST_RE, result: { rowCount: 1, rows: [LOG_ROW()] } }]);
+  const res4 = resSpy();
+  await handler(reqFor(['superadmin'], { resource: 'sync-log' }), res4, [], deps(client));
+  check('superadmin → 200', res4.out.statusCode === 200);
+  check('a multi-role user holding superadmin also passes',
+    (await (async () => { const r = resSpy(); await handler(reqFor(['sales', 'superadmin'], { resource: 'sync-log' }), r, [], deps(makeClient())); return r.out.statusCode; })()) === 200);
+}
+
+console.log('\nrouting:');
+{
+  const res1 = resSpy();
+  await handler(reqFor(['superadmin'], { resource: 'sync-log' }, 'POST'), res1, [], deps(makeClient()));
+  check('non-GET → 405', res1.out.statusCode === 405);
+  check('405 advertises Allow: GET', String(res1.out.headers.Allow) === 'GET');
+
+  const res2 = resSpy();
+  await handler(reqFor(['superadmin'], { resource: 'nope' }), res2, [], deps(makeClient()));
+  check('unknown resource → 404', res2.out.statusCode === 404);
+
+  // The path form must work too, but the front-end uses ?resource= (Vercel multi-segment 404s).
+  const res3 = resSpy();
+  await handler(reqFor(['superadmin'], {}), res3, ['sync-log'], deps(makeClient()));
+  check('path form resolves the same resource', res3.out.statusCode === 200);
+}
+
+console.log('\nlisting + summary:');
+{
+  const client = makeClient([
+    { match: SUMMARY_RE, result: { rowCount: 1, rows: [{ total: '4', sent: '2', failed: '1', pending: '1', skipped: '0' }] } },
+    { match: LIST_RE, result: { rowCount: 1, rows: [LOG_ROW()] } },
+  ]);
+  const res = resSpy();
+  await handler(reqFor(['superadmin'], { resource: 'sync-log' }), res, [], deps(client));
+  check('returns rows', Array.isArray(res.out.body?.rows) && res.out.body.rows.length === 1);
+  check('returns a health summary (drives the failure alert)', res.out.body?.summary?.failed === 1 && res.out.body.summary.sent === 2);
+  check('summary counts are numbers, not strings', typeof res.out.body.summary.total === 'number');
+  const list = client.calls.find((c) => LIST_RE.test(c.sql) && /ORDER BY/i.test(c.sql));
+  check('newest-first (an ops log reads top-down)', /ORDER BY\s+id\s+DESC/i.test(list.sql));
+  check('client is released', client.released === 1);
+}
+
+console.log('\nfilters are parameterised (never string-interpolated):');
+{
+  const client = makeClient([{ match: LIST_RE, result: { rowCount: 0, rows: [] } }]);
+  const res = resSpy();
+  await handler(reqFor(['superadmin'], {
+    resource: 'sync-log', status: 'failed', source: 'podium',
+    event_type: 'workorder.review_request', q: "review_request:42'; DROP TABLE users;--",
+  }), res, [], deps(client));
+  // NB: pick the LIST query specifically — the summary query legitimately contains the
+  // literal 'failed' inside its count(*) FILTER, which would mask an interpolation bug.
+  const list = client.calls.find((c) => LIST_RE.test(c.sql) && /LIMIT/i.test(c.sql));
+  check('status filter is a bound param', list.params.includes('failed') && !/status = 'failed'/.test(list.sql));
+  check('source filter is a bound param', list.params.includes('podium') && !/'podium'/.test(list.sql));
+  check('event_type filter is a bound param', list.params.includes('workorder.review_request'));
+  check('a SQL-injection attempt stays in params, never in the SQL text', !/DROP TABLE/i.test(list.sql));
+  check('reference search uses a bound LIKE pattern', list.params.some((p) => String(p).includes('DROP TABLE')));
+}
+
+console.log('\nlimit:');
+{
+  const client = makeClient([{ match: LIST_RE, result: { rowCount: 0, rows: [] } }]);
+  const res = resSpy();
+  await handler(reqFor(['superadmin'], { resource: 'sync-log', limit: '9999' }), res, [], deps(client));
+  const list = client.calls.find((c) => LIST_RE.test(c.sql) && /LIMIT/i.test(c.sql));
+  check('an absurd limit is capped (no unbounded scan)', list.params.includes(200));
+
+  const client2 = makeClient([{ match: LIST_RE, result: { rowCount: 0, rows: [] } }]);
+  const res2 = resSpy();
+  await handler(reqFor(['superadmin'], { resource: 'sync-log', limit: 'abc' }), res2, [], deps(client2));
+  const list2 = client2.calls.find((c) => LIST_RE.test(c.sql) && /LIMIT/i.test(c.sql));
+  check('a junk limit falls back to the default', list2.params.includes(100));
+}
+
+console.log('\nbare-DB degrade (42P01):');
+{
+  const err = new Error('relation "integration_sync_log" does not exist'); err.code = '42P01';
+  const client = makeClient([{ match: LIST_RE, throws: err }]);
+  const res = resSpy();
+  await handler(reqFor(['superadmin'], { resource: 'sync-log' }), res, [], deps(client));
+  check('missing table → 200 with empty rows, not a 500', res.out.statusCode === 200 && res.out.body.rows.length === 0);
+  check('client still released on the degrade path', client.released === 1);
+}
+
+console.log(`\n✅ integrations smoke: ${passed} checks passed`);

--- a/scripts/podium-integrations-smoke.mjs
+++ b/scripts/podium-integrations-smoke.mjs
@@ -41,9 +41,11 @@ function resSpy() {
   };
 }
 
+// A real row: F8a is the writer that's actually on main, and its reference_id is
+// underscore-heavy, which is exactly what the LIKE-escaping below has to survive.
 const LOG_ROW = (over = {}) => ({
-  id: 9, source: 'podium', direction: 'outbound', event_type: 'workorder.review_request',
-  reference_id: 'review_request:42', status: 'sent', payload: { workorder_id: 42 },
+  id: 9, source: 'podium', direction: 'outbound', event_type: 'waitlist.back_in_stock',
+  reference_id: 'waitlist_back_in_stock:12', status: 'sent', payload: { waitlist_id: 12, sku: 'TM-95T' },
   error: null, created_at: '2026-07-17T01:00:00.000Z', ...over,
 });
 
@@ -139,19 +141,19 @@ console.log('\nfilters are parameterised (never string-interpolated):');
   const res = resSpy();
   await handler(reqFor(['superadmin'], {
     resource: 'sync-log', status: 'failed', source: 'podium',
-    event_type: 'workorder.review_request', q: "review_request:42'; DROP TABLE users;--",
+    event_type: 'waitlist.back_in_stock', q: "waitlist_back_in_stock:12'; DROP TABLE users;--",
   }), res, [], deps(client));
   // NB: pick the LIST query specifically — the summary legitimately contains the literal
   // 'failed' inside its count(*) FILTER, which would mask an interpolation bug.
   const list = pickList(client);
   // Position-blind `includes` would pass even if the placeholders were transposed, and
   // $n numbering is the whole point — assert the exact params, in order.
-  deepStrictEqual(list.params, ['podium', 'workorder.review_request', "%review\\_request:42'; DROP TABLE users;--%", 'failed', 100]);
+  deepStrictEqual(list.params, ['podium', 'waitlist.back_in_stock', "%waitlist\\_back\\_in\\_stock:12'; DROP TABLE users;--%", 'failed', 100]);
   check('list params bind source, event_type, q, status, limit in $1..$5 order', true);
   check('placeholders are sequential $1..$5', /source = \$1/.test(list.sql) && /event_type = \$2/.test(list.sql) && /\$3 ESCAPE/.test(list.sql) && /status = \$4/.test(list.sql) && /LIMIT \$5/.test(list.sql));
   check('no filter value is interpolated into the SQL text', !/'podium'/.test(list.sql) && !/status = 'failed'/.test(list.sql));
   check('a SQL-injection attempt stays in params, never in the SQL text', !/DROP TABLE/i.test(list.sql));
-  check('LIKE metacharacters in user text are escaped', list.params[2].includes('review\\_request'));
+  check('LIKE metacharacters in user text are escaped', list.params[2].includes('waitlist\\_back\\_in\\_stock'));
 }
 
 console.log('\nthe tiles keep telling the truth while you filter:');

--- a/src/App.js
+++ b/src/App.js
@@ -9,6 +9,7 @@ import Settings from './pages/settings';
 import Inbox from './pages/inbox';
 import Leads from './pages/leads';
 import AwaitingWorkorder from './pages/logistics/awaiting-workorder';
+import Integrations from './pages/integrations';
 
 import ProductsPage from './pages/products';
 import EditProduct from './pages/products/edit';
@@ -111,6 +112,7 @@ function App() {
         <Route path="/inbox" element={<Inbox />} />
         <Route path="/leads" element={<Leads />} />
         <Route path="/logistics/awaiting-workorder" element={<AwaitingWorkorder />} />
+        <Route path="/integrations" element={<Integrations />} />
 
         <Route path="/products" element={<ProductsPage />} />
         <Route path="/products/:sku/edit" element={<EditProduct />} />

--- a/src/pages/dashboard.js
+++ b/src/pages/dashboard.js
@@ -50,6 +50,9 @@ export default function Dashboard() {
   // F7b: the Awaiting-Workorder queue is a logistics tool (the server also gates
   // /api/logistics). superadmin sees it too.
   const canUseLogistics = hasAnyRole(getRoles(), ['logistics', 'superadmin']);
+  // F10: the Integrations log is an ops/observability tool (the server also gates
+  // /api/integrations to superadmin).
+  const canUseIntegrations = hasAnyRole(getRoles(), ['superadmin']);
 
   // base datasets
   const [products, setProducts] = useState([]);
@@ -314,6 +317,13 @@ export default function Dashboard() {
             <Link to="/peloton" className="text-gray-700 hover:bg-gray-200 p-2 rounded flex items-center gap-2">
               <span className="inline-block w-2 h-2 rounded-full bg-black flex-shrink-0" />
               Peloton
+            </Link>
+          )}
+
+          {/* Integrations observability — superadmin (F10) */}
+          {canUseIntegrations && (
+            <Link to="/integrations" className="text-gray-700 hover:bg-gray-200 p-2 rounded">
+              Integrations
             </Link>
           )}
 

--- a/src/pages/integrations.js
+++ b/src/pages/integrations.js
@@ -33,14 +33,14 @@ const ADMIN_ROLES = ['superadmin'];
 // Inbound  (F2 webhook):     received → processed | failed.
 const STATUSES = ['', 'sent', 'failed', 'pending', 'skipped', 'received', 'processed'];
 
-// Plain-English labels for the event types the integrations write. `delivery.booked` and
-// `workorder.review_request` arrive with PRs #72/#73; today only the first two occur.
+// Plain-English labels for the event types the integrations write. `delivery.booked`
+// arrives with PR #72; today only the first three occur. Anything unmapped falls back to
+// its raw event_type, so a new writer is never invisible here.
 const EVENT_LABELS = {
   'waitlist.back_in_stock': 'Waitlist — back in stock SMS',
   'message.received': 'Inbound message',
   'message.sent': 'Outbound message',
   'delivery.booked': 'Delivery booked SMS',
-  'workorder.review_request': 'Review request',
 };
 
 const STATUS_STYLES = {

--- a/src/pages/integrations.js
+++ b/src/pages/integrations.js
@@ -19,7 +19,7 @@
 // P1: the log holds envelope metadata only (ids, SKUs, event types) — no chat bodies were
 // ever written to it, so nothing here can leak message content.
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import BackButton from '../components/backbutton';
@@ -29,20 +29,26 @@ import { parseMaybeJson } from '../utils/http';
 
 const ADMIN_ROLES = ['superadmin'];
 
-const STATUSES = ['', 'sent', 'failed', 'pending', 'skipped'];
+// Outbound (F8 automations): pending → sent | failed | skipped.
+// Inbound  (F2 webhook):     received → processed | failed.
+const STATUSES = ['', 'sent', 'failed', 'pending', 'skipped', 'received', 'processed'];
 
-// Plain-English labels for the event types the integrations actually write.
+// Plain-English labels for the event types the integrations write. `delivery.booked` and
+// `workorder.review_request` arrive with PRs #72/#73; today only the first two occur.
 const EVENT_LABELS = {
   'waitlist.back_in_stock': 'Waitlist — back in stock SMS',
-  'delivery_booked': 'Delivery booked SMS',
+  'message.received': 'Inbound message',
+  'message.sent': 'Outbound message',
   'delivery.booked': 'Delivery booked SMS',
   'workorder.review_request': 'Review request',
 };
 
 const STATUS_STYLES = {
   sent: 'bg-green-100 text-green-800',
+  processed: 'bg-green-100 text-green-800',
   failed: 'bg-red-100 text-red-800',
   pending: 'bg-amber-100 text-amber-800',
+  received: 'bg-blue-100 text-blue-800',
   skipped: 'bg-gray-100 text-gray-700',
 };
 
@@ -77,12 +83,23 @@ export default function Integrations() {
 
   const [authorized, setAuthorized] = useState(false);
   const [rows, setRows] = useState([]);
-  const [summary, setSummary] = useState({ total: 0, sent: 0, failed: 0, pending: 0, skipped: 0 });
+  const [summary, setSummary] = useState({ total: 0, sent: 0, failed: 0, pending: 0, skipped: 0, received: 0, processed: 0, other: 0 });
+  const [matching, setMatching] = useState(0);
   const [unavailable, setUnavailable] = useState(false);
   const [loading, setLoading] = useState(true);
   const [status, setStatus] = useState('');
   const [q, setQ] = useState('');
+  const [debouncedQ, setDebouncedQ] = useState('');
   const [expanded, setExpanded] = useState(null);
+  // Guards against out-of-order responses: only the newest request may set state.
+  const reqIdRef = useRef(0);
+
+  // Debounce the free-text box — otherwise every keystroke fires a query (mirrors the
+  // F14 inbox search).
+  useEffect(() => {
+    const t = setTimeout(() => setDebouncedQ(q.trim()), 300);
+    return () => clearTimeout(t);
+  }, [q]);
 
   useEffect(() => {
     if (!getToken()) { navigate('/'); return; }
@@ -95,25 +112,29 @@ export default function Integrations() {
   }, [navigate]);
 
   const load = useCallback(async ({ silent = false } = {}) => {
+    const myReq = ++reqIdRef.current;
     if (!silent) setLoading(true);
     try {
       const params = new URLSearchParams({ resource: 'sync-log' });
       if (status) params.set('status', status);
-      if (q.trim()) params.set('q', q.trim());
+      if (debouncedQ) params.set('q', debouncedQ);
       const res = await fetch(`/api/integrations?${params.toString()}`, { headers: authHeaders() });
       if (res.status === 401) { navigate('/'); return; }
       if (res.status === 403) { toast.error('Integrations is for superadmins'); navigate('/dashboard'); return; }
       const data = await parseMaybeJson(res);
+      if (myReq !== reqIdRef.current) return; // a newer request won; drop this response
       if (!res.ok) { toast.error(data?.error || 'Could not load the integration log'); return; }
       setRows(Array.isArray(data?.rows) ? data.rows : []);
-      setSummary(data?.summary || { total: 0, sent: 0, failed: 0, pending: 0, skipped: 0 });
+      setSummary(data?.summary || { total: 0, sent: 0, failed: 0, pending: 0, skipped: 0, received: 0, processed: 0, other: 0 });
+      setMatching(Number(data?.matching || 0));
       setUnavailable(!!data?.unavailable);
+      setExpanded(null);
     } catch {
       toast.error('Server error loading the integration log');
     } finally {
-      if (!silent) setLoading(false);
+      if (!silent && myReq === reqIdRef.current) setLoading(false);
     }
-  }, [navigate, status, q]);
+  }, [navigate, status, debouncedQ]);
 
   useEffect(() => {
     if (authorized) load();
@@ -160,13 +181,22 @@ export default function Integrations() {
           </div>
         )}
 
-        <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-4">
+        {/* The tiles are status-agnostic on the server, so they keep showing the whole
+            health picture even while you're filtered into one status. */}
+        <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-3 mb-1">
           <Tile label="Total" value={summary.total} onClick={() => setStatus('')} active={status === ''} />
-          <Tile label="Sent" value={summary.sent} tone="good" onClick={() => toggleStatus('sent')} active={status === 'sent'} />
           <Tile label="Failed" value={summary.failed} tone="bad" onClick={() => toggleStatus('failed')} active={status === 'failed'} />
           <Tile label="Pending" value={summary.pending} tone="warn" onClick={() => toggleStatus('pending')} active={status === 'pending'} />
+          <Tile label="Sent" value={summary.sent} tone="good" onClick={() => toggleStatus('sent')} active={status === 'sent'} />
           <Tile label="Skipped" value={summary.skipped} onClick={() => toggleStatus('skipped')} active={status === 'skipped'} />
+          <Tile label="Received" value={summary.received} tone="warn" onClick={() => toggleStatus('received')} active={status === 'received'} />
+          <Tile label="Processed" value={summary.processed} tone="good" onClick={() => toggleStatus('processed')} active={status === 'processed'} />
         </div>
+        <p className="text-xs text-gray-500 mb-4">
+          Sent / Pending / Skipped are messages we send out. Received / Processed are events Podium
+          sends us. Failed covers both.
+          {summary.other > 0 && ` (${summary.other} with another status — use the dropdown.)`}
+        </p>
 
         <div className="flex flex-wrap items-center gap-2 mb-3">
           <select
@@ -185,7 +215,11 @@ export default function Integrations() {
             className="text-sm rounded border border-gray-300 px-2 py-1.5 bg-white flex-1 min-w-[12rem]"
           />
           <span className="text-sm text-gray-500">
-            {loading ? 'Loading…' : `${rows.length} shown`}
+            {loading
+              ? 'Loading…'
+              : matching > rows.length
+                ? `Showing the most recent ${rows.length} of ${matching}`
+                : `${rows.length} shown`}
           </span>
         </div>
 
@@ -248,8 +282,9 @@ export default function Integrations() {
         </div>
 
         <p className="text-xs text-gray-500 mt-3">
-          Newest first, most recent {rows.length} shown. Only what was sent is recorded — never the
-          text of a customer conversation (Podium holds that).
+          Newest first{matching > rows.length ? `, ${rows.length} of ${matching} shown — narrow the filters to see older entries` : ''}.
+          Only the fact of a message is recorded — never the text of a customer conversation
+          (Podium holds that).
         </p>
       </div>
     </div>

--- a/src/pages/integrations.js
+++ b/src/pages/integrations.js
@@ -1,0 +1,257 @@
+// src/pages/integrations.js — Integrations observability (feature F10).
+//
+// The superadmin read of `integration_sync_log` over the F10 backend
+// (lib/handlers/integrations.js → GET /api/integrations?resource=sync-log).
+//
+// Every Podium integration already writes here — the F2 webhook receiver dedupes inbound
+// events on it, and the F8 automations (waitlist back-in-stock, delivery-booked, review
+// request) claim and record every outbound send. Nothing surfaced it until now: a failed
+// customer SMS was invisible without a SQL console. This page answers the only question
+// ops actually has — "is anything failing?" — and the health tiles ARE the alert
+// (execution-plan §F10; a push/email alert is the next increment).
+//
+// A `failed` row matters: the F8 automations are AT-MOST-ONCE by design, so a failed send
+// is NOT retried. That customer did not get their message, and someone has to decide
+// whether to contact them by hand. Hence failures are called out, not just listed.
+//
+// Gated to superadmin (display-only here; the server re-checks on the login JWT). Query
+// form (?resource=) keeps us on the app's proven-safe single-segment routing convention.
+// P1: the log holds envelope metadata only (ids, SKUs, event types) — no chat bodies were
+// ever written to it, so nothing here can leak message content.
+
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import toast from 'react-hot-toast';
+import BackButton from '../components/backbutton';
+import HomeButton from '../components/homebutton';
+import { authHeaders, getToken, getRoles, hasAnyRole } from '../utils/auth';
+import { parseMaybeJson } from '../utils/http';
+
+const ADMIN_ROLES = ['superadmin'];
+
+const STATUSES = ['', 'sent', 'failed', 'pending', 'skipped'];
+
+// Plain-English labels for the event types the integrations actually write.
+const EVENT_LABELS = {
+  'waitlist.back_in_stock': 'Waitlist — back in stock SMS',
+  'delivery_booked': 'Delivery booked SMS',
+  'delivery.booked': 'Delivery booked SMS',
+  'workorder.review_request': 'Review request',
+};
+
+const STATUS_STYLES = {
+  sent: 'bg-green-100 text-green-800',
+  failed: 'bg-red-100 text-red-800',
+  pending: 'bg-amber-100 text-amber-800',
+  skipped: 'bg-gray-100 text-gray-700',
+};
+
+function when(iso) {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return '—';
+  return d.toLocaleString('en-AU', { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+function Tile({ label, value, tone = 'default', active, onClick }) {
+  const tones = {
+    default: 'border-gray-200',
+    good: 'border-green-200',
+    bad: value > 0 ? 'border-red-300 bg-red-50' : 'border-gray-200',
+    warn: value > 0 ? 'border-amber-300 bg-amber-50' : 'border-gray-200',
+  };
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`text-left rounded-lg border bg-white px-4 py-3 transition hover:shadow-sm ${tones[tone]} ${active ? 'ring-2 ring-offset-1 ring-gray-400' : ''}`}
+    >
+      <div className="text-xs uppercase tracking-wide text-gray-500">{label}</div>
+      <div className={`text-2xl font-semibold ${tone === 'bad' && value > 0 ? 'text-red-700' : 'text-gray-900'}`}>{value}</div>
+    </button>
+  );
+}
+
+export default function Integrations() {
+  const navigate = useNavigate();
+
+  const [authorized, setAuthorized] = useState(false);
+  const [rows, setRows] = useState([]);
+  const [summary, setSummary] = useState({ total: 0, sent: 0, failed: 0, pending: 0, skipped: 0 });
+  const [unavailable, setUnavailable] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const [status, setStatus] = useState('');
+  const [q, setQ] = useState('');
+  const [expanded, setExpanded] = useState(null);
+
+  useEffect(() => {
+    if (!getToken()) { navigate('/'); return; }
+    if (!hasAnyRole(getRoles(), ADMIN_ROLES)) {
+      toast.error('Integrations is for superadmins');
+      navigate('/dashboard');
+      return;
+    }
+    setAuthorized(true);
+  }, [navigate]);
+
+  const load = useCallback(async ({ silent = false } = {}) => {
+    if (!silent) setLoading(true);
+    try {
+      const params = new URLSearchParams({ resource: 'sync-log' });
+      if (status) params.set('status', status);
+      if (q.trim()) params.set('q', q.trim());
+      const res = await fetch(`/api/integrations?${params.toString()}`, { headers: authHeaders() });
+      if (res.status === 401) { navigate('/'); return; }
+      if (res.status === 403) { toast.error('Integrations is for superadmins'); navigate('/dashboard'); return; }
+      const data = await parseMaybeJson(res);
+      if (!res.ok) { toast.error(data?.error || 'Could not load the integration log'); return; }
+      setRows(Array.isArray(data?.rows) ? data.rows : []);
+      setSummary(data?.summary || { total: 0, sent: 0, failed: 0, pending: 0, skipped: 0 });
+      setUnavailable(!!data?.unavailable);
+    } catch {
+      toast.error('Server error loading the integration log');
+    } finally {
+      if (!silent) setLoading(false);
+    }
+  }, [navigate, status, q]);
+
+  useEffect(() => {
+    if (authorized) load();
+  }, [authorized, load]);
+
+  if (!authorized) return null;
+
+  const toggleStatus = (s) => setStatus((cur) => (cur === s ? '' : s));
+
+  return (
+    <div className="min-h-screen bg-gray-100 p-4 md:p-6">
+      <div className="max-w-6xl mx-auto">
+        <div className="flex items-center gap-2 mb-4">
+          <BackButton />
+          <HomeButton />
+          <div className="ml-auto">
+            <button
+              onClick={() => load()}
+              className="text-sm px-3 py-1.5 rounded border border-gray-300 bg-white hover:bg-gray-50"
+            >
+              Refresh
+            </button>
+          </div>
+        </div>
+
+        <h1 className="text-2xl font-semibold text-gray-900">Integrations</h1>
+        <p className="text-sm text-gray-600 mt-1 mb-4">
+          Every message the portal sends through Podium, and every event it receives, is recorded here.
+          Automated messages are sent <strong>once</strong> — a failure is not retried, so anything red
+          means that customer was never contacted.
+        </p>
+
+        {unavailable && (
+          <div className="mb-4 rounded border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+            The integration log table doesn’t exist on this database yet — it ships with the Podium
+            migration. Nothing is broken; there’s simply nothing to show.
+          </div>
+        )}
+
+        {summary.failed > 0 && (
+          <div className="mb-4 rounded border border-red-300 bg-red-50 px-4 py-3 text-sm text-red-900">
+            <strong>{summary.failed} failed {summary.failed === 1 ? 'message' : 'messages'}.</strong>{' '}
+            These were not retried automatically — check whether the customer needs contacting by hand.
+          </div>
+        )}
+
+        <div className="grid grid-cols-2 md:grid-cols-5 gap-3 mb-4">
+          <Tile label="Total" value={summary.total} onClick={() => setStatus('')} active={status === ''} />
+          <Tile label="Sent" value={summary.sent} tone="good" onClick={() => toggleStatus('sent')} active={status === 'sent'} />
+          <Tile label="Failed" value={summary.failed} tone="bad" onClick={() => toggleStatus('failed')} active={status === 'failed'} />
+          <Tile label="Pending" value={summary.pending} tone="warn" onClick={() => toggleStatus('pending')} active={status === 'pending'} />
+          <Tile label="Skipped" value={summary.skipped} onClick={() => toggleStatus('skipped')} active={status === 'skipped'} />
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 mb-3">
+          <select
+            value={status}
+            onChange={(e) => setStatus(e.target.value)}
+            className="text-sm rounded border border-gray-300 px-2 py-1.5 bg-white"
+          >
+            {STATUSES.map((s) => (
+              <option key={s || 'all'} value={s}>{s ? s[0].toUpperCase() + s.slice(1) : 'All statuses'}</option>
+            ))}
+          </select>
+          <input
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Search reference or error…"
+            className="text-sm rounded border border-gray-300 px-2 py-1.5 bg-white flex-1 min-w-[12rem]"
+          />
+          <span className="text-sm text-gray-500">
+            {loading ? 'Loading…' : `${rows.length} shown`}
+          </span>
+        </div>
+
+        <div className="bg-white rounded-lg border border-gray-200 overflow-x-auto">
+          <table className="min-w-full text-sm">
+            <thead className="bg-gray-50 text-gray-600">
+              <tr>
+                <th className="text-left px-3 py-2 font-medium">When</th>
+                <th className="text-left px-3 py-2 font-medium">Event</th>
+                <th className="text-left px-3 py-2 font-medium">Direction</th>
+                <th className="text-left px-3 py-2 font-medium">Reference</th>
+                <th className="text-left px-3 py-2 font-medium">Status</th>
+                <th className="text-left px-3 py-2 font-medium">Detail</th>
+              </tr>
+            </thead>
+            <tbody>
+              {!loading && rows.length === 0 && (
+                <tr>
+                  <td colSpan={6} className="px-3 py-8 text-center text-gray-500">
+                    Nothing logged yet. Automated messages appear here once Podium is live
+                    (they run in mock mode today, so nothing is actually sent).
+                  </td>
+                </tr>
+              )}
+              {rows.map((r) => (
+                <tr key={r.id} className={`border-t border-gray-100 ${r.status === 'failed' ? 'bg-red-50' : ''}`}>
+                  <td className="px-3 py-2 whitespace-nowrap text-gray-700">{when(r.created_at)}</td>
+                  <td className="px-3 py-2">
+                    <div className="text-gray-900">{EVENT_LABELS[r.event_type] || r.event_type}</div>
+                    <div className="text-xs text-gray-500">{r.source}</div>
+                  </td>
+                  <td className="px-3 py-2 text-gray-700">{r.direction}</td>
+                  <td className="px-3 py-2 font-mono text-xs text-gray-700">{r.reference_id || '—'}</td>
+                  <td className="px-3 py-2">
+                    <span className={`inline-block rounded px-2 py-0.5 text-xs font-medium ${STATUS_STYLES[r.status] || 'bg-gray-100 text-gray-700'}`}>
+                      {r.status}
+                    </span>
+                  </td>
+                  <td className="px-3 py-2">
+                    {r.error && <div className="text-xs text-red-700 mb-1">{r.error}</div>}
+                    {r.payload && (
+                      <button
+                        type="button"
+                        onClick={() => setExpanded(expanded === r.id ? null : r.id)}
+                        className="text-xs text-gray-600 underline"
+                      >
+                        {expanded === r.id ? 'Hide' : 'Show'} details
+                      </button>
+                    )}
+                    {expanded === r.id && (
+                      <pre className="mt-1 text-xs bg-gray-50 border border-gray-200 rounded p-2 overflow-x-auto">
+                        {JSON.stringify(r.payload, null, 2)}
+                      </pre>
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        <p className="text-xs text-gray-500 mt-3">
+          Newest first, most recent {rows.length} shown. Only what was sent is recorded — never the
+          text of a customer conversation (Podium holds that).
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## F10 — Integrations observability + ops runbook

`integration_sync_log` is where every Podium integration already writes — the F2 webhook receiver dedupes inbound events on it, and the F8 automations claim and record every outbound send. **Nothing surfaced it.** A failed customer SMS was invisible unless you opened a SQL console. F10 gives it a face (execution-plan §F10).

### Scope

| | |
|---|---|
| **New** | `lib/handlers/integrations.js` — `GET /api/integrations?resource=sync-log`, superadmin, **read-only** |
| **New** | `src/pages/integrations.js` — the ops page; health tiles double as filters *and* as the alert |
| **New** | `docs/PODIUM_OPS_RUNBOOK.md` — the runbook §F10 asks for |
| **Wired** | `integrations` case in `api/[...path].js` + `/integrations` route + superadmin nav |
| **Tests** | `scripts/podium-integrations-smoke.mjs` — **31 checks**, injected client, no DB |
| **Migration** | **None** — `integration_sync_log` ships in F0 `0001` |
| **Functions** | No new serverless fn (`nodejs:5`, same as `main`) |

### The thing worth understanding

The F8 automations are **at-most-once**: a failed send is **not retried**. So a red row means *that customer never got their message* and someone has to decide whether to contact them by hand. The page leads with that rather than just listing rows.

### Code review — it caught three real bugs

All three were the same question — *do the numbers on screen mean what they appear to mean?* — and all are fixed in `02e6856`:

1. **The tiles zeroed themselves the moment you used them.** The summary shared the list's predicate *including* `status`, so clicking "Failed" re-ran it as `WHERE status='failed'`: every other tile collapsed to `0`, and the alert banner became tautological. The summary now runs on a **status-agnostic** predicate — only the rows narrow. This broke the page's primary interaction.
2. **The tiles omitted the statuses that will dominate the table.** The webhook writes `received` → `processed`; I only counted the outbound vocabulary (`sent`/`failed`/`pending`/`skipped`). Every inbound row sat inside Total but in **no** bucket, so Total silently failed to add up, and there was no way to filter to them. Verified against `podiumWebhook.js` + `0001`'s `DEFAULT 'received'`. Added `received`/`processed` tiles + filters, plus an `other` count so Total always reconciles.
3. **The list was capped while the summary wasn't** — and my comment claimed the opposite. With 1,234 matches the Total read 1,234 while 100 rendered, unannounced. Now: *"Showing the most recent 100 of 1,234."*

Also fixed: labels for writers that don't exist here yet (only F8a + the webhook write today — `delivery.booked`/`workorder.review_request` arrive with #72/#73; I'd also invented a `delivery_booked` label, whereas F8b actually emits `delivery.booked`), unescaped LIKE metacharacters (underscore-heavy reference ids matched too broadly — bound, so never an injection risk), and a refetch-per-keystroke with no ordering guard (now debounced 300ms + request-id guard).

**The reviewer confirmed clean:** `$n` parameter numbering across all filter combinations, the superadmin gate, P1, client release/no-leak, and no writes.

**Two test weaknesses it caught, now fixed:** params were asserted with position-blind `includes` (a transposition would have passed) — now `deepStrictEqual` in `$1..$5` order; and nothing compared the summary's params to the list's, which is exactly where bug 1 lived. Both are now regression-tested.

### Deliberately deferred

**Alerting beyond the page** (push/email on repeated failures). The page *is* a passive alert — red banner, red tile, and the runbook points ops at it — and since `PODIUM_MOCK=true` nothing actually sends yet, so there is nothing to alert on until credentials flip. Note the criterion says *"alert on **repeated** failed"* and this fires on **any** failure; a repetition threshold belongs with real alerting. Smallest shippable, reviewable slice.

### Test steps (Preview)

1. Log in as superadmin → **Integrations** in the nav → `/integrations`. Non-superadmins shouldn't see the link, and hitting the URL directly should bounce them.
2. You'll see **6 demo rows** (seeded on dev — the table was empty because the automations are mock-first). One is deliberately `failed` → the red banner and red Failed tile should both appear.
3. **Click the "Failed" tile.** The rows narrow to the failure — and **every other tile keeps its number** (that's bug 1 above; the whole point).
4. Click it again to clear. Try the search box: `review_request` finds the review rows; typing is debounced.
5. **Show details** on a row → the envelope (ids/SKUs only). Confirm there is **no message text anywhere** — P1.

Offline, no DB: `node scripts/podium-integrations-smoke.mjs` → 31 checks.

### Dev demo seed — remove whenever you like

Six clearly-labelled rows (all `reference_id LIKE 'demo:%'`, the failed one's error says `DEMO ROW`). **Neon dev only.** Removal:

```sql
DELETE FROM integration_sync_log WHERE reference_id LIKE 'demo:%';
```

### Reviewer checklist

- [ ] The page answers "is anything failing?" at a glance.
- [ ] Superadmin-only is the right audience.
- [ ] The at-most-once framing (a failed row = *contact that customer by hand*) matches how you want ops to treat it.
- [ ] Deferring real alerting (and the "repeated" threshold) to a later increment is acceptable.
- [ ] `docs/PODIUM_OPS_RUNBOOK.md` reads as something a non-developer could actually follow at 2am — **that's the bit worth your eyes**; it documents the one `DELETE` that unblocks a stuck `pending` reference.
- [ ] Delete the demo rows (SQL above) whenever you're done looking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
