### PR TITLE
F24 — CI pipeline + auto-discovered smoke runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+# Runs on every PR and on pushes to main. Until now the ~470 smoke checks only ran when an
+# agent remembered to; on a human PR they never ran. This is the gate that catches the next
+# size/gate/predicate regression before a reviewer ever sees it.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+# A newer push to the same ref supersedes an in-flight run.
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build-and-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # CRA treats warnings as errors under CI=true (GitHub Actions sets CI=true itself, but
+      # we set it explicitly so the gate is obvious and matches the local build command).
+      - name: Build
+        run: npm run build
+        env:
+          CI: true
+
+      # Every scripts/*-smoke.mjs, discovered automatically. A red suite fails this step.
+      - name: Smoke suites
+        run: npm run smoke

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build": "react-scripts build",
     "test": "react-scripts test",
     "eject": "react-scripts eject",
+    "smoke": "node scripts/smoke-runner.mjs",
     "smoke:labels": "node scripts/lot-label-smoke.mjs",
     "migrate": "node db/migrate.js up",
     "migrate:status": "node db/migrate.js status",

--- a/scripts/fixtures/green/ok-smoke.mjs
+++ b/scripts/fixtures/green/ok-smoke.mjs
@@ -1,0 +1,3 @@
+// Fixture for the smoke-runner self-test: a suite that passes (exit 0). Lives in a subdir
+// of scripts/, so the runner's non-recursive discovery never picks it up in a normal run.
+console.log('  ✓ fixture ok');

--- a/scripts/fixtures/red/broken-smoke.mjs
+++ b/scripts/fixtures/red/broken-smoke.mjs
@@ -1,0 +1,3 @@
+// Fixture: a suite that fails the way real suites do — a thrown check → uncaught → exit 1.
+// The self-test points the real runner at this dir and asserts the runner exits non-zero.
+throw new Error('FAIL: deliberate fixture failure');

--- a/scripts/fixtures/red/ok-smoke.mjs
+++ b/scripts/fixtures/red/ok-smoke.mjs
@@ -1,0 +1,3 @@
+// Fixture: a passing suite that shares the "red" dir with a failing one, to prove a red
+// suite does not stop the others (and the runner still exits non-zero overall).
+console.log('  ✓ fixture ok (in red dir)');

--- a/scripts/smoke-runner-smoke.mjs
+++ b/scripts/smoke-runner-smoke.mjs
@@ -3,13 +3,21 @@
 // The runner (scripts/smoke-runner.mjs) is what CI calls via `npm run smoke`. Its whole
 // job is: discover every offline suite and FAIL THE PROCESS if any one of them fails. If
 // that exit-code contract ever breaks, CI would go green over a red suite — the exact
-// regression F24 exists to prevent — so the contract itself needs coverage. No network,
-// no database, no child processes: runSuites takes an injected `run`, so we test the
-// aggregation/exit logic directly.
+// regression F24 exists to prevent — so the contract itself needs coverage.
+//
+// Most checks are pure (injected `run`, no processes). A few deliberately spawn the real
+// runner against fixture suites, because the two links that actually make CI go red — the
+// real exit-code → boolean mapping in runOne(), and the process.exit(1) in the main block
+// — can only be proven with real child processes, not an injected run().
 //
 //   node scripts/smoke-runner-smoke.mjs
 
-import { runSuites, discoverSuites } from './smoke-runner.mjs';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { runSuites, discoverSuites, runOne } from './smoke-runner.mjs';
+
+const fixture = (rel) => fileURLToPath(new URL(rel, import.meta.url));
+const RUNNER = fixture('./smoke-runner.mjs');
 
 let passed = 0;
 function check(name, cond, detail) {
@@ -20,7 +28,7 @@ function check(name, cond, detail) {
 
 const silent = () => {};
 
-console.log('smoke-runner smoke — no DB, no network, no child processes\n');
+console.log('smoke-runner smoke — no DB, no network (a few real child processes for the exit-code path)\n');
 
 console.log('exit-code contract (a failing suite must fail the run):');
 {
@@ -55,14 +63,34 @@ console.log('\nevery suite runs (no silent truncation — F24 exists because sui
   check('runSuites invokes run() once per file, in order', seen.join(',') === '1-smoke.mjs,2-smoke.mjs,3-smoke.mjs');
 }
 
+console.log('\nreal exit-code mapping (runOne spawns a real child — this is what CI trusts):');
+{
+  // stdio:'ignore' keeps the throwing fixture's stack out of the CI log; real runs inherit.
+  check('runOne: a suite that exits 0 → true', (await runOne(fixture('./fixtures/green/ok-smoke.mjs'), { stdio: 'ignore' })) === true);
+  check('runOne: a suite that throws (exit 1) → false', (await runOne(fixture('./fixtures/red/broken-smoke.mjs'), { stdio: 'ignore' })) === false);
+}
+
+console.log('\nend-to-end (the runner PROCESS exits non-zero when a suite fails):');
+{
+  const runnerExit = (dir) =>
+    new Promise((res) => {
+      const c = spawn(process.execPath, [RUNNER, dir], { stdio: 'ignore' });
+      c.on('close', (code) => res(code));
+    });
+  check('an all-green fixture dir → runner exits 0', (await runnerExit(fixture('./fixtures/green'))) === 0);
+  check('a fixture dir with one red suite → runner exits non-zero', (await runnerExit(fixture('./fixtures/red'))) !== 0);
+}
+
 console.log('\ndiscovery (auto-find suites so a new one is never forgotten):');
 {
   const suites = discoverSuites().map((p) => p.replace(/\\/g, '/'));
   const bases = suites.map((p) => p.split('/').pop());
   check('discovers a non-empty set of suites', suites.length > 0);
+  // The real suite count is well into double digits; a threshold catches accidental
+  // narrowing of the glob without pinning every filename.
+  check('discovers the full suite set, not a narrowed subset', suites.length >= 10, `found ${suites.length}`);
   check('every discovered file is a *-smoke.mjs', bases.every((b) => b.endsWith('-smoke.mjs')));
   check('includes a known existing suite', bases.includes('podium-rbac-smoke.mjs'));
-  check('includes a second known suite', bases.includes('podium-leads-smoke.mjs'));
   // Recursion guard: the runner ends in "-runner.mjs", not "-smoke.mjs", so it must never
   // discover (and re-spawn) itself.
   check('does NOT discover the runner itself', !bases.includes('smoke-runner.mjs'));

--- a/scripts/smoke-runner-smoke.mjs
+++ b/scripts/smoke-runner-smoke.mjs
@@ -1,0 +1,74 @@
+// scripts/smoke-runner-smoke.mjs — offline smoke for the CI smoke-runner itself.
+//
+// The runner (scripts/smoke-runner.mjs) is what CI calls via `npm run smoke`. Its whole
+// job is: discover every offline suite and FAIL THE PROCESS if any one of them fails. If
+// that exit-code contract ever breaks, CI would go green over a red suite — the exact
+// regression F24 exists to prevent — so the contract itself needs coverage. No network,
+// no database, no child processes: runSuites takes an injected `run`, so we test the
+// aggregation/exit logic directly.
+//
+//   node scripts/smoke-runner-smoke.mjs
+
+import { runSuites, discoverSuites } from './smoke-runner.mjs';
+
+let passed = 0;
+function check(name, cond, detail) {
+  if (!cond) throw new Error(`FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  passed += 1;
+  console.log(`  ✓ ${name}`);
+}
+
+const silent = () => {};
+
+console.log('smoke-runner smoke — no DB, no network, no child processes\n');
+
+console.log('exit-code contract (a failing suite must fail the run):');
+{
+  // All suites pass → nothing failed.
+  const allPass = await runSuites(['a-smoke.mjs', 'b-smoke.mjs'], {
+    run: async () => true,
+    log: silent,
+  });
+  check('every suite green → failed list is empty', allPass.failed.length === 0);
+  check('every suite green → all results ok', allPass.results.every((r) => r.ok === true));
+
+  // One suite fails → it surfaces in `failed` (the process exits 1 on this).
+  const oneFails = await runSuites(['ok-smoke.mjs', 'broken-smoke.mjs', 'ok2-smoke.mjs'], {
+    run: async (file) => file !== 'broken-smoke.mjs',
+    log: silent,
+  });
+  check('one red suite → failed list is non-empty', oneFails.failed.length === 1);
+  check('one red suite → failed names exactly the broken suite', oneFails.failed[0] === 'broken-smoke.mjs');
+  check('a red suite does not stop the others from running', oneFails.results.length === 3);
+}
+
+console.log('\nevery suite runs (no silent truncation — F24 exists because suites went unrun):');
+{
+  const seen = [];
+  await runSuites(['1-smoke.mjs', '2-smoke.mjs', '3-smoke.mjs'], {
+    run: async (file) => {
+      seen.push(file);
+      return true;
+    },
+    log: silent,
+  });
+  check('runSuites invokes run() once per file, in order', seen.join(',') === '1-smoke.mjs,2-smoke.mjs,3-smoke.mjs');
+}
+
+console.log('\ndiscovery (auto-find suites so a new one is never forgotten):');
+{
+  const suites = discoverSuites().map((p) => p.replace(/\\/g, '/'));
+  const bases = suites.map((p) => p.split('/').pop());
+  check('discovers a non-empty set of suites', suites.length > 0);
+  check('every discovered file is a *-smoke.mjs', bases.every((b) => b.endsWith('-smoke.mjs')));
+  check('includes a known existing suite', bases.includes('podium-rbac-smoke.mjs'));
+  check('includes a second known suite', bases.includes('podium-leads-smoke.mjs'));
+  // Recursion guard: the runner ends in "-runner.mjs", not "-smoke.mjs", so it must never
+  // discover (and re-spawn) itself.
+  check('does NOT discover the runner itself', !bases.includes('smoke-runner.mjs'));
+  // The live Podium webhook REGISTER script needs creds + network — it is not a smoke and
+  // must never be pulled into the offline CI run.
+  check('does NOT discover the live webhook-register script', !bases.includes('podium-webhook-register.mjs'));
+}
+
+console.log(`\n✅ smoke-runner smoke: ${passed} checks passed`);

--- a/scripts/smoke-runner.mjs
+++ b/scripts/smoke-runner.mjs
@@ -1,0 +1,71 @@
+// scripts/smoke-runner.mjs — runs every offline smoke suite and fails the process if any
+// one of them fails. This is what CI (and `npm run smoke`) calls.
+//
+// Why a runner instead of a chain of npm scripts: the suites are added by hand over time,
+// and the point of F24 is that a NEW suite must be covered without anyone remembering to
+// wire it up. So discovery is automatic — every scripts/*-smoke.mjs is picked up. The
+// runner is deliberately named "*-runner.mjs" (not "*-smoke.mjs") so it never discovers
+// and re-spawns itself.
+//
+// Exit code is the contract: 0 iff every suite exits 0, otherwise 1. A red suite must
+// turn CI red — that is the whole reason this exists.
+
+import { spawn } from 'node:child_process';
+import { readdirSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, basename, join } from 'node:path';
+
+const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
+const SELF = basename(fileURLToPath(import.meta.url));
+
+// Every offline smoke suite, discovered by filename so a new one is never forgotten.
+// The runner itself ends in "-runner.mjs", so it is excluded naturally; the live
+// webhook-register script is not a "*-smoke.mjs", so it is excluded too.
+export function discoverSuites(dir = SCRIPTS_DIR) {
+  return readdirSync(dir)
+    .filter((f) => f.endsWith('-smoke.mjs') && f !== SELF)
+    .sort()
+    .map((f) => join(dir, f));
+}
+
+// Run one suite as a child `node <file>`, inheriting stdio so CI shows its output.
+// Resolves true on exit 0, false otherwise. Never rejects — a crashed suite is a failure,
+// not a runner error.
+function runOne(file) {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [file], { stdio: 'inherit' });
+    child.on('error', () => resolve(false));
+    child.on('close', (code) => resolve(code === 0));
+  });
+}
+
+// Run each suite in turn; collect results. `run` is injectable so the contract is testable
+// without spawning real processes. One failure does not stop the rest — we want the full
+// picture of what is red, not just the first thing.
+export async function runSuites(files, opts = {}) {
+  const run = opts.run || runOne;
+  const log = opts.log || console.log;
+  const results = [];
+  for (const file of files) {
+    const ok = await run(file);
+    results.push({ file, ok });
+    log(`${ok ? 'PASS' : 'FAIL'}  ${basename(file)}`);
+  }
+  const failed = results.filter((r) => !r.ok).map((r) => r.file);
+  return { results, failed };
+}
+
+// Run directly (node scripts/smoke-runner.mjs), not when imported by the self-test.
+const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
+if (invokedDirectly) {
+  const suites = discoverSuites();
+  console.log(`Running ${suites.length} smoke suites…\n`);
+  const { failed } = await runSuites(suites);
+  console.log(`\n${suites.length - failed.length}/${suites.length} suites passed.`);
+  if (failed.length) {
+    console.error(`\n❌ ${failed.length} suite(s) failed:`);
+    for (const f of failed) console.error(`   - ${basename(f)}`);
+    process.exit(1);
+  }
+  console.log('✅ all smoke suites passed.');
+}

--- a/scripts/smoke-runner.mjs
+++ b/scripts/smoke-runner.mjs
@@ -13,7 +13,7 @@
 import { spawn } from 'node:child_process';
 import { readdirSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { dirname, basename, join } from 'node:path';
+import { dirname, basename, join, resolve } from 'node:path';
 
 const SCRIPTS_DIR = dirname(fileURLToPath(import.meta.url));
 const SELF = basename(fileURLToPath(import.meta.url));
@@ -30,12 +30,14 @@ export function discoverSuites(dir = SCRIPTS_DIR) {
 
 // Run one suite as a child `node <file>`, inheriting stdio so CI shows its output.
 // Resolves true on exit 0, false otherwise. Never rejects — a crashed suite is a failure,
-// not a runner error.
-function runOne(file) {
-  return new Promise((resolve) => {
-    const child = spawn(process.execPath, [file], { stdio: 'inherit' });
-    child.on('error', () => resolve(false));
-    child.on('close', (code) => resolve(code === 0));
+// not a runner error. Exported so the self-test can prove the real exit-code → boolean
+// mapping, not just the injected-`run` aggregation.
+export function runOne(file, opts = {}) {
+  const stdio = opts.stdio || 'inherit';
+  return new Promise((done) => {
+    const child = spawn(process.execPath, [file], { stdio });
+    child.on('error', () => done(false));
+    child.on('close', (code) => done(code === 0));
   });
 }
 
@@ -58,7 +60,15 @@ export async function runSuites(files, opts = {}) {
 // Run directly (node scripts/smoke-runner.mjs), not when imported by the self-test.
 const invokedDirectly = process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1];
 if (invokedDirectly) {
-  const suites = discoverSuites();
+  // Optional dir arg lets the self-test point the real runner at fixture suites; normal
+  // runs (npm run smoke) pass nothing and scan scripts/.
+  const dirArg = process.argv[2];
+  const suites = discoverSuites(dirArg ? resolve(dirArg) : undefined);
+  // No suites at all is a misconfiguration, not a pass — never let CI go green on nothing.
+  if (suites.length === 0) {
+    console.error('❌ no *-smoke.mjs suites found — refusing to report success.');
+    process.exit(1);
+  }
   console.log(`Running ${suites.length} smoke suites…\n`);
   const { failed } = await runSuites(suites);
   console.log(`\n${suites.length - failed.length}/${suites.length} suites passed.`);


### PR DESCRIPTION
## What & why

The repo had **no `.github/workflows` at all**, and none of the offline smoke suites were wired to any npm script or CI — only `smoke:labels` existed. So ~470 regression checks (14 suites) ran only when an agent remembered to; on a **human** PR they never ran. This adds the missing safety gate.

## Changes (test-infra only — no app behaviour change, no new serverless fn, no migration)

- **`scripts/smoke-runner.mjs`** — discovers every `scripts/*-smoke.mjs` and runs each as a child `node` process, exiting **1** if any suite fails. Auto-discovery means a *new* suite is covered without anyone remembering to wire it. Named `*-runner.mjs` so it never discovers/re-spawns itself; the live `podium-webhook-register.mjs` (needs creds+network) isn't a `*-smoke.mjs`, so it's excluded too. Refuses to report success on zero discovered suites (no false green).
- **`scripts/smoke-runner-smoke.mjs`** — self-test (itself a discovered suite) covering the exit-code contract, per-file order, discovery/recursion guard, **and** the real spawn exit-code->boolean mapping + end-to-end runner exit code (via tiny fixtures under `scripts/fixtures/`).
- **`package.json`** — `npm run smoke` runs the whole suite.
- **`.github/workflows/ci.yml`** — on push(`main`)+PR: `npm ci` -> `CI=true npm run build` -> `npm run smoke`.

This PR's own CI run is the first end-to-end proof: the workflow triggers on this `pull_request`.

## Verification (local)

- `npm run smoke` -> **15/15 suites green**, exit 0 (self-test 16 checks).
- Deliberate broken suite -> runner exits **1** (negative test).
- `CI=true npm run build` -> exit 0 (warning-clean).

## Reviewer checklist

- [ ] Exit-code contract: a red suite turns CI red (see self-test + fixtures).
- [ ] Recursion guard: runner never discovers itself; register script excluded.
- [ ] Cross-platform (`process.execPath`, non-recursive discovery ignores `fixtures/`).
- [ ] Workflow step order/env matches the spec; `npm ci` lockfile present.

Code-reviewed pre-push (general-purpose reviewer): no Critical; Important #1 (self-test didn't cover the real exit path) and fail-safes addressed in commit `a470ef2`; Important #2 (build warning-clean) verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)