### PR TITLE
F23 — Stop /api/users leaking bcrypt hashes (+ hash-or-preserve on edit)

### DIFF
--- a/api/[...path].js
+++ b/api/[...path].js
@@ -3,6 +3,7 @@ import { compare, hash } from 'bcryptjs';
 import jwt from 'jsonwebtoken';
 import { getClientWithTimezone } from '../lib/db.js';
 import { getRolesForUser, syncUserRoles, sanitizeRoles, primaryRole, requireRoles } from '../lib/rbac.js';
+import { usersSelectList, buildUserUpdate } from '../lib/usersAdmin.js';
 // Formerly standalone /api functions (workorder/delivery/collections/winnings),
 // relocated under lib/handlers/ and routed here so they don't each consume one of the
 // Vercel Hobby plan's 12 Serverless-Function slots. Their handler logic is unchanged;
@@ -505,12 +506,16 @@ async function handleUsers(req, res) {
       const access = (req.query?.access || '').toString();
       // F0b: return each user's full role set alongside the legacy columns.
       // Falls back to [access] if user_roles is absent (undefined_table).
+      // F23: SELECT an explicit allow-list of columns (never a wildcard select) — the users
+      // list is fetched token-less by the workorder/technician dropdowns, so it must never
+      // carry the bcrypt password hash. (id is the PK, so the explicit columns stay valid
+      // under GROUP BY u.id via functional dependency.)
       try {
         const params = [];
         let where = '';
         if (access) { params.push(access); where = 'WHERE u.access = $1'; }
         const r = await client.query(
-          `SELECT u.*,
+          `SELECT ${usersSelectList('u')},
                   COALESCE(array_agg(ur.role) FILTER (WHERE ur.role IS NOT NULL),
                            ARRAY[]::text[]) AS roles
              FROM users u
@@ -524,8 +529,8 @@ async function handleUsers(req, res) {
       } catch (err) {
         if (err?.code !== '42P01') throw err; // only fall back when user_roles is missing
         const r = access
-          ? await client.query('SELECT * FROM users WHERE access = $1', [access])
-          : await client.query('SELECT * FROM users');
+          ? await client.query(`SELECT ${usersSelectList()} FROM users WHERE access = $1`, [access])
+          : await client.query(`SELECT ${usersSelectList()} FROM users`);
         return res.status(200).json(r.rows.map((u) => ({ ...u, roles: u.access ? [u.access] : [] })));
       }
     }
@@ -552,12 +557,12 @@ async function handleUsers(req, res) {
         });
       }
 
-      await client.query(
-        `UPDATE users
-           SET name=$1, email=$2, password=$3, access=$4
-         WHERE id=$5`,
-        [name, email, password, primary, id]
-      );
+      // F23: the list no longer returns the password hash, so the admin page's edit no
+      // longer round-trips it. buildUserUpdate preserves the existing password when none is
+      // supplied (no lockout on a name/role edit) and hashes a genuinely new one (the raw
+      // write this replaced would have stored plaintext and broken login).
+      const upd = await buildUserUpdate({ id, name, email, primary, password }, { hash });
+      await client.query(upd.text, upd.params);
       await syncUserRoles(client, id, roles, gate.auth.id); // F9: granted_by = the acting admin
       return res.status(200).json({ message: 'User updated successfully', roles });
     }

--- a/lib/usersAdmin.js
+++ b/lib/usersAdmin.js
@@ -1,0 +1,39 @@
+// lib/usersAdmin.js — the security-critical bits of the /api/users admin endpoints,
+// extracted so they can be unit-tested without a database (see
+// scripts/podium-users-security-smoke.mjs).
+
+// Every column of `users` EXCEPT `password`. The users list is fetched token-less by the
+// workorder/technician dropdowns, so we cannot gate the read — but it must never carry the
+// bcrypt hash. Allow-list (default-deny): a future sensitive column is not exposed until it
+// is deliberately added here.
+export const USERS_PUBLIC_COLUMNS = ['id', 'name', 'email', 'access', 'podium_user_id'];
+
+// Column list for a SELECT. Pass the table alias used in the query ('u'), or nothing for
+// the un-aliased fallback query.
+export function usersSelectList(alias) {
+  const prefix = alias ? `${alias}.` : '';
+  return USERS_PUBLIC_COLUMNS.map((c) => `${prefix}${c}`).join(', ');
+}
+
+// Build the UPDATE for a user edit. The list no longer returns the password hash, so an
+// edit that isn't changing the password omits it — and we must NOT blank the column. When a
+// real new password IS supplied we hash it: the column stores bcrypt, and writing a raw
+// value here would lock the user out on their next login.
+//
+// `deps.hash` is bcrypt's hash (injected so the logic is testable offline).
+export async function buildUserUpdate(fields, deps = {}) {
+  const { id, name, email, primary, password } = fields;
+  const hasNewPassword = typeof password === 'string' && password.trim().length > 0;
+
+  if (hasNewPassword) {
+    const hashed = await deps.hash(password, 10);
+    return {
+      text: 'UPDATE users SET name=$1, email=$2, access=$3, password=$4 WHERE id=$5',
+      params: [name, email, primary, hashed, id],
+    };
+  }
+  return {
+    text: 'UPDATE users SET name=$1, email=$2, access=$3 WHERE id=$4',
+    params: [name, email, primary, id],
+  };
+}

--- a/lib/usersAdmin.js
+++ b/lib/usersAdmin.js
@@ -15,6 +15,15 @@ export function usersSelectList(alias) {
   return USERS_PUBLIC_COLUMNS.map((c) => `${prefix}${c}`).join(', ');
 }
 
+// A value already in bcrypt form ($2a/$2b/$2y$<cost>$<53 chars>) is NOT a new password —
+// it's a hash that a stale admin-page tab (loaded before this fix, when GET still returned
+// the hash) round-tripped back on Save. Re-hashing it would lock that user out, so we treat
+// it as "no change". Guards the deploy cutover window; harmless afterwards.
+const BCRYPT_RE = /^\$2[aby]\$\d{2}\$[./A-Za-z0-9]{53}$/;
+export function isBcryptHash(s) {
+  return typeof s === 'string' && BCRYPT_RE.test(s);
+}
+
 // Build the UPDATE for a user edit. The list no longer returns the password hash, so an
 // edit that isn't changing the password omits it — and we must NOT blank the column. When a
 // real new password IS supplied we hash it: the column stores bcrypt, and writing a raw
@@ -23,7 +32,8 @@ export function usersSelectList(alias) {
 // `deps.hash` is bcrypt's hash (injected so the logic is testable offline).
 export async function buildUserUpdate(fields, deps = {}) {
   const { id, name, email, primary, password } = fields;
-  const hasNewPassword = typeof password === 'string' && password.trim().length > 0;
+  const hasNewPassword =
+    typeof password === 'string' && password.trim().length > 0 && !isBcryptHash(password);
 
   if (hasNewPassword) {
     const hashed = await deps.hash(password, 10);

--- a/scripts/podium-users-security-smoke.mjs
+++ b/scripts/podium-users-security-smoke.mjs
@@ -1,0 +1,76 @@
+// scripts/podium-users-security-smoke.mjs — offline smoke for the F23 user-admin fixes.
+//
+// Two pre-existing security faults on /api/users:
+//   1. GET returned `SELECT u.*` — including every user's bcrypt password hash — with no
+//      auth. The list is fetched token-less by three dropdown pages, so the fix is to stop
+//      SELECTing the hash (an allow-list of non-sensitive columns), not to gate the read.
+//   2. PUT wrote `password` RAW from the request body. It only "worked" because the admin
+//      page round-tripped the hash it read back from that open GET. Once GET stops
+//      returning the hash, PUT must (a) NOT blank the password when none is supplied, and
+//      (b) HASH a genuinely new one — writing a raw value would lock the user out.
+//
+// The security-critical logic lives in lib/usersAdmin.js so it can be tested directly,
+// with a wiring check that api/[...path].js actually uses it.
+//
+//   node scripts/podium-users-security-smoke.mjs
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { USERS_PUBLIC_COLUMNS, usersSelectList, buildUserUpdate } from '../lib/usersAdmin.js';
+
+let passed = 0;
+function check(name, cond, detail) {
+  if (!cond) throw new Error(`FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  passed += 1;
+  console.log(`  ✓ ${name}`);
+}
+
+console.log('F23 user-admin security smoke — no DB, no network\n');
+
+console.log('the users list never exposes the password hash:');
+{
+  check('USERS_PUBLIC_COLUMNS excludes password', !USERS_PUBLIC_COLUMNS.includes('password'));
+  check('USERS_PUBLIC_COLUMNS is exactly the non-sensitive columns',
+    USERS_PUBLIC_COLUMNS.join(',') === 'id,name,email,access,podium_user_id');
+  const aliased = usersSelectList('u');
+  check('usersSelectList(alias) prefixes every column', aliased === 'u.id, u.name, u.email, u.access, u.podium_user_id');
+  check('usersSelectList(alias) never selects password', !/password/.test(aliased));
+  const bare = usersSelectList();
+  check('usersSelectList() (fallback, no alias) is safe too', bare === 'id, name, email, access, podium_user_id' && !/password/.test(bare));
+}
+
+console.log('\nPUT preserves the password when none is supplied (no lockout after an edit):');
+{
+  const noPw = await buildUserUpdate({ id: 'GS', name: 'Gray', email: 'g@x.co', primary: 'staff' }, { hash: async () => 'SHOULD_NOT_RUN' });
+  check('UPDATE omits password entirely when none is supplied', !/password/.test(noPw.text));
+  check('the existing hash is left untouched (id is the WHERE param)', noPw.params[noPw.params.length - 1] === 'GS');
+  check('empty-string password is treated as "no change", not a blank-out',
+    !/password/.test((await buildUserUpdate({ id: 'GS', name: 'n', email: 'e', primary: 'staff', password: '   ' }, { hash: async () => 'X' })).text));
+}
+
+console.log('\nPUT hashes a genuinely new password (never stores it raw):');
+{
+  let hashedArgs = null;
+  const fakeHash = async (pw, rounds) => { hashedArgs = [pw, rounds]; return `HASHED::${pw}`; };
+  const withPw = await buildUserUpdate({ id: 'GS', name: 'n', email: 'e', primary: 'staff', password: 'plaintext-secret' }, { hash: fakeHash });
+  check('UPDATE sets the password column when a new one is supplied', /password/.test(withPw.text));
+  check('the stored value is the HASH, never the raw password', withPw.params.includes('HASHED::plaintext-secret') && !withPw.params.includes('plaintext-secret'));
+  check('the password is hashed with cost 10', hashedArgs && hashedArgs[0] === 'plaintext-secret' && hashedArgs[1] === 10);
+  check('id is still the WHERE param', withPw.params[withPw.params.length - 1] === 'GS');
+}
+
+console.log('\nwiring — api/[...path].js handleUsers actually uses the safe helpers:');
+{
+  const src = readFileSync(fileURLToPath(new URL('../api/[...path].js', import.meta.url)), 'utf8');
+  const start = src.indexOf('async function handleUsers');
+  const usersBlock = src.slice(start, src.indexOf('async function', start + 10));
+  const getBranch = usersBlock.slice(usersBlock.indexOf("method === 'GET'"), usersBlock.indexOf("method === 'PUT'"));
+  check('GET no longer does SELECT u.* on users', !/u\.\*/.test(getBranch));
+  check('GET fallback no longer does SELECT * FROM users', !/SELECT \* FROM users/.test(getBranch));
+  check('GET builds its column list from usersSelectList', /usersSelectList/.test(getBranch));
+  const putBranch = usersBlock.slice(usersBlock.indexOf("method === 'PUT'"), usersBlock.indexOf("method === 'DELETE'"));
+  check('PUT delegates the password decision to buildUserUpdate', /buildUserUpdate/.test(putBranch));
+  check('PUT no longer writes a raw password=$3 column', !/SET name=\$1, email=\$2, password=/.test(putBranch));
+}
+
+console.log(`\n✅ users-security smoke: ${passed} checks passed`);

--- a/scripts/podium-users-security-smoke.mjs
+++ b/scripts/podium-users-security-smoke.mjs
@@ -16,7 +16,7 @@
 
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { USERS_PUBLIC_COLUMNS, usersSelectList, buildUserUpdate } from '../lib/usersAdmin.js';
+import { USERS_PUBLIC_COLUMNS, usersSelectList, buildUserUpdate, isBcryptHash } from '../lib/usersAdmin.js';
 
 let passed = 0;
 function check(name, cond, detail) {
@@ -57,6 +57,17 @@ console.log('\nPUT hashes a genuinely new password (never stores it raw):');
   check('the stored value is the HASH, never the raw password', withPw.params.includes('HASHED::plaintext-secret') && !withPw.params.includes('plaintext-secret'));
   check('the password is hashed with cost 10', hashedArgs && hashedArgs[0] === 'plaintext-secret' && hashedArgs[1] === 10);
   check('id is still the WHERE param', withPw.params[withPw.params.length - 1] === 'GS');
+}
+
+console.log('\ndeploy-cutover guard — an already-hashed value round-tripped by a stale tab is not re-hashed:');
+{
+  const realHash = '$2b$10$N9qo8uLOickgx2ZMRZoMyeIjZAgcfl7p92ldGxad68LJZdL17lhWy';
+  check('isBcryptHash recognises a bcrypt hash', isBcryptHash(realHash) === true);
+  check('isBcryptHash rejects a normal password', isBcryptHash('hunter2') === false);
+  const stale = await buildUserUpdate({ id: 'GS', name: 'n', email: 'e', primary: 'staff', password: realHash },
+    { hash: async () => 'DOUBLE_HASH_SHOULD_NOT_HAPPEN' });
+  check('a round-tripped hash is treated as "no change" (no double-hash lockout)', !/password/.test(stale.text));
+  check('and the hash function is never called on it', !stale.params.includes('DOUBLE_HASH_SHOULD_NOT_HAPPEN'));
 }
 
 console.log('\nwiring — api/[...path].js handleUsers actually uses the safe helpers:');


### PR DESCRIPTION
## 🔴 Security fix

Two **pre-existing** faults on the user-admin endpoints (`api/[...path].js` → `handleUsers`):

1. **`GET /api/users` returned `SELECT u.*`** — every user's **bcrypt password hash** and email — reachable with **no token**. Three pages fetch this list token-less for name/technician dropdowns (`create_workorder.js`, `delivery_operations/workorder/[id].js`, `register.js`), so the fix is to **stop selecting the hash** (an allow-list of non-sensitive columns), not to gate the read.
2. **`PUT /api/users` wrote `password` RAW** from the request body. It only "worked" because the admin page round-tripped the hash it read back from that open GET. Once GET stops returning the hash, a naive edit would send no password and **blank the column → lock the user out**.

The two are coupled: the GET fix would break edits without the PUT fix.

## Changes (no migration, no new serverless fn, no app behaviour change)

- **`lib/usersAdmin.js`** (new, unit-tested): `USERS_PUBLIC_COLUMNS` (allow-list, default-deny, excludes `password`), `usersSelectList(alias)`, and `buildUserUpdate(fields, {hash})` — **preserves** the existing password when none is supplied and **hashes** a genuinely new one. `isBcryptHash()` treats a round-tripped hash (from a stale pre-deploy tab) as "no change" so it's never double-hashed.
- **`api/[...path].js` handleUsers** — GET selects the allow-list in **both** the primary (`GROUP BY u.id`) and 42P01-fallback queries; PUT delegates to `buildUserUpdate`.
- **`scripts/podium-users-security-smoke.mjs`** (new, 21 checks) — list never exposes password; PUT preserves-or-hashes; deploy-cutover guard; wiring guard.

## Verification

- Primary GET SQL **round-tripped read-only on Neon dev** → executes under `GROUP BY u.id`, returns **no `password` key**.
- users-security smoke **21/21**; all 15 suites green (rbac **31/31** regression); `CI=true npm run build` exit 0.
- Traced the only PUT caller (`register.js`): a name/email/role edit now sends `password: undefined` → password **preserved**, no lockout.

## Scope / follow-ups (recorded, out of this PR)

- GET still returns **names + emails** token-less — the deliberate F9-carried decision (gating breaks 3 dropdowns). Gating GET + having those pages send `authHeaders()` is the separate follow-up this row itself names.
- `buildUserUpdate` writes name/email/access unconditionally — latent only (sole caller always sends the full row).

## Reviewer checklist
- [ ] Confirm no endpoint returns the bcrypt hash (primary + 42P01 fallback).
- [ ] Confirm a name/email/role edit preserves the password (no lockout); a new password is hashed, never raw.
- [ ] PUT/DELETE still superadmin-gated (F9); register POST still hashes.

Code-reviewed pre-push (security-focused reviewer): **verdict Yes/ready**, no Critical/Important; the one Minor lockout edge (stale-tab double-hash) is fixed in commit `62b38f7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)