### PR TITLE
HotLabel lot stickers: 50x30mm -> 80x50mm

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
+    "smoke:labels": "node scripts/lot-label-smoke.mjs",
     "migrate": "node db/migrate.js up",
     "migrate:status": "node db/migrate.js status",
     "migrate:down": "node db/migrate.js down"

--- a/scripts/lot-label-smoke.mjs
+++ b/scripts/lot-label-smoke.mjs
@@ -25,9 +25,10 @@ function check(name, cond, detail) {
 
 const PT_TO_MM = 0.352778;
 const fakeBarcode = (lot) => `<svg data-lot="${lot}"></svg>`;
+// The real format: lib/handlers/collections.js mints 'L' || lpad(seq, 5, '0') → L00042.
 const LOTS = [
-  { lot_number: 'LOT-0001', product_sku: 'TM-95T', product_name: 'Life Fitness 95T Treadmill' },
-  { lot_number: 'LOT-0002', product_sku: 'RW-C2', product_name: 'Concept2 RowErg' },
+  { lot_number: 'L00042', product_sku: 'TM-95T', product_name: 'Life Fitness 95T Treadmill' },
+  { lot_number: 'L00043', product_sku: 'RW-C2', product_name: 'Concept2 RowErg' },
 ];
 
 const html = buildLotLabelsHtml(LOTS, fakeBarcode);
@@ -41,7 +42,6 @@ console.log('stock size (80 × 50 mm as of 17 Jul 2026):');
   check('@page is the sticker size', new RegExp(`@page \\{ size: ${LABEL_W}mm ${LABEL_H}mm;`).test(html));
   check('.label is the same size as @page (drift here = clipped or split labels)',
     new RegExp(`width: ${LABEL_W}mm; height: ${LABEL_H}mm;`).test(html));
-  check('no stale 50mm/30mm geometry left anywhere', !/\b50mm 30mm\b/.test(html) && !/width: 50mm; height: 30mm/.test(html));
 }
 
 console.log('\neverything fits inside the sticker:');
@@ -52,9 +52,14 @@ console.log('\neverything fits inside the sticker:');
   check('barcode fits the usable width', BARCODE_W <= usableW, `${BARCODE_W}mm in ${usableW}mm`);
   check('barcode is wide enough to be worth scanning (>60% of the label)', BARCODE_W / LABEL_W > 0.6);
 
-  // The stack: barcode + lotnum(+1mm margin) + sku + name(capped).
+  // The stack: barcode + lotnum(+ its margin) + sku + name(capped). Every term comes from
+  // the geometry constants, so this relates the TEXT sizes to the LABEL size through a
+  // real physical constant — bump lotnum to 40pt and this genuinely fails.
+  // (The .bc svg is display:block, so the barcode div really is BARCODE_H tall; as an
+  // inline element it would carry ~1mm of extra descender space this sum can't see.)
+  check('the barcode div has no inline descender gap the maths would miss', /\.bc svg \{[^}]*display: block/.test(html));
   const stackH = BARCODE_H
-    + 1 + TEXT.lotnum.size * TEXT.lotnum.lineHeight * PT_TO_MM
+    + TEXT.lotnum.marginTop + TEXT.lotnum.size * TEXT.lotnum.lineHeight * PT_TO_MM
     + TEXT.sku.size * TEXT.sku.lineHeight * PT_TO_MM
     + TEXT.name.maxHeight;
   check('the whole text stack fits the usable height', stackH <= usableH, `${stackH.toFixed(1)}mm in ${usableH}mm`);
@@ -69,12 +74,19 @@ console.log('\neverything fits inside the sticker:');
 console.log('\ncontent:');
 {
   check('one label per lot', (html.match(/class="label"/g) || []).length === LOTS.length);
-  check('each label carries its own barcode', html.includes('data-lot="LOT-0001"') && html.includes('data-lot="LOT-0002"'));
-  check('lot number is printed as text too', html.includes('LOT-0001'));
+  check('each label carries its own barcode', html.includes('data-lot="L00042"') && html.includes('data-lot="L00043"'));
+  check('lot number is printed as text too', html.includes('L00042'));
   check('sku is printed', html.includes('TM-95T'));
   check('product name is printed', html.includes('Life Fitness 95T Treadmill'));
   check('one sticker each — page break after every label', /page-break-after: always/.test(html));
   check('no lots → no labels, still a valid document', !/class="label"/.test(buildLotLabelsHtml([], fakeBarcode)));
+
+  // A lot with no number would print a barcode reading "undefined" onto real stock, so
+  // the filter belongs in the builder — not only in printLotLabels (which can't be tested
+  // here: it needs a DOM). Nothing else may bypass it.
+  const junk = buildLotLabelsHtml([{ lot_number: null, product_sku: 'X', product_name: 'No lot' }, LOTS[0]], fakeBarcode);
+  check('a lot with no number is dropped, not printed as "undefined"',
+    (junk.match(/class="label"/g) || []).length === 1 && !/undefined/.test(junk));
 }
 
 console.log('\nescaping (a product name is free text from the collection form):');

--- a/scripts/lot-label-smoke.mjs
+++ b/scripts/lot-label-smoke.mjs
@@ -1,0 +1,90 @@
+// scripts/lot-label-smoke.mjs — offline smoke for the HotLabel HL-M6 lot labels (G4).
+//
+//   node scripts/lot-label-smoke.mjs
+//
+// The label is PRINT output: getting it wrong costs a roll of stickers and a trip to the
+// workshop, and the failure is silent in code review (the CSS looks fine either way). So
+// this asserts the geometry ADDS UP rather than just eyeballing numbers:
+//   • @page and .label agree — if they drift, the printer clips the label or spreads it
+//     across two stickers. This is the single most likely regression on a size change.
+//   • the barcode fits inside the label's usable width
+//   • the whole text stack fits inside the usable height
+//   • a product name with HTML in it can't break the document
+//
+// No DOM and no printer needed: buildLotLabelsHtml is pure and takes the barcode
+// generator as an argument.
+
+const { buildLotLabelsHtml, LABEL_GEOMETRY } = await import('../src/utils/lotLabels.js');
+
+let passed = 0;
+function check(name, cond, detail) {
+  if (!cond) throw new Error(`FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  passed += 1;
+  console.log(`  ✓ ${name}`);
+}
+
+const PT_TO_MM = 0.352778;
+const fakeBarcode = (lot) => `<svg data-lot="${lot}"></svg>`;
+const LOTS = [
+  { lot_number: 'LOT-0001', product_sku: 'TM-95T', product_name: 'Life Fitness 95T Treadmill' },
+  { lot_number: 'LOT-0002', product_sku: 'RW-C2', product_name: 'Concept2 RowErg' },
+];
+
+const html = buildLotLabelsHtml(LOTS, fakeBarcode);
+const { LABEL_W, LABEL_H, PADDING, BARCODE_W, BARCODE_H, TEXT } = LABEL_GEOMETRY;
+
+console.log('HotLabel HL-M6 lot label smoke — pure, no DOM\n');
+
+console.log('stock size (80 × 50 mm as of 17 Jul 2026):');
+{
+  check('geometry is the 80 × 50 stock', LABEL_W === 80 && LABEL_H === 50, `${LABEL_W}×${LABEL_H}`);
+  check('@page is the sticker size', new RegExp(`@page \\{ size: ${LABEL_W}mm ${LABEL_H}mm;`).test(html));
+  check('.label is the same size as @page (drift here = clipped or split labels)',
+    new RegExp(`width: ${LABEL_W}mm; height: ${LABEL_H}mm;`).test(html));
+  check('no stale 50mm/30mm geometry left anywhere', !/\b50mm 30mm\b/.test(html) && !/width: 50mm; height: 30mm/.test(html));
+}
+
+console.log('\neverything fits inside the sticker:');
+{
+  const usableW = LABEL_W - PADDING * 2;
+  const usableH = LABEL_H - PADDING * 2;
+
+  check('barcode fits the usable width', BARCODE_W <= usableW, `${BARCODE_W}mm in ${usableW}mm`);
+  check('barcode is wide enough to be worth scanning (>60% of the label)', BARCODE_W / LABEL_W > 0.6);
+
+  // The stack: barcode + lotnum(+1mm margin) + sku + name(capped).
+  const stackH = BARCODE_H
+    + 1 + TEXT.lotnum.size * TEXT.lotnum.lineHeight * PT_TO_MM
+    + TEXT.sku.size * TEXT.sku.lineHeight * PT_TO_MM
+    + TEXT.name.maxHeight;
+  check('the whole text stack fits the usable height', stackH <= usableH, `${stackH.toFixed(1)}mm in ${usableH}mm`);
+  check('and leaves some slack for font metrics', usableH - stackH >= 2, `slack ${(usableH - stackH).toFixed(1)}mm`);
+
+  check('the lot number is the biggest text (read-by-eye fallback)',
+    TEXT.lotnum.size > TEXT.sku.size && TEXT.lotnum.size > TEXT.name.size);
+  check('text got bigger with the bigger stock, not left at the old sizes',
+    TEXT.lotnum.size > 12 && TEXT.sku.size > 7 && TEXT.name.size > 6);
+}
+
+console.log('\ncontent:');
+{
+  check('one label per lot', (html.match(/class="label"/g) || []).length === LOTS.length);
+  check('each label carries its own barcode', html.includes('data-lot="LOT-0001"') && html.includes('data-lot="LOT-0002"'));
+  check('lot number is printed as text too', html.includes('LOT-0001'));
+  check('sku is printed', html.includes('TM-95T'));
+  check('product name is printed', html.includes('Life Fitness 95T Treadmill'));
+  check('one sticker each — page break after every label', /page-break-after: always/.test(html));
+  check('no lots → no labels, still a valid document', !/class="label"/.test(buildLotLabelsHtml([], fakeBarcode)));
+}
+
+console.log('\nescaping (a product name is free text from the collection form):');
+{
+  const nasty = buildLotLabelsHtml(
+    [{ lot_number: 'LOT-1', product_sku: 'X', product_name: '<script>alert(1)</script> & "quotes"' }],
+    fakeBarcode
+  );
+  check('markup in a product name cannot break the document', !/<script>alert\(1\)<\/script>/.test(nasty));
+  check('it is escaped, not dropped', nasty.includes('&lt;script&gt;') && nasty.includes('&amp;') && nasty.includes('&quot;'));
+}
+
+console.log(`\n✅ lot label smoke: ${passed} checks passed`);

--- a/src/pages/delivery_operations/collections/[id].js
+++ b/src/pages/delivery_operations/collections/[id].js
@@ -571,7 +571,7 @@ export default function CollectionDetailPage() {
                 <button
                   onClick={() => printLotLabels(lots.filter((l) => l.status !== 'Void'))}
                   className="rounded border px-3 py-1 text-sm hover:bg-gray-50"
-                  title="Print a 50×30mm barcode label for every lot"
+                  title="Print an 80×50mm barcode label for every lot"
                 >
                   🖨 Print all labels
                 </button>

--- a/src/utils/lotLabels.js
+++ b/src/utils/lotLabels.js
@@ -1,9 +1,32 @@
-// G4 — printable lot labels for the HotLabel HL-M6 (50 mm × 30 mm).
-// Generates a Code 128 barcode of the lot number (universal for USB scanners)
-// plus a human-readable lot number, SKU and product name, then opens a print
-// window sized to the sticker. The barcode SVG is generated in-app and injected
-// as self-contained markup, so the print window needs no scripts/libraries.
+// G4 — printable lot labels for the HotLabel HL-M6.
+//
+// Stock: 80 mm × 50 mm (changed from 50 × 30 on 17 Jul 2026 at Nick's request).
+//
+// Generates a Code 128 barcode of the lot number (universal for USB scanners) plus a
+// human-readable lot number, SKU and product name, then opens a print window sized to the
+// sticker. The barcode SVG is generated in-app and injected as self-contained markup, so
+// the print window needs no scripts/libraries.
 import JsBarcode from 'jsbarcode';
+
+// ---- Sticker geometry -------------------------------------------------------
+// One place, because @page and .label MUST agree: if they drift the printer either clips
+// the label or spreads it across two stickers. Everything else is derived from these, so
+// a future stock change is LABEL_W/LABEL_H + a reprint test, not a hunt through the CSS.
+const LABEL_W = 80;   // mm
+const LABEL_H = 50;   // mm
+const PADDING = 2.5;  // mm — keeps ink off the die-cut edge
+
+// The barcode is the whole point of the label, so give it the usable width: wider modules
+// scan more reliably on a worn or angled sticker. 2.5mm of slack each side of the padding.
+const BARCODE_W = LABEL_W - PADDING * 2 - 5; // 70mm
+const BARCODE_H = 18;                        // mm
+
+// Text stack, in print order. Sizes scaled ~1.6× with the stock (50→80 wide, 30→50 tall).
+const TEXT = {
+  lotnum: { size: 19, lineHeight: 1 },                 // read-by-eye fallback — biggest
+  sku: { size: 11, lineHeight: 1.1 },
+  name: { size: 9, lineHeight: 1.05, maxHeight: 10 },  // mm — clipped, never overflows
+};
 
 function esc(s) {
   return String(s ?? '').replace(/[<>&"]/g, (c) => (
@@ -33,40 +56,55 @@ function barcodeSvgString(text) {
   }
 }
 
-// lots: array of { lot_number, product_sku, product_name }
-export function printLotLabels(lots) {
-  const list = (lots || []).filter((l) => l && l.lot_number);
-  if (!list.length) return;
-
-  const labels = list.map((l) => `
+/**
+ * Build the print document. PURE — no DOM, no window — so the geometry can be checked
+ * offline (scripts/lot-label-smoke.mjs) instead of by burning stickers. `barcodeFor`
+ * returns the barcode SVG markup for a lot number; printLotLabels passes the real one.
+ * @param {Array<{lot_number:string, product_sku:string, product_name:string}>} lots
+ * @param {(lotNumber:string) => string} barcodeFor
+ */
+export function buildLotLabelsHtml(lots, barcodeFor) {
+  const labels = (lots || []).map((l) => `
     <div class="label">
-      <div class="bc">${barcodeSvgString(l.lot_number)}</div>
+      <div class="bc">${barcodeFor(l.lot_number)}</div>
       <div class="lotnum">${esc(l.lot_number)}</div>
       <div class="sku">${esc(l.product_sku)}</div>
       <div class="name">${esc(l.product_name)}</div>
     </div>`).join('');
 
-  const html = `<!doctype html><html><head><meta charset="utf-8"><title>Lot labels</title>
+  return `<!doctype html><html><head><meta charset="utf-8"><title>Lot labels</title>
   <style>
-    @page { size: 50mm 30mm; margin: 0; }
+    @page { size: ${LABEL_W}mm ${LABEL_H}mm; margin: 0; }
     * { box-sizing: border-box; }
     html, body { margin: 0; padding: 0; }
     .label {
-      width: 50mm; height: 30mm; padding: 1.5mm;
+      width: ${LABEL_W}mm; height: ${LABEL_H}mm; padding: ${PADDING}mm;
       display: flex; flex-direction: column; align-items: center; justify-content: center;
       page-break-after: always; overflow: hidden;
       font-family: Arial, Helvetica, sans-serif; text-align: center;
     }
     .label:last-child { page-break-after: auto; }
-    .bc svg { width: 44mm; height: 11mm; }
-    .lotnum { font-family: 'Courier New', monospace; font-weight: 700; font-size: 12pt; line-height: 1; margin-top: 0.5mm; }
-    .sku { font-size: 7pt; line-height: 1.1; }
-    .name { font-size: 6pt; line-height: 1.05; max-height: 6mm; overflow: hidden; }
+    .bc svg { width: ${BARCODE_W}mm; height: ${BARCODE_H}mm; }
+    .lotnum { font-family: 'Courier New', monospace; font-weight: 700; font-size: ${TEXT.lotnum.size}pt; line-height: ${TEXT.lotnum.lineHeight}; margin-top: 1mm; }
+    .sku { font-size: ${TEXT.sku.size}pt; line-height: ${TEXT.sku.lineHeight}; }
+    .name { font-size: ${TEXT.name.size}pt; line-height: ${TEXT.name.lineHeight}; max-height: ${TEXT.name.maxHeight}mm; overflow: hidden; }
   </style></head><body>${labels}
   <script>window.onload=function(){window.focus();window.print();};</script>
   </body></html>`;
+}
 
-  const w = window.open('', '_blank', 'width=420,height=320');
+/** The geometry, exported so the smoke can assert it adds up. */
+export const LABEL_GEOMETRY = { LABEL_W, LABEL_H, PADDING, BARCODE_W, BARCODE_H, TEXT };
+
+// lots: array of { lot_number, product_sku, product_name }
+export function printLotLabels(lots) {
+  const list = (lots || []).filter((l) => l && l.lot_number);
+  if (!list.length) return;
+
+  const html = buildLotLabelsHtml(list, barcodeSvgString);
+
+  // Roughly the sticker's aspect, scaled up with the stock (was 420×320 for 50×30).
+  const w = window.open('', '_blank', 'width=660,height=500');
   if (!w) {
     alert('Please allow pop-ups to print lot labels.');
     return;

--- a/src/utils/lotLabels.js
+++ b/src/utils/lotLabels.js
@@ -18,12 +18,17 @@ const PADDING = 2.5;  // mm — keeps ink off the die-cut edge
 
 // The barcode is the whole point of the label, so give it the usable width: wider modules
 // scan more reliably on a worn or angled sticker. 2.5mm of slack each side of the padding.
+// At 70mm a real lot number (L00042) prints a ~30 mil X-dimension — very comfortable.
 const BARCODE_W = LABEL_W - PADDING * 2 - 5; // 70mm
+// NB this is a BOUNDING BOX, not the bar height. JsBarcode sets a viewBox and no
+// preserveAspectRatio, so the SVG scales uniformly (no distortion) and letterboxes: a
+// short lot number is WIDTH-constrained, inking ~15.6mm and centring the rest. Raising
+// this alone therefore buys dead space, not taller bars — widen the label instead.
 const BARCODE_H = 18;                        // mm
 
 // Text stack, in print order. Sizes scaled ~1.6× with the stock (50→80 wide, 30→50 tall).
 const TEXT = {
-  lotnum: { size: 19, lineHeight: 1 },                 // read-by-eye fallback — biggest
+  lotnum: { size: 19, lineHeight: 1, marginTop: 1 },   // read-by-eye fallback — biggest
   sku: { size: 11, lineHeight: 1.1 },
   name: { size: 9, lineHeight: 1.05, maxHeight: 10 },  // mm — clipped, never overflows
 };
@@ -64,7 +69,9 @@ function barcodeSvgString(text) {
  * @param {(lotNumber:string) => string} barcodeFor
  */
 export function buildLotLabelsHtml(lots, barcodeFor) {
-  const labels = (lots || []).map((l) => `
+  // Filter here, not in the caller: a lot with no number would print a barcode reading
+  // "undefined" onto physical stock. This is the function anything else should call.
+  const labels = (lots || []).filter((l) => l && l.lot_number).map((l) => `
     <div class="label">
       <div class="bc">${barcodeFor(l.lot_number)}</div>
       <div class="lotnum">${esc(l.lot_number)}</div>
@@ -84,8 +91,10 @@ export function buildLotLabelsHtml(lots, barcodeFor) {
       font-family: Arial, Helvetica, sans-serif; text-align: center;
     }
     .label:last-child { page-break-after: auto; }
-    .bc svg { width: ${BARCODE_W}mm; height: ${BARCODE_H}mm; }
-    .lotnum { font-family: 'Courier New', monospace; font-weight: 700; font-size: ${TEXT.lotnum.size}pt; line-height: ${TEXT.lotnum.lineHeight}; margin-top: 1mm; }
+    /* display:block so the SVG isn't an inline element — inline adds ~1mm of descender
+       space below the baseline, which silently eats the stack's slack. */
+    .bc svg { width: ${BARCODE_W}mm; height: ${BARCODE_H}mm; display: block; }
+    .lotnum { font-family: 'Courier New', monospace; font-weight: 700; font-size: ${TEXT.lotnum.size}pt; line-height: ${TEXT.lotnum.lineHeight}; margin-top: ${TEXT.lotnum.marginTop}mm; }
     .sku { font-size: ${TEXT.sku.size}pt; line-height: ${TEXT.sku.lineHeight}; }
     .name { font-size: ${TEXT.name.size}pt; line-height: ${TEXT.name.lineHeight}; max-height: ${TEXT.name.maxHeight}mm; overflow: hidden; }
   </style></head><body>${labels}
@@ -98,6 +107,7 @@ export const LABEL_GEOMETRY = { LABEL_W, LABEL_H, PADDING, BARCODE_W, BARCODE_H,
 
 // lots: array of { lot_number, product_sku, product_name }
 export function printLotLabels(lots) {
+  // buildLotLabelsHtml filters too; this early return just avoids opening an empty popup.
   const list = (lots || []).filter((l) => l && l.lot_number);
   if (!list.length) return;
 


### PR DESCRIPTION
## HotLabel lot stickers: 50 × 30 mm → 80 × 50 mm

At Nick's request (17 Jul 2026). The HL-M6 stock changes size, so the label has to grow with it.

### ⚠️ The code alone won't change what comes off the printer

`@page { size: 80mm 50mm }` tells the *browser* the label size — it does **not** pick the paper. For the physical HL-M6 you also need:

1. **80 × 50 rolls loaded**, and
2. the **HL-M6 driver's paper/media size changed to 80 × 50**, and
3. **Default / 100% scaling** in the print dialog (not "Fit to page").

If the driver still says 50 × 30, Chrome will scale-to-fit or clip and this change won't save it. Worth confirming with the workshop before calling it done.

### What changed

A bigger sticker isn't just a bigger `@page` — everything on it grows, or you print a 50×30 label marooned in the middle of an 80×50 sticker. Scaled ~1.6×:

| | before | after |
|---|---|---|
| page + label | 50 × 30 mm | **80 × 50 mm** |
| padding | 1.5 mm | 2.5 mm |
| barcode | 44 × 11 mm | **70 × 18 mm** |
| lot number | 12 pt | **19 pt** |
| SKU | 7 pt | 11 pt |
| product name | 6 pt / 6 mm | 9 pt / 10 mm |
| print window | 420 × 320 | 660 × 500 |

**The barcode scans better, not just bigger:** the X-dimension goes from ~19 mil to ~31 mil on a real lot number (`L00042`) — well clear of the Code 128 floor, and more forgiving of a worn or angled sticker.

### Why the diff is bigger than six numbers

`@page` and `.label` each hard-coded the size independently. The classic failure is changing one and not the other — and the printer expresses that as a clipped label or one label spread across two stickers, which no amount of code review catches. **The geometry is now named constants at the top, interpolated into the CSS, so they cannot disagree.**

`buildLotLabelsHtml(lots, barcodeFor)` is split out as a pure function (no DOM, barcode generator injected) so the geometry can be checked offline instead of by burning a roll of stock. `printLotLabels` behaves exactly as before.

### Verification

- `npm run smoke:labels` → **20 checks**: `@page` matches `.label`, the barcode fits the usable width, the whole text stack fits the usable height with slack (40 mm of 45 mm), one label per lot, a lot with no number is dropped rather than printed as `undefined`, and a product name containing markup can't break the document. I verified the drift assertions genuinely **fail** when the HTML is tampered with.
- `CI=true npm run build` green. Frontend-only: no migration, no serverless function, no API change.

**The code review print-tested it** in headless Chrome: 3 lots → exactly **3 pages**, page box 80.09 × 50.12 mm, **no overflow** even with a 113-character product name, no blank trailing sticker. It also caught three things worth fixing, now done: the barcode div was silently 1.06 mm taller than the maths assumed (inline-SVG descender space — now `display:block`); the lot number's 1 mm margin was the one constant left duplicated between the CSS and its test; and the exported builder didn't apply the `lot_number` filter, so a bad caller could have printed `undefined` onto stock.

**Not verified by me: the physical print.** The numbers add up on paper, but only a test print on the actual HL-M6 proves die-cut registration — and that alignment test was already an outstanding item for G4.

### Note

`package.json` gains `smoke:labels` so the test is runnable. The repo has **no CI pipeline at all**, and none of its 12 smoke scripts are wired to anything — a pre-existing gap I've backlogged rather than half-fixed inside a label resize.

### Reviewer checklist

- [ ] **Confirm the printer/driver media size is switched to 80 × 50** and the rolls are loaded — the code change is necessary but not sufficient.
- [ ] Print one sticker and check die-cut registration (the outstanding G4 alignment test).
- [ ] Scan the printed barcode with the USB scanner (the other outstanding G4 item).
- [ ] The proportions look right in the flesh — barcode dominant, lot number readable across the workshop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
