### PR TITLE
F20 — Compose: start a new conversation, with dedupe (backend seam + inbox UI)

### DIFF
--- a/lib/podium.js
+++ b/lib/podium.js
@@ -648,6 +648,40 @@ export function getContact(userId, contactUid, opts = {}) {
   return request(userId, 'GET', `contacts/${contactUid}`, { client: opts.client });
 }
 
+/**
+ * POST /v4/contacts — create a contact (F20 compose). Sends only the identity fields we
+ * have (name/phoneNumber/email/channels). Mock-first: the typed mock dedupes on
+ * phone/email and returns the existing contact when one matches.
+ * VERIFY the exact live Podium create-contact body shape + duplicate behaviour at wiring.
+ */
+export function createContact(userId, { name, phoneNumber, email, channels } = {}) {
+  const bodyOut = {};
+  if (name) bodyOut.name = name;
+  if (phoneNumber) bodyOut.phoneNumber = phoneNumber;
+  if (email) bodyOut.email = email;
+  if (Array.isArray(channels) && channels.length) bodyOut.channels = channels;
+  return request(userId, 'POST', 'contacts', { body: bodyOut });
+}
+
+/**
+ * Open a BRAND-NEW conversation with a recipient, carrying the first outbound message
+ * (F20 compose, create branch). Kept separate from sendMessage() so a system SMS
+ * (sendSystemSms) never accidentally spawns a conversation. Mock-first via POST
+ * /conversations. VERIFY the live Podium create-conversation endpoint/shape at wiring —
+ * Podium may instead open the thread implicitly on the first POST /messages to a number.
+ */
+export function openConversation(userId, { to, channel, body, contactUid, locationUid } = {}) {
+  return request(userId, 'POST', 'conversations', {
+    body: {
+      to,
+      channel,
+      body,
+      contactUid,
+      locationUid: locationUid || process.env.PODIUM_LOCATION_UID || undefined,
+    },
+  });
+}
+
 /** POST /v4/reviews/invites (F8c). */
 export function requestReview(userId, { contactUid, locationUid, channel } = {}) {
   return request(userId, 'POST', 'reviews/invites', {

--- a/lib/podium.mock.js
+++ b/lib/podium.mock.js
@@ -229,6 +229,17 @@ function normalizeAssigneeUids(body = {}) {
   return [...new Set(raw.filter(Boolean).map(String))];
 }
 
+// F20: match a contact against a create body by phone (last-8 digits) or email (case-
+// insensitive) — the same identity keys lib/podiumCompose.js dedupes on.
+function digitsTail(v, n = 8) {
+  return String(v || '').replace(/\D/g, '').slice(-n);
+}
+function contactMatchesIdentity(contact, body = {}) {
+  if (body.phoneNumber && contact.phoneNumber && digitsTail(body.phoneNumber) === digitsTail(contact.phoneNumber)) return true;
+  if (body.email && contact.email && String(body.email).trim().toLowerCase() === String(contact.email).trim().toLowerCase()) return true;
+  return false;
+}
+
 /**
  * Route a mock request. Returns a plain object shaped like the live API.
  * @param {string} method  GET|POST|PUT|PATCH|DELETE
@@ -252,18 +263,61 @@ export function handle(method, path, opts = {}) {
     return paginateList(USERS, query);
   }
 
-  // GET /contacts  ·  GET /contacts/{uid}
+  // GET /contacts  ·  GET /contacts/{uid}  ·  POST /contacts (F20 create, dedupe)
   if (segs[0] === 'contacts') {
     if (segs[1]) {
       const c = CONTACTS.find((x) => x.uid === segs[1]);
       if (!c) return notFound('contact', segs[1]);
       return c;
     }
+    if (m === 'POST') {
+      // F20: idempotent create — Podium returns the existing contact when phone/email
+      // matches, so a dedupe race never spawns a duplicate. Otherwise append a new one.
+      const existing = CONTACTS.find((c) => contactMatchesIdentity(c, body));
+      if (existing) return existing;
+      const contact = {
+        uid: `pod_con_new_${Date.now().toString(36)}`,
+        name: body.name || null,
+        phoneNumber: body.phoneNumber || null,
+        email: body.email || null,
+        channels: Array.isArray(body.channels) ? body.channels : [],
+      };
+      CONTACTS.push(contact);
+      return contact;
+    }
     return paginateList(CONTACTS, query);
   }
 
   // conversations ...
   if (segs[0] === 'conversations') {
+    // POST /conversations — F20 compose: open a NEW conversation carrying the first
+    // outbound message. Appended to the in-memory fixtures so it's readable back on the
+    // Preview (writes nothing to the portal DB — Podium is the system of record, P1).
+    // Dedupe is the caller's job (lib/podiumCompose.js); this always creates.
+    if (!segs[1] && m === 'POST') {
+      const uid = `pod_cnv_new_${Date.now().toString(36)}`;
+      const conv = {
+        uid,
+        channel: { type: body.channel || 'sms', identifier: body.to || null },
+        contact: body.contactUid ? { uid: body.contactUid } : null,
+        assignedUser: null,
+        status: 'open',
+        location: { uid: LOCATION_UID(), organizationUid: ORG_UID() },
+        lastMessageAt: nowIso(),
+      };
+      CONVERSATIONS.push(conv);
+      MESSAGES[uid] = [];
+      if (body.body) {
+        MESSAGES[uid].push({
+          uid: `pod_msg_${Date.now().toString(36)}`,
+          direction: 'outbound',
+          channel: conv.channel.type,
+          body: body.body,
+          createdAt: nowIso(),
+        });
+      }
+      return conv;
+    }
     // GET /conversations
     if (!segs[1]) {
       let items = CONVERSATIONS;

--- a/lib/podium.mock.js
+++ b/lib/podium.mock.js
@@ -296,14 +296,17 @@ export function handle(method, path, opts = {}) {
     // Dedupe is the caller's job (lib/podiumCompose.js); this always creates.
     if (!segs[1] && m === 'POST') {
       const uid = `pod_cnv_new_${Date.now().toString(36)}`;
+      // A just-composed thread carries a REAL timestamp (not the epoch-0 nowIso()) so it
+      // sorts to the TOP of the inbox — the newest conversation — for the increment-2 UI.
+      const createdAt = new Date().toISOString();
       const conv = {
         uid,
-        channel: { type: body.channel || 'sms', identifier: body.to || null },
+        channel: { type: body.channel || 'phone', identifier: body.to || null },
         contact: body.contactUid ? { uid: body.contactUid } : null,
         assignedUser: null,
         status: 'open',
         location: { uid: LOCATION_UID(), organizationUid: ORG_UID() },
-        lastMessageAt: nowIso(),
+        lastMessageAt: createdAt,
       };
       CONVERSATIONS.push(conv);
       MESSAGES[uid] = [];
@@ -313,7 +316,7 @@ export function handle(method, path, opts = {}) {
           direction: 'outbound',
           channel: conv.channel.type,
           body: body.body,
-          createdAt: nowIso(),
+          createdAt,
         });
       }
       return conv;

--- a/lib/podiumCompose.js
+++ b/lib/podiumCompose.js
@@ -69,29 +69,39 @@ function isOpen(conv) {
   return conv?.closed !== true && (conv?.status || 'open') !== 'closed';
 }
 
-// Find an existing conversation for the target. Scans one page (≤100) of ALL conversations
-// (both statuses) and prefers an OPEN match, falling back to a closed one. (Single-page
-// scan mirrors F14's dedupe/search cap; a paginating scan is a live-wiring follow-up.)
+// Find an existing conversation for the target. Scans one page (≤100) of the most-recent
+// conversations and prefers an OPEN match, falling back to a closed one.
+//
+// ⚠️ LIVE-WIRING VERIFY (do NOT point this at live Podium as-is): this 100-row recency
+// scan is fine for the mock, but the real Grays org has thousands of conversations, so a
+// customer whose existing thread is older than the newest ~100 would be MISSED and compose
+// would create a DUPLICATE — the exact thing this feature prevents. Before live wiring,
+// replace this with a contact-search-FIRST lookup (search Podium contacts by phone/email —
+// the F4 bridge / F14 identity approach — then fetch that contact's conversations), so
+// dedupe doesn't depend on recency. Tracked as F20's #1 wiring task.
 export async function findExistingConversation(userId, target, deps = {}) {
   const svc = { listConversations, getContact, ...deps };
   const resp = await svc.listConversations(userId, { limit: 100 });
   const convs = Array.isArray(resp?.data) ? resp.data : [];
-  let openMatch = null;
   let anyMatch = null;
   for (const conv of convs) {
     // eslint-disable-next-line no-await-in-loop
-    if (await conversationMatchesTarget(userId, conv, target, svc)) {
-      if (!anyMatch) anyMatch = conv;
-      if (isOpen(conv) && !openMatch) openMatch = conv;
-    }
+    const matched = await conversationMatchesTarget(userId, conv, target, svc);
+    if (!matched) continue;
+    if (!anyMatch) anyMatch = conv;
+    // An open match is the best possible outcome — stop scanning (avoids up to 100
+    // sequential getContact round-trips once we've already found what we want).
+    if (isOpen(conv)) return conv;
   }
-  return openMatch || anyMatch || null;
+  return anyMatch || null;
 }
 
 function normalizeChannel(channel, target) {
   const c = String(channel ?? '').trim().toLowerCase();
   if (c) return c;
-  return target.kind === 'email' ? 'email' : 'sms';
+  // Default to the channel TYPE the inbox model uses ('phone'/'email'), so a composed
+  // thread renders with the same ChannelBadge as the rest of the inbox.
+  return target.kind === 'email' ? 'email' : 'phone';
 }
 
 // Start (or continue) a conversation with `to` on `channel`, carrying the first message

--- a/lib/podiumCompose.js
+++ b/lib/podiumCompose.js
@@ -1,0 +1,140 @@
+// lib/podiumCompose.js — F20: start a NEW conversation to a phone/email, with dedupe.
+//
+// A salesperson composes a new chat. Before creating anything we DEDUPE: if a conversation
+// for that phone/email already exists, we reopen it (if closed) and continue it rather than
+// spawning a duplicate thread; only when nothing matches do we create the Podium contact
+// and open a fresh conversation. Reuses the F4 bridge's phone normalisation and the F11
+// open/close (setConversationStatus). Mock-first: every Podium hop routes through
+// lib/podium.js, which serves the typed mock under PODIUM_MOCK.
+//
+// The Podium service functions are injectable (deps) so the dedupe/reopen/create decision
+// is unit-testable without network or DB. P1 holds — no message body is persisted here.
+
+import { phoneKey } from './podiumContact.js';
+import {
+  listConversations, getContact, sendMessage, setConversationStatus, createContact,
+  openConversation,
+} from './podium.js';
+
+function composeError(message, code) {
+  const err = new Error(message);
+  err.code = code;
+  return err;
+}
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+// Classify the recipient as a phone or an email, and derive a stable match key
+// (phone → normalised last-8 digits; email → trimmed + lowercased). Throws
+// INVALID_COMPOSE_TARGET for anything that is neither.
+export function classifyTarget(to) {
+  const value = String(to ?? '').trim();
+  if (!value) throw composeError('A phone number or email is required', 'INVALID_COMPOSE_TARGET');
+  if (EMAIL_RE.test(value)) {
+    return { kind: 'email', value, key: value.toLowerCase() };
+  }
+  const digits = value.replace(/\D/g, '');
+  if (digits.length >= 6) {
+    return { kind: 'phone', value, key: phoneKey(value) };
+  }
+  throw composeError('Enter a valid phone number or email address', 'INVALID_COMPOSE_TARGET');
+}
+
+// Does a resolved Podium contact match the target?
+export function contactMatchesTarget(contact, target) {
+  if (!contact) return false;
+  if (target.kind === 'phone') {
+    return !!contact.phoneNumber && phoneKey(contact.phoneNumber) === target.key;
+  }
+  return !!contact.email && String(contact.email).trim().toLowerCase() === target.key;
+}
+
+// Does a conversation belong to the target? Fast path on the channel identifier (phone/
+// email channels carry the raw number/address); otherwise resolve the contact and compare.
+async function conversationMatchesTarget(userId, conv, target, svc) {
+  const ident = conv?.channel?.identifier;
+  if (ident) {
+    if (target.kind === 'phone' && /\d/.test(ident) && phoneKey(ident) === target.key) return true;
+    if (target.kind === 'email' && String(ident).includes('@') && String(ident).trim().toLowerCase() === target.key) return true;
+  }
+  const contactUid = conv?.contact?.uid;
+  if (contactUid) {
+    const contact = await svc.getContact(userId, contactUid);
+    if (contactMatchesTarget(contact, target)) return true;
+  }
+  return false;
+}
+
+function isOpen(conv) {
+  return conv?.closed !== true && (conv?.status || 'open') !== 'closed';
+}
+
+// Find an existing conversation for the target. Scans one page (≤100) of ALL conversations
+// (both statuses) and prefers an OPEN match, falling back to a closed one. (Single-page
+// scan mirrors F14's dedupe/search cap; a paginating scan is a live-wiring follow-up.)
+export async function findExistingConversation(userId, target, deps = {}) {
+  const svc = { listConversations, getContact, ...deps };
+  const resp = await svc.listConversations(userId, { limit: 100 });
+  const convs = Array.isArray(resp?.data) ? resp.data : [];
+  let openMatch = null;
+  let anyMatch = null;
+  for (const conv of convs) {
+    // eslint-disable-next-line no-await-in-loop
+    if (await conversationMatchesTarget(userId, conv, target, svc)) {
+      if (!anyMatch) anyMatch = conv;
+      if (isOpen(conv) && !openMatch) openMatch = conv;
+    }
+  }
+  return openMatch || anyMatch || null;
+}
+
+function normalizeChannel(channel, target) {
+  const c = String(channel ?? '').trim().toLowerCase();
+  if (c) return c;
+  return target.kind === 'email' ? 'email' : 'sms';
+}
+
+// Start (or continue) a conversation with `to` on `channel`, carrying the first message
+// `body`. Returns { conversationId, reused, reopened, contactUid }.
+export async function composeConversation(userId, { to, channel, body } = {}, deps = {}) {
+  const svc = {
+    listConversations, getContact, sendMessage, setConversationStatus, createContact, openConversation,
+    ...deps,
+  };
+
+  const text = (body == null ? '' : String(body)).trim();
+  if (!text) throw composeError('A message is required to start a conversation', 'COMPOSE_BODY_REQUIRED');
+  const target = classifyTarget(to); // throws INVALID_COMPOSE_TARGET
+  const ch = normalizeChannel(channel, target);
+
+  const existing = await findExistingConversation(userId, target, svc);
+  if (existing) {
+    const wasClosed = !isOpen(existing);
+    if (wasClosed) await svc.setConversationStatus(userId, existing.uid, 'open');
+    await svc.sendMessage(userId, { conversationUid: existing.uid, body: text });
+    return {
+      conversationId: existing.uid,
+      reused: true,
+      reopened: wasClosed,
+      contactUid: existing?.contact?.uid || null,
+    };
+  }
+
+  // Nothing matched — create the contact, then open a new thread carrying the first message.
+  const contactFields = target.kind === 'phone'
+    ? { phoneNumber: target.value, channels: [ch] }
+    : { email: target.value, channels: [ch] };
+  const contact = await svc.createContact(userId, contactFields);
+  const conv = await svc.openConversation(userId, {
+    to: target.value,
+    channel: ch,
+    body: text,
+    contactUid: contact?.uid || null,
+  });
+  return {
+    conversationId: conv?.uid || null,
+    reused: false,
+    reopened: false,
+    contactUid: contact?.uid || null,
+  };
+}

--- a/lib/podiumRoutes/inbox.js
+++ b/lib/podiumRoutes/inbox.js
@@ -43,6 +43,7 @@ import {
   resolveSelfPodiumUid, filterUpdatedSince, clampLimit, normalizeBucket, normalizeStatus,
 } from '../podiumInbox.js';
 import { buildConversationIdentity, identityMatchesSearch } from '../podiumContact.js';
+import { composeConversation } from '../podiumCompose.js';
 import { getClientWithTimezone } from '../db.js';
 
 const ALLOWED_ROLES = ['sales', 'superadmin'];
@@ -89,6 +90,10 @@ export default async function handler(req, res) {
   if (resource === 'reps') {
     if (method !== 'GET') return res.status(405).json({ error: 'Method not allowed' });
     return repsRoute(req, res, auth);
+  }
+  if (resource === 'compose') {
+    if (method !== 'POST') return res.status(405).json({ error: 'Method not allowed' });
+    return composeRoute(req, res, auth);
   }
   return res.status(400).json({ error: 'Unknown inbox resource', resource: resource || null });
 }
@@ -364,6 +369,24 @@ async function pollRoute(req, res, auth) {
     return respondUpstreamError(res, err, 'poll conversations');
   } finally {
     client.release();
+  }
+}
+
+// POST ?resource=compose { to, channel, body } — F20: start a new conversation to a
+// phone/email. Dedupes first — an existing conversation for that number/address is reopened
+// (if closed) and continued instead of duplicated; otherwise a Podium contact is created and
+// a new thread opened. Runs on the rep's token (P4); no chat body persisted (P1). 201 for a
+// freshly created thread, 200 when an existing one was reused.
+async function composeRoute(req, res, auth) {
+  const { to, channel, body } = req.body || {};
+  try {
+    const result = await composeConversation(auth.id, { to, channel, body });
+    return res.status(result.reused ? 200 : 201).json({ ...result, mock: isMock() });
+  } catch (err) {
+    if (err?.code === 'INVALID_COMPOSE_TARGET' || err?.code === 'COMPOSE_BODY_REQUIRED') {
+      return res.status(400).json({ error: err.message, code: err.code });
+    }
+    return respondUpstreamError(res, err, 'start the conversation');
   }
 }
 

--- a/scripts/podium-compose-smoke.mjs
+++ b/scripts/podium-compose-smoke.mjs
@@ -129,13 +129,21 @@ console.log('\nend-to-end against the typed mock (PODIUM_MOCK):');
 {
   process.env.PODIUM_MOCK = 'true';
   const { composeConversation: realCompose } = await import('../lib/podiumCompose.js');
+  const { fixtures } = await import('../lib/podium.mock.js');
   // Maria (+61400111222) is a mock fixture with an OPEN conversation → reuse.
   const reuse = await realCompose('GA', { to: '+61400111222', channel: 'phone', body: 'Hi Maria' });
   check('mock: an existing fixture contact reuses its conversation', reuse.reused === true && !!reuse.conversationId);
+  // Linda's ONLY thread (pod_cnv_00004, instagram) is CLOSED → reopen, not duplicate.
+  const beforeReopen = fixtures.CONVERSATIONS.length;
+  const reopened = await realCompose('GA', { to: '+61400555666', channel: 'phone', body: 'Hi Linda' });
+  check('mock: a contact whose only thread is closed is REOPENED', reopened.reused === true && reopened.reopened === true);
+  check('mock: reopen did NOT append a duplicate conversation', fixtures.CONVERSATIONS.length === beforeReopen);
   // A brand-new number → create contact + open a new conversation.
-  const fresh = await realCompose('GA', { to: '+61400000123', channel: 'sms', body: 'New lead' });
+  const beforeCreate = fixtures.CONVERSATIONS.length;
+  const fresh = await realCompose('GA', { to: '+61400000123', channel: 'phone', body: 'New lead' });
   check('mock: a new number creates a new conversation', fresh.reused === false && !!fresh.conversationId);
-  check('mock: the new conversation is readable back', fresh.conversationId !== reuse.conversationId);
+  check('mock: create DID append exactly one conversation', fixtures.CONVERSATIONS.length === beforeCreate + 1);
+  check('mock: the new conversation id differs from the reused one', fresh.conversationId !== reuse.conversationId);
 }
 
 console.log(`\n✅ compose smoke: ${passed} checks passed`);

--- a/scripts/podium-compose-smoke.mjs
+++ b/scripts/podium-compose-smoke.mjs
@@ -155,7 +155,7 @@ console.log('\nend-to-end against the typed mock (PODIUM_MOCK):');
 // through both and asserts they agree, rather than testing the client mirror in isolation.
 console.log('\nincrement 2 — client target validation (src/utils/compose.js):');
 {
-  const { classifyComposeTarget, isValidComposeTarget, composeResultMessage } =
+  const { classifyComposeTarget, isValidComposeTarget, MIN_PHONE_DIGITS } =
     await import('../src/utils/compose.js');
 
   check('a spaced phone is accepted', isValidComposeTarget('+61 400 111 222') === true);
@@ -167,16 +167,36 @@ console.log('\nincrement 2 — client target validation (src/utils/compose.js):'
   check('email is classified as email', classifyComposeTarget('a@b.co')?.kind === 'email');
   check('classify returns null for junk (never throws in render)', classifyComposeTarget('nope') === null);
 
-  // Parity with the server's classifyTarget across the same corpus.
+  // Parity with the server's classifyTarget.
+  //
+  // The corpus alone is NOT enough: every realistic number carries 10-11 digits, so a client
+  // threshold anywhere from 6 to 10 classifies all of them identically and would ship green
+  // while blocking a short local number the server accepts. So the corpus is padded with
+  // cases that sit exactly ON the boundary, and the threshold itself is asserted equal.
+  check(`client MIN_PHONE_DIGITS (${MIN_PHONE_DIGITS}) equals the server's threshold`,
+    classifyTarget('1'.repeat(MIN_PHONE_DIGITS)).kind === 'phone'
+    && classifyComposeTarget('1'.repeat(MIN_PHONE_DIGITS))?.kind === 'phone'
+    && await throwsCode(() => classifyTarget('1'.repeat(MIN_PHONE_DIGITS - 1)), 'INVALID_COMPOSE_TARGET')
+    && classifyComposeTarget('1'.repeat(MIN_PHONE_DIGITS - 1)) === null);
+
   const corpus = [
     '+61 400 111 222', '0400111222', '(03) 8360 7047', '+61-3-8360-7047',
     'maria@example.com', '  Maria@Example.COM ', 'a@b.co',
-    'hello there', '', '   ', '12345', 'not@anemail', '@nope.com',
+    'hello there', '', '   ', 'not@anemail', '@nope.com',
+    // digit-count boundary (either side of MIN_PHONE_DIGITS = 6) and awkward-but-valid emails
+    '12345', '123456', '1234567', 'a@b.c', 'first.last+tag@sub.example.co.uk',
   ];
   let agreed = 0;
   for (const input of corpus) {
     let serverKind = null;
-    try { serverKind = classifyTarget(input).kind; } catch { serverKind = null; }
+    try {
+      serverKind = classifyTarget(input).kind;
+    } catch (e) {
+      // Only a rejection counts as "server says invalid" — swallowing ANY throw would let a
+      // genuine crash inside the server helper read as agreement with the client's null.
+      if (e?.code !== 'INVALID_COMPOSE_TARGET') throw e;
+      serverKind = null;
+    }
     const clientKind = classifyComposeTarget(input)?.kind ?? null;
     if (serverKind !== clientKind) {
       throw new Error(`FAIL: client/server target parity — "${input}" server=${serverKind} client=${clientKind}`);
@@ -201,6 +221,13 @@ console.log('\nincrement 2 — compose result messaging (proves dedupe to the re
     composeResultMessage({ reused: true, reopened: true }) !== composeResultMessage({ reused: true, reopened: false }));
   check('a null result still returns a string (never renders "undefined")',
     typeof composeResultMessage(null) === 'string' && composeResultMessage(null).length > 0);
+  // parseMaybeJson yields {raw:'…'} for a non-JSON 200 (proxy-mangled body). Falling through
+  // to "started" there would claim a fresh thread when one may have been REUSED — the exact
+  // mis-signal this message exists to prevent, so an unreadable result must not say "started".
+  check('an unreadable response does not claim a thread was started',
+    !/started/i.test(composeResultMessage({ raw: '<html>502</html>' })));
+  check('an unreadable response still returns something a rep can read',
+    composeResultMessage({ raw: 'x' }).length > 0);
 }
 
 console.log(`\n✅ compose smoke: ${passed} checks passed`);

--- a/scripts/podium-compose-smoke.mjs
+++ b/scripts/podium-compose-smoke.mjs
@@ -1,0 +1,141 @@
+// scripts/podium-compose-smoke.mjs — offline smoke for F20 increment 1 (compose seam).
+//
+// F20: a salesperson starts a NEW chat to a phone/email — but first DEDUPE. If a
+// conversation for that phone/email already exists, reopen (if closed) and continue it
+// instead of creating a duplicate; otherwise create the Podium contact and open a new
+// thread. The dedupe/reopen/create decision is the feature's value, so it's covered here
+// with injected service functions (no network, no mock, no DB), plus a handful of checks
+// against the REAL typed mock to prove the create path is wired end-to-end.
+//
+//   node scripts/podium-compose-smoke.mjs
+
+import {
+  classifyTarget, contactMatchesTarget, findExistingConversation, composeConversation,
+} from '../lib/podiumCompose.js';
+
+let passed = 0;
+function check(name, cond, detail) {
+  if (!cond) throw new Error(`FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  passed += 1;
+  console.log(`  ✓ ${name}`);
+}
+async function throwsCode(fn, code) {
+  try { await fn(); return false; } catch (e) { return e?.code === code; }
+}
+
+console.log('F20 compose smoke — no DB, no network\n');
+
+console.log('classifyTarget — phone vs email vs junk:');
+{
+  const phone = classifyTarget('+61 400 111 222');
+  check('a spaced phone is classified as phone', phone.kind === 'phone');
+  check('phone key is the normalised last-8 digits', phone.key === '00111222');
+  const email = classifyTarget('  Maria@Example.COM ');
+  check('an email is classified as email', email.kind === 'email');
+  check('email key is trimmed + lowercased', email.key === 'maria@example.com');
+  check('junk throws INVALID_COMPOSE_TARGET', await throwsCode(() => classifyTarget('hello there'), 'INVALID_COMPOSE_TARGET'));
+  check('empty throws INVALID_COMPOSE_TARGET', await throwsCode(() => classifyTarget(''), 'INVALID_COMPOSE_TARGET'));
+}
+
+console.log('\ncontactMatchesTarget — phone (last-8) and email (case-insensitive):');
+{
+  const c = { phoneNumber: '+61400333444', email: 'Tom.H@Example.com' };
+  check('matches on phone regardless of formatting', contactMatchesTarget(c, classifyTarget('0400 333 444')));
+  check('matches on email case-insensitively', contactMatchesTarget(c, classifyTarget('tom.h@example.com')));
+  check('does not match a different number', !contactMatchesTarget(c, classifyTarget('+61400999000')));
+}
+
+// --- injected service doubles ---------------------------------------------
+const CONTACTS = {
+  c_maria: { uid: 'c_maria', name: 'Maria', phoneNumber: '+61400111222', email: 'maria@example.com' },
+  c_tom: { uid: 'c_tom', name: 'Tom', phoneNumber: '+61400333444', email: 'tom@example.com' },
+};
+const CONVS = [
+  { uid: 'A', channel: { type: 'phone', identifier: '+61400111222' }, contact: { uid: 'c_maria' }, status: 'open' },
+  { uid: 'B', channel: { type: 'facebook', identifier: 'fb:x' }, contact: { uid: 'c_tom' }, status: 'closed' },
+];
+function makeDeps(overrides = {}) {
+  const calls = { sendMessage: [], setConversationStatus: [], createContact: [], openConversation: [] };
+  const deps = {
+    listConversations: async () => ({ data: CONVS }),
+    getContact: async (_u, uid) => CONTACTS[uid] || null,
+    sendMessage: async (_u, args) => { calls.sendMessage.push(args); return { conversationUid: args.conversationUid, uid: 'msg1' }; },
+    setConversationStatus: async (_u, uid, status) => { calls.setConversationStatus.push({ uid, status }); return { uid, status }; },
+    createContact: async (_u, args) => { calls.createContact.push(args); return { uid: 'c_new', ...args }; },
+    openConversation: async (_u, args) => { calls.openConversation.push(args); return { uid: 'NEW_CNV' }; },
+    ...overrides,
+  };
+  return { deps, calls };
+}
+
+console.log('\nfindExistingConversation — matches on phone and on the resolved contact:');
+{
+  const { deps } = makeDeps();
+  const hitPhone = await findExistingConversation('U', classifyTarget('+61400111222'), deps);
+  check('a phone target finds the phone-channel conversation', hitPhone?.uid === 'A');
+  const hitEmail = await findExistingConversation('U', classifyTarget('tom@example.com'), deps);
+  check('an email target finds the conversation via its resolved contact', hitEmail?.uid === 'B');
+  const miss = await findExistingConversation('U', classifyTarget('+61400999000'), deps);
+  check('an unknown target finds nothing', miss === null);
+}
+
+console.log('\ncomposeConversation — REUSE an open thread (no duplicate, no new contact):');
+{
+  const { deps, calls } = makeDeps();
+  const r = await composeConversation('U', { to: '+61 400 111 222', channel: 'phone', body: 'Hi again' }, deps);
+  check('reused=true', r.reused === true);
+  check('reopened=false (it was already open)', r.reopened === false);
+  check('returns the existing conversation id', r.conversationId === 'A');
+  check('did NOT create a contact', calls.createContact.length === 0);
+  check('did NOT reopen', calls.setConversationStatus.length === 0);
+  check('sent the body INTO the existing conversation', calls.sendMessage.length === 1 && calls.sendMessage[0].conversationUid === 'A' && calls.sendMessage[0].body === 'Hi again');
+}
+
+console.log('\ncomposeConversation — REOPEN a closed thread, then continue it:');
+{
+  const { deps, calls } = makeDeps();
+  const r = await composeConversation('U', { to: 'tom@example.com', channel: 'facebook', body: 'Following up' }, deps);
+  check('reused=true', r.reused === true);
+  check('reopened=true (it was closed)', r.reopened === true);
+  check('returns the existing conversation id', r.conversationId === 'B');
+  check('reopened via setConversationStatus(open)', calls.setConversationStatus.length === 1 && calls.setConversationStatus[0].uid === 'B' && calls.setConversationStatus[0].status === 'open');
+  check('did NOT create a contact', calls.createContact.length === 0);
+  check('sent the body into the reopened conversation', calls.sendMessage[0].conversationUid === 'B');
+}
+
+console.log('\ncomposeConversation — CREATE a brand-new thread when nothing matches:');
+{
+  const { deps, calls } = makeDeps();
+  const r = await composeConversation('U', { to: '+61400999000', channel: 'sms', body: 'Hello, this is Grays' }, deps);
+  check('reused=false', r.reused === false);
+  check('created a contact with the phone number', calls.createContact.length === 1 && calls.createContact[0].phoneNumber === '+61400999000');
+  check('opened a new conversation with the first message + the new contact', calls.openConversation.length === 1 && calls.openConversation[0].to === '+61400999000' && calls.openConversation[0].body === 'Hello, this is Grays' && calls.openConversation[0].contactUid === 'c_new');
+  check('did NOT send into an existing conversation', calls.sendMessage.length === 0);
+  check('returns the new conversation id', r.conversationId === 'NEW_CNV');
+  check('did NOT reopen anything', calls.setConversationStatus.length === 0);
+}
+
+console.log('\ncomposeConversation — validation:');
+{
+  const { deps } = makeDeps();
+  check('a junk target rejects with INVALID_COMPOSE_TARGET',
+    await throwsCode(() => composeConversation('U', { to: 'nope', channel: 'sms', body: 'x' }, deps), 'INVALID_COMPOSE_TARGET'));
+  check('an empty body rejects with COMPOSE_BODY_REQUIRED',
+    await throwsCode(() => composeConversation('U', { to: '+61400999000', channel: 'sms', body: '   ' }, deps), 'COMPOSE_BODY_REQUIRED'));
+}
+
+// --- against the REAL typed mock (proves createContact + send-to-number wiring) -------
+console.log('\nend-to-end against the typed mock (PODIUM_MOCK):');
+{
+  process.env.PODIUM_MOCK = 'true';
+  const { composeConversation: realCompose } = await import('../lib/podiumCompose.js');
+  // Maria (+61400111222) is a mock fixture with an OPEN conversation → reuse.
+  const reuse = await realCompose('GA', { to: '+61400111222', channel: 'phone', body: 'Hi Maria' });
+  check('mock: an existing fixture contact reuses its conversation', reuse.reused === true && !!reuse.conversationId);
+  // A brand-new number → create contact + open a new conversation.
+  const fresh = await realCompose('GA', { to: '+61400000123', channel: 'sms', body: 'New lead' });
+  check('mock: a new number creates a new conversation', fresh.reused === false && !!fresh.conversationId);
+  check('mock: the new conversation is readable back', fresh.conversationId !== reuse.conversationId);
+}
+
+console.log(`\n✅ compose smoke: ${passed} checks passed`);

--- a/scripts/podium-compose-smoke.mjs
+++ b/scripts/podium-compose-smoke.mjs
@@ -146,4 +146,61 @@ console.log('\nend-to-end against the typed mock (PODIUM_MOCK):');
   check('mock: the new conversation id differs from the reused one', fresh.conversationId !== reuse.conversationId);
 }
 
+// --- increment 2: the client-side helpers behind the compose UI ----------------------
+//
+// The modal validates the recipient in the browser so a typo is caught before a round-trip.
+// That duplicates lib/podiumCompose.js classifyTarget — and a DIVERGENCE is the real risk:
+// if the client is stricter the rep can't send something the server would accept, and if
+// it's looser they get an opaque 400. So the parity block below runs the SAME inputs
+// through both and asserts they agree, rather than testing the client mirror in isolation.
+console.log('\nincrement 2 — client target validation (src/utils/compose.js):');
+{
+  const { classifyComposeTarget, isValidComposeTarget, composeResultMessage } =
+    await import('../src/utils/compose.js');
+
+  check('a spaced phone is accepted', isValidComposeTarget('+61 400 111 222') === true);
+  check('an email is accepted', isValidComposeTarget('  Maria@Example.COM ') === true);
+  check('junk is rejected', isValidComposeTarget('hello there') === false);
+  check('empty is rejected', isValidComposeTarget('') === false);
+  check('a too-short number is rejected', isValidComposeTarget('12345') === false);
+  check('phone is classified as phone', classifyComposeTarget('0400 111 222')?.kind === 'phone');
+  check('email is classified as email', classifyComposeTarget('a@b.co')?.kind === 'email');
+  check('classify returns null for junk (never throws in render)', classifyComposeTarget('nope') === null);
+
+  // Parity with the server's classifyTarget across the same corpus.
+  const corpus = [
+    '+61 400 111 222', '0400111222', '(03) 8360 7047', '+61-3-8360-7047',
+    'maria@example.com', '  Maria@Example.COM ', 'a@b.co',
+    'hello there', '', '   ', '12345', 'not@anemail', '@nope.com',
+  ];
+  let agreed = 0;
+  for (const input of corpus) {
+    let serverKind = null;
+    try { serverKind = classifyTarget(input).kind; } catch { serverKind = null; }
+    const clientKind = classifyComposeTarget(input)?.kind ?? null;
+    if (serverKind !== clientKind) {
+      throw new Error(`FAIL: client/server target parity — "${input}" server=${serverKind} client=${clientKind}`);
+    }
+    agreed += 1;
+  }
+  check(`client and server classify all ${corpus.length} target cases identically`, agreed === corpus.length);
+}
+
+console.log('\nincrement 2 — compose result messaging (proves dedupe to the rep):');
+{
+  const { composeResultMessage } = await import('../src/utils/compose.js');
+  // The toast is the ONLY signal that dedupe happened — a rep who sees "Conversation
+  // started" after we actually reused a thread would reasonably think they'd duplicated it.
+  check('a created thread reads as started',
+    /started/i.test(composeResultMessage({ reused: false, reopened: false })));
+  check('a reused OPEN thread says it continued an existing conversation',
+    /existing/i.test(composeResultMessage({ reused: true, reopened: false })));
+  check('a REOPENED thread says reopened (distinct from plain reuse)',
+    /reopen/i.test(composeResultMessage({ reused: true, reopened: true })));
+  check('reopened and reused messages differ',
+    composeResultMessage({ reused: true, reopened: true }) !== composeResultMessage({ reused: true, reopened: false }));
+  check('a null result still returns a string (never renders "undefined")',
+    typeof composeResultMessage(null) === 'string' && composeResultMessage(null).length > 0);
+}
+
 console.log(`\n✅ compose smoke: ${passed} checks passed`);

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -49,6 +49,7 @@ import BackButton from '../components/backbutton';
 import HomeButton from '../components/homebutton';
 import { authHeaders, getToken, getRoles, hasAnyRole } from '../utils/auth';
 import { parseMaybeJson } from '../utils/http';
+import { classifyComposeTarget, isValidComposeTarget, composeResultMessage } from '../utils/compose';
 
 const INBOX_ROLES = ['sales', 'superadmin'];
 const POLL_MS = 8000;
@@ -174,6 +175,11 @@ export default function Inbox() {
   const [creating, setCreating] = useState(false);
   const [createEmail, setCreateEmail] = useState('');
   const [needEmail, setNeedEmail] = useState(false);
+
+  // F20 incr 2 — compose a new conversation (to a phone/email). The server dedupes:
+  // an existing thread for that number/address is reopened and continued, never duplicated.
+  const [showCompose, setShowCompose] = useState(false);
+  const [composeSending, setComposeSending] = useState(false);
 
   // F17 — workorder detail modal (opened from a workorder card in the panel).
   const [woDetail, setWoDetail] = useState(null);
@@ -325,6 +331,31 @@ export default function Inbox() {
     }
   }, []);
 
+  // Open a conversation by uid even when it isn't in the current bucket/status list —
+  // fetches it directly, then opens its thread + panel. Used by the funnel deep-link and
+  // (F20 incr 2) after composing, where the resulting thread may sit outside the active
+  // filters (e.g. bucket=mine but Podium hasn't assigned the new thread to this rep yet).
+  const openConversationById = useCallback(async (convId) => {
+    if (!convId) return false;
+    try {
+      const res = await fetch(
+        `/api/podium/inbox?resource=conversation&conversationId=${encodeURIComponent(convId)}`,
+        { headers: authHeaders() },
+      );
+      if (res.status === 401) { navigate('/'); return false; }
+      const data = await parseMaybeJson(res);
+      if (!res.ok || !data?.conversation) return false;
+      setSelectedId(convId);
+      setSelectedConv(data.conversation);
+      loadThread(convId);
+      loadPanel(convId);
+      loadAssignees(convId);
+      return true;
+    } catch {
+      return false;
+    }
+  }, [navigate, loadThread, loadPanel, loadAssignees]);
+
   // Fetch the timeline whenever the panel resolves a lead.
   useEffect(() => {
     loadLeadHistory(panel?.lead?.lead_id || null);
@@ -386,24 +417,8 @@ export default function Inbox() {
     if (!convId) return;
     deepLinkedRef.current = true;
     setBucket('all'); // widen the list so the deep-linked thread isn't behind a notLinked prompt
-    (async () => {
-      try {
-        const res = await fetch(
-          `/api/podium/inbox?resource=conversation&conversationId=${encodeURIComponent(convId)}`,
-          { headers: authHeaders() },
-        );
-        if (res.status === 401) { navigate('/'); return; }
-        const data = await parseMaybeJson(res);
-        if (res.ok && data?.conversation) {
-          setSelectedId(convId);
-          setSelectedConv(data.conversation);
-          loadThread(convId);
-          loadPanel(convId);
-          loadAssignees(convId);
-        }
-      } catch { /* deep-link is best-effort */ }
-    })();
-  }, [authorized, navigate, loadThread, loadPanel, loadAssignees]);
+    openConversationById(convId); // best-effort; swallows its own errors
+  }, [authorized, openConversationById]);
 
   // ---- Poll: refresh the list (and the open thread) for new activity -------------
   const pollNow = useCallback(async () => {
@@ -553,6 +568,35 @@ export default function Inbox() {
     loadThread(c.uid);
     loadPanel(c.uid);
     loadAssignees(c.uid);
+  };
+
+  // F20 incr 2 — start a new conversation. The SERVER dedupes (reopen-and-continue over
+  // duplicate), so the response tells us which happened and the toast reports it back:
+  // silently reusing a thread while saying "started" would read as an accidental duplicate.
+  const submitCompose = async ({ to, channel, body }) => {
+    if (composeSending) return;
+    setComposeSending(true);
+    try {
+      const res = await fetch('/api/podium/inbox?resource=compose', {
+        method: 'POST',
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
+        body: JSON.stringify({ to, channel, body }),
+      });
+      if (res.status === 401) { navigate('/'); return; }
+      const data = await parseMaybeJson(res);
+      if (!res.ok) {
+        toast.error(data?.error || 'Could not start the conversation');
+        return; // leave the modal open with the draft intact so the rep can correct it
+      }
+      setShowCompose(false);
+      toast.success(composeResultMessage(data));
+      loadConversations({ silent: true });
+      if (data?.conversationId) await openConversationById(data.conversationId);
+    } catch {
+      toast.error('Server error starting the conversation');
+    } finally {
+      setComposeSending(false);
+    }
   };
 
   // Feedback (8 Jul): a salesperson opens/closes the selected conversation. It then
@@ -874,6 +918,15 @@ export default function Inbox() {
                   </button>
                 ))}
               </div>
+              {/* F20 incr 2 — start a new conversation to a phone/email (server dedupes). */}
+              <button
+                type="button"
+                onClick={() => setShowCompose(true)}
+                className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-blue-500 bg-blue-500 text-sm text-white hover:bg-blue-600"
+                title="Start a new conversation with a phone number or email"
+              >
+                <span aria-hidden="true">✉️</span> New conversation
+              </button>
               {/* F15 — in-inbox product price/stock lookup (list cached client-side). */}
               <button
                 type="button"
@@ -1238,6 +1291,15 @@ export default function Inbox() {
           detail={woDetail}
           loading={woLoading}
           onClose={closeWorkorder}
+        />
+      )}
+
+      {/* F20 incr 2 — compose a new conversation (phone/email; the server dedupes). */}
+      {showCompose && (
+        <ComposeModal
+          sending={composeSending}
+          onSubmit={submitCompose}
+          onClose={() => setShowCompose(false)}
         />
       )}
 
@@ -1668,6 +1730,133 @@ function WorkorderModal({ workorderId, detail, loading, onClose }) {
           )}
         </div>
       </div>
+    </div>
+  );
+}
+
+// ---- Compose a new conversation (F20 incr 2) ------------------------------------
+// A rep starts a chat to a phone number or email. The DEDUPE lives on the server
+// (POST ?resource=compose reopens and continues an existing thread rather than creating a
+// duplicate), so this component deliberately makes no create/reuse decision of its own —
+// it collects the recipient + first message, and reports back what the server did.
+//
+// The recipient is validated in the browser only to catch a typo before the round-trip;
+// src/utils/compose.js mirrors the server's rule and the smoke asserts they agree.
+function ComposeModal({ sending, onSubmit, onClose }) {
+  const [to, setTo] = useState('');
+  const [body, setBody] = useState('');
+
+  const target = classifyComposeTarget(to);
+  const touched = to.trim().length > 0;
+  const targetInvalid = touched && !isValidComposeTarget(to);
+  const canSend = !sending && isValidComposeTarget(to) && body.trim().length > 0;
+
+  const submit = (e) => {
+    e.preventDefault();
+    if (!canSend) return;
+    // Channel follows the recipient type — the server defaults the same way, but sending
+    // it explicitly keeps the composed thread's ChannelBadge predictable.
+    onSubmit({ to: to.trim(), channel: target.kind, body: body.trim() });
+  };
+
+  // Escape closes — but never mid-send, or the rep loses the draft with a request in flight.
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape' && !sending) onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [sending, onClose]);
+
+  return (
+    <div
+      className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
+      onClick={() => { if (!sending) onClose(); }}
+    >
+      <form
+        className="bg-white rounded-lg shadow-lg w-full max-w-md flex flex-col"
+        onClick={(e) => e.stopPropagation()}
+        onSubmit={submit}
+      >
+        <header className="flex items-center justify-between px-5 py-3 border-b border-gray-200">
+          <h2 className="text-lg font-bold">New conversation</h2>
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={sending}
+            className="text-gray-400 hover:text-gray-700 text-xl leading-none disabled:opacity-40"
+            aria-label="Close"
+          >
+            ×
+          </button>
+        </header>
+
+        <div className="px-5 py-4 space-y-4">
+          <div>
+            <label htmlFor="compose-to" className="block text-sm font-medium text-gray-700 mb-1">
+              To
+            </label>
+            <input
+              id="compose-to"
+              type="text"
+              autoFocus
+              value={to}
+              onChange={(e) => setTo(e.target.value)}
+              placeholder="Phone number or email address"
+              className={`w-full text-sm border rounded-md px-3 py-2 focus:outline-none focus:ring-2 ${
+                targetInvalid
+                  ? 'border-red-400 focus:ring-red-300'
+                  : 'border-gray-300 focus:ring-blue-400'
+              }`}
+            />
+            {targetInvalid && (
+              <p className="mt-1 text-xs text-red-600">
+                Enter a valid phone number or email address.
+              </p>
+            )}
+            {target && (
+              <p className="mt-1 text-xs text-gray-500">
+                Sending by {target.kind === 'email' ? 'email' : 'text message'}.
+              </p>
+            )}
+          </div>
+
+          <div>
+            <label htmlFor="compose-body" className="block text-sm font-medium text-gray-700 mb-1">
+              Message
+            </label>
+            <textarea
+              id="compose-body"
+              rows={4}
+              value={body}
+              onChange={(e) => setBody(e.target.value)}
+              placeholder="Type the first message…"
+              className="w-full text-sm border border-gray-300 rounded-md px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-400"
+            />
+          </div>
+
+          <p className="text-[11px] text-gray-500">
+            If this customer already has a conversation, it will be reopened and continued
+            rather than duplicated.
+          </p>
+        </div>
+
+        <footer className="flex items-center justify-end gap-2 px-5 py-3 border-t border-gray-200">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={sending}
+            className="px-3 py-1.5 rounded-lg border border-gray-300 bg-white text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-40"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={!canSend}
+            className="px-3 py-1.5 rounded-lg bg-blue-500 text-white text-sm hover:bg-blue-600 disabled:opacity-40 disabled:hover:bg-blue-500"
+          >
+            {sending ? 'Starting…' : 'Start conversation'}
+          </button>
+        </footer>
+      </form>
     </div>
   );
 }

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -53,6 +53,7 @@ import { classifyComposeTarget, isValidComposeTarget, composeResultMessage } fro
 
 const INBOX_ROLES = ['sales', 'superadmin'];
 const POLL_MS = 8000;
+const COMPOSE_TIMEOUT_MS = 30000; // give up on a stalled compose rather than lock the modal
 
 // Channel presentation (label + Tailwind classes). Falls back to the raw type.
 const CHANNELS = {
@@ -180,6 +181,7 @@ export default function Inbox() {
   // an existing thread for that number/address is reopened and continued, never duplicated.
   const [showCompose, setShowCompose] = useState(false);
   const [composeSending, setComposeSending] = useState(false);
+  const composeSendingRef = useRef(false); // synchronous double-submit guard (see submitCompose)
 
   // F17 — workorder detail modal (opened from a workorder card in the panel).
   const [woDetail, setWoDetail] = useState(null);
@@ -335,8 +337,31 @@ export default function Inbox() {
   // fetches it directly, then opens its thread + panel. Used by the funnel deep-link and
   // (F20 incr 2) after composing, where the resulting thread may sit outside the active
   // filters (e.g. bucket=mine but Podium hasn't assigned the new thread to this rep yet).
+  const clearAttachments = useCallback(() => {
+    setAttachments((prev) => {
+      prev.forEach((a) => URL.revokeObjectURL(a.url));
+      return [];
+    });
+  }, []);
+
+  // Everything the rep may have typed for the PREVIOUS thread. Reset whenever the open
+  // conversation changes, so a draft (or an active internal-note mode) can't follow them
+  // into a different customer's thread.
+  const resetComposerState = useCallback(() => {
+    setComposerMode('reply');
+    setShowTemplates(false);
+    setDraft('');
+    clearAttachments();
+  }, [clearAttachments]);
+
   const openConversationById = useCallback(async (convId) => {
     if (!convId) return false;
+    // Reset the composer before switching threads. Without this, a half-typed reply to
+    // customer A (and, worse, an active internal-note mode) survives into customer B's
+    // thread — one Send away from a genuine mis-send. Reaching a thread WITHOUT clicking a
+    // list item is new here, so this path clears; the pre-existing openConversation click
+    // path has the same gap and is recorded in the backlog rather than fixed in passing.
+    resetComposerState();
     try {
       const res = await fetch(
         `/api/podium/inbox?resource=conversation&conversationId=${encodeURIComponent(convId)}`,
@@ -354,7 +379,7 @@ export default function Inbox() {
     } catch {
       return false;
     }
-  }, [navigate, loadThread, loadPanel, loadAssignees]);
+  }, [navigate, loadThread, loadPanel, loadAssignees, resetComposerState]);
 
   // Fetch the timeline whenever the panel resolves a lead.
   useEffect(() => {
@@ -516,13 +541,6 @@ export default function Inbox() {
     });
   };
 
-  const clearAttachments = useCallback(() => {
-    setAttachments((prev) => {
-      prev.forEach((a) => URL.revokeObjectURL(a.url));
-      return [];
-    });
-  }, []);
-
   // F12 — insert a Podium message template into the reply draft.
   const insertTemplate = (tpl) => {
     setComposerMode('reply');
@@ -542,10 +560,7 @@ export default function Inbox() {
     setLeadHistory([]);
     setAssignees([]);
     setShowAssign(false);
-    setComposerMode('reply');
-    setShowTemplates(false);
-    setDraft('');
-    clearAttachments();
+    resetComposerState();
   };
 
   const switchBucket = (next) => {
@@ -574,13 +589,23 @@ export default function Inbox() {
   // duplicate), so the response tells us which happened and the toast reports it back:
   // silently reusing a thread while saying "started" would read as an accidental duplicate.
   const submitCompose = async ({ to, channel, body }) => {
-    if (composeSending) return;
+    // Guard on a ref, not on composeSending: the state value is captured at render, so two
+    // submits dispatched before React re-renders (key-repeat on Enter in the To field) would
+    // both read `false`. Dedupe would keep them to ONE thread but the customer would still
+    // receive the message twice.
+    if (composeSendingRef.current) return;
+    composeSendingRef.current = true;
     setComposeSending(true);
+    // A stalled connection (warehouse wifi, hotspot handover) would otherwise leave the
+    // modal locked with no way out but a reload, which loses the draft anyway.
+    const abort = new AbortController();
+    const timeout = setTimeout(() => abort.abort(), COMPOSE_TIMEOUT_MS);
     try {
       const res = await fetch('/api/podium/inbox?resource=compose', {
         method: 'POST',
         headers: authHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({ to, channel, body }),
+        signal: abort.signal,
       });
       if (res.status === 401) { navigate('/'); return; }
       const data = await parseMaybeJson(res);
@@ -591,10 +616,33 @@ export default function Inbox() {
       setShowCompose(false);
       toast.success(composeResultMessage(data));
       loadConversations({ silent: true });
-      if (data?.conversationId) await openConversationById(data.conversationId);
-    } catch {
-      toast.error('Server error starting the conversation');
+      // Landing the rep in the thread is an acceptance criterion, so a failure here must be
+      // said out loud — the modal and the draft are already gone, and on bucket=mine the new
+      // thread may not be in the list either, leaving them with no way back to it.
+      const opened = data?.conversationId
+        ? await openConversationById(data.conversationId)
+        : false;
+      if (!opened) {
+        toast('Started — find it under All conversations', { icon: 'ℹ️' });
+      } else if (bucket !== 'all') {
+        // Widen the list so the thread the rep is now reading is actually in it (Podium may
+        // not have assigned a brand-new conversation to them yet). Same reasoning as the
+        // funnel deep-link; setBucket directly, since switchBucket would clear the selection.
+        setBucket('all');
+      }
+    } catch (err) {
+      // The server sends to Podium BEFORE it responds, so a lost response does not mean a
+      // lost message. Saying "server error" here invites a retry that texts the customer a
+      // second time — dedupe protects the thread, not the message.
+      toast.error(
+        err?.name === 'AbortError'
+          ? 'Timed out — the message may already have been sent. Check the inbox before retrying.'
+          : "Couldn't confirm — the message may already have been sent. Check the inbox before retrying.",
+      );
+      loadConversations({ silent: true }); // so the thread shows up if it did land
     } finally {
+      clearTimeout(timeout);
+      composeSendingRef.current = false;
       setComposeSending(false);
     }
   };
@@ -1766,10 +1814,20 @@ function ComposeModal({ sending, onSubmit, onClose }) {
     return () => window.removeEventListener('keydown', onKey);
   }, [sending, onClose]);
 
+  // Backdrop-to-close only while nothing has been typed. Selecting text in the textarea and
+  // releasing outside the form fires a click on the BACKDROP (the form's stopPropagation
+  // can't help — the backdrop is the target), which would discard the message with no undo.
+  // Escape, Cancel and × remain, so nothing is trapped.
+  const closeOnBackdrop = () => {
+    if (sending) return;
+    if (to.trim() || body.trim()) return;
+    onClose();
+  };
+
   return (
     <div
       className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
-      onClick={() => { if (!sending) onClose(); }}
+      onClick={closeOnBackdrop}
     >
       <form
         className="bg-white rounded-lg shadow-lg w-full max-w-md flex flex-col"

--- a/src/utils/compose.js
+++ b/src/utils/compose.js
@@ -10,7 +10,11 @@
 // and fails on any divergence; if you change one, change the other.
 
 const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-const MIN_PHONE_DIGITS = 6;
+// Exported so the smoke can assert it EQUALS the server's threshold directly. A corpus of
+// example numbers can't do that on its own: every real-world number has 10-11 digits, so
+// tightening this to 8 or 10 would still classify every example identically and ship green
+// while silently blocking a short local number the server accepts.
+export const MIN_PHONE_DIGITS = 6;
 
 // Classify a recipient as a phone or an email. Returns { kind, value } or null — it never
 // throws, because it runs on every keystroke in render.
@@ -30,7 +34,11 @@ export function isValidComposeTarget(to) {
 // What the rep is told after composing. This toast is the ONLY signal that dedupe did its
 // job: after reusing an existing thread, "Conversation started" would read as a duplicate.
 export function composeResultMessage(result) {
-  if (result?.reused && result?.reopened) return 'Reopened and continued the existing conversation';
-  if (result?.reused) return 'Continued the existing conversation';
+  // A response we can't read (proxy-mangled body, non-JSON 200) must NOT fall through to
+  // "started" — claiming a fresh thread when one may have been reused is the precise
+  // mis-signal this message exists to prevent.
+  if (typeof result?.reused !== 'boolean') return 'Conversation ready — opening it now';
+  if (result.reused && result.reopened) return 'Reopened and continued the existing conversation';
+  if (result.reused) return 'Continued the existing conversation';
   return 'Conversation started';
 }

--- a/src/utils/compose.js
+++ b/src/utils/compose.js
@@ -1,0 +1,36 @@
+// src/utils/compose.js — F20 increment 2: pure helpers behind the inbox compose modal.
+//
+// Kept out of the component (and free of JSX/React) so scripts/podium-compose-smoke.mjs
+// can import it directly in node — the same arrangement as src/utils/lotLabels.js.
+//
+// ⚠️ PARITY: classifyComposeTarget MIRRORS lib/podiumCompose.js classifyTarget. The server
+// stays authoritative — this only exists so a typo is caught before a round-trip — but the
+// two must agree on what is valid, or the rep is either blocked from sending something the
+// server would accept, or shown an opaque 400. The smoke runs a shared corpus through BOTH
+// and fails on any divergence; if you change one, change the other.
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+const MIN_PHONE_DIGITS = 6;
+
+// Classify a recipient as a phone or an email. Returns { kind, value } or null — it never
+// throws, because it runs on every keystroke in render.
+export function classifyComposeTarget(to) {
+  const value = String(to ?? '').trim();
+  if (!value) return null;
+  if (EMAIL_RE.test(value)) return { kind: 'email', value };
+  const digits = value.replace(/\D/g, '');
+  if (digits.length >= MIN_PHONE_DIGITS) return { kind: 'phone', value };
+  return null;
+}
+
+export function isValidComposeTarget(to) {
+  return classifyComposeTarget(to) !== null;
+}
+
+// What the rep is told after composing. This toast is the ONLY signal that dedupe did its
+// job: after reusing an existing thread, "Conversation started" would read as a duplicate.
+export function composeResultMessage(result) {
+  if (result?.reused && result?.reopened) return 'Reopened and continued the existing conversation';
+  if (result?.reused) return 'Continued the existing conversation';
+  return 'Conversation started';
+}


### PR DESCRIPTION
## What & why

**F20 — "start a new chat to a phone/email", now complete across both increments.**

- **Increment 1** — the create-or-reopen backend seam.
- **Increment 2** *(added)* — the inbox UI that reaches it. A rep clicks **New conversation**, types a phone number or email plus a first message, and lands in the resulting thread.

**Dedupe is the feature's value:** before creating anything, look for an existing conversation for that phone/email. If one exists → **reopen it (if closed) and continue it**; only when nothing matches → create the Podium contact and open a fresh thread. Reuses the F4 phone normalisation (`phoneKey`) and F11 open/close.

The dedupe decision stays **entirely on the server**. The UI makes no create/reuse choice — it reports back what the server did, because that toast is the only signal the rep gets that dedupe happened. Silently reusing a thread while saying "Conversation started" would read as an accidental duplicate.

## Changes (mock-first, no migration, no new serverless fn)

### Increment 1 — backend seam
- **`lib/podiumCompose.js`** (new): `classifyTarget` (phone|email + match key), `contactMatchesTarget`, `findExistingConversation` (prefers an open match, early-breaks on it), `composeConversation` (reopen-or-create). Podium service fns are **injectable** so the decision is unit-tested with no network/DB.
- **`lib/podium.js`**: `createContact` (POST /contacts) + `openConversation` (POST /conversations — kept **separate** from `sendMessage` so a system SMS never spawns a thread).
- **`lib/podium.mock.js`**: `POST /contacts` (idempotent create, dedupes on phone/email), `POST /conversations` (opens a thread + first message, real timestamp).
- **`lib/podiumRoutes/inbox.js`**: `POST ?resource=compose { to, channel, body }` (sales/superadmin gate inherited; rep's token P4; **201** created / **200** reused; **400** on bad target/empty body). No chat body persisted (**P1**).

### Increment 2 — inbox compose UI
- **`src/utils/compose.js`** (new): `classifyComposeTarget` / `isValidComposeTarget` / `composeResultMessage`. Pure and JSX-free so the smoke imports it directly in node — same arrangement as `src/utils/lotLabels.js`.
- **`src/pages/inbox.js`**: **New conversation** header button + `ComposeModal` (recipient with live validation, message, send/cancel, Escape-to-close). On success: toast what actually happened → refresh list → open the thread.
- **`openConversationById`** extracted from the funnel deep-link effect and reused by compose — a composed thread can sit outside the active bucket/status filters (e.g. `bucket=mine` before Podium assigns it), so it opens the thread regardless and widens the bucket to **All** so the list matches what's on screen.

## Verification

- compose smoke **38 → 55**; all **15 suites green** (inbox **128** regression); `CI=true npm run build` exit 0 (`main.10f2dfe9.js`, 163.61 kB).
- Client validation duplicates the server's `classifyTarget`, so the smoke runs a shared **17-case corpus through BOTH** and fails on any disagreement — plus asserts the digit threshold itself is equal. **Mutation-checked:** forcing the client threshold to 10 fails the suite; reverting the unreadable-response guard fails the suite.

## Code review (pre-push) — no Critical

Four Important, all fixed in `c6fd1a5`:
1. **A stalled request trapped the rep in the modal** — every exit was gated on `!sending` and the fetch had no timeout. Now a 30s `AbortController` releases the controls and keeps the draft.
2. **The error copy invited a double text** — the server sends to Podium *before* it responds, so a lost response doesn't mean a lost message; "server error" reads as "it didn't go", the rep retries, and the customer gets it twice. Dedupe protects the *thread*, not the *message*. Copy now says it may already have sent, and the list refreshes.
3. **"Rep lands in the thread" (an acceptance criterion) failed silently** — the failure return was discarded. Now reported.
4. **The parity smoke couldn't see the likeliest divergence** — every realistic number has 10–11 digits, so any client threshold from 6 to 10 passed the old corpus. Threshold now asserted equal, with on-boundary cases.

Minors fixed: ref-based double-submit guard (key-repeat on Enter could send twice); backdrop click no longer discards a typed message; an unreadable 200 no longer claims "started"; `openConversationById` resets the composer so a half-typed reply (or internal-note mode) can't follow the rep into another customer's thread.

**Recorded, not fixed here:** no React component tests (RTL is present, but CI discovers only `*-smoke.mjs`, so a component test would run nowhere until #77 merges); modals lack `role="dialog"`/focus trap (pre-existing across all four in this file); `openConversation`'s click path has the same composer-reset gap.

## ⚠️ Live-wiring VERIFY (before this route is pointed at live Podium)

1. **Dedupe must become contact-search-FIRST.** The current dedupe scans one page (≤100) of the most-recent conversations — fine for the mock, but the real org has thousands, so an older existing thread would be missed and a **duplicate** created. Replace with a Podium contact search by phone/email (F4/F14 approach) → then that contact's conversations. **(F20 wiring task #1.)**
2. `createContact` / `openConversation` request shapes are unverified (Podium may open the thread implicitly on first POST /messages). Isolated in those two service fns.
3. `openConversation` is non-idempotent (a lost response on create → retry could double a thread).

## How to test on the Preview

1. Log in as a **sales** or **superadmin** user → **Inbox**.
2. Click **✉️ New conversation**. Type junk (`hello there`) → the field goes red and **Start conversation** stays disabled.
3. Enter a **brand-new** number (e.g. `+61400000999`) + a message → **"Conversation started"**, and you land in the new thread.
4. Repeat with **`+61400111222`** (mock fixture Maria, thread already open) → **"Continued the existing conversation"**, and **no duplicate** appears in the list.
5. Repeat with **`+61400555666`** (mock fixture Linda, only thread is *closed*) → **"Reopened and continued the existing conversation"**.
6. Type a message, then click the dark backdrop → the modal **stays open** (draft preserved). Clear both fields, click backdrop → closes.

## Reviewer checklist
- [ ] Dedupe: reuse open / reopen closed / create-new all correct; no duplicate on the mock.
- [ ] The toast always tells the rep which of the three happened.
- [ ] P1 (no body persisted) & P4 (rep's token); endpoint gated to sales/superadmin.
- [ ] `sendSystemSms` untouched (can't spawn a thread).
- [ ] Approve & merge, **or** leave feedback.

_Note: F24's CI workflow isn't merged yet, so no GitHub Actions run fires on this PR — verified locally instead._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
