### PR TITLE
F21 — Make the workorder handler testable, and cover completion

### DIFF
--- a/lib/handlers/workorder.js
+++ b/lib/handlers/workorder.js
@@ -61,14 +61,23 @@ async function adjustProductStock(client, sku, delta) {
   return { before: current, after: next };
 }
 
-export default async function handler(req, res) {
+// deps.getClient lets an offline smoke inject a fake pg client (default = the real pool),
+// mirroring lib/handlers/leads.js. Pure test-enablement — no behaviour change (F21).
+//
+// `sub` is unused today (workorder has no sub-paths) but is kept in leads.js's ARGUMENT
+// POSITION deliberately: api/[...path].js passes `parts.slice(1)` as arg 3 to every other
+// sub-path handler, so if this route ever gains one (/api/workorder/:id/history is the
+// obvious candidate) the router would hand an array to `deps`, `deps.getClient` would be
+// undefined, and this would silently fall back to the real pool instead of failing loudly.
+export default async function handler(req, res, sub = [], deps = {}) {
   const {
     method,
     query: { id },
     body,
   } = req;
 
-  const client = await getClientWithTimezone();
+  const getClient = deps.getClient || getClientWithTimezone;
+  const client = await getClient();
 
   try {
     if (method === 'GET') {
@@ -840,7 +849,9 @@ export default async function handler(req, res) {
 
       // Return updated resource
       req.query.id = id;
-      return await handler({ ...req, method: 'GET' }, res);
+      // Pass deps through: without it this re-read would acquire a REAL pool client even
+      // when the caller injected one, so an offline test would silently hit the network.
+      return await handler({ ...req, method: 'GET' }, res, sub, deps);
     }
 
     /** =========================

--- a/scripts/podium-workorder-smoke.mjs
+++ b/scripts/podium-workorder-smoke.mjs
@@ -1,0 +1,230 @@
+// scripts/podium-workorder-smoke.mjs — offline smoke for lib/handlers/workorder.js (F21).
+//
+// The workorder handler is the busiest write path in the portal (890 lines: inventory,
+// per-item status, auto-completion, delivery creation, append-only logs) and until now it
+// had ZERO test cover, because it built its own pg client and so could not be driven
+// offline. F21 injects deps.getClient; this suite is what that buys.
+//
+// Its focus is the COMPLETION LOGIC — the part other features hang off (F6's Customer-360
+// journey reads workorder_logs; F7c creates the shell; the scrapped F8c hung its review
+// request here) and the part where the F8c review already found one real bug.
+//
+// These are CHARACTERIZATION tests: they pin down what the handler does TODAY, including
+// the §4 inconsistency that F22 is a decision about. Where behaviour looks wrong, the test
+// says so in its name rather than asserting the behaviour someone might prefer — F21 is a
+// pure test-enablement refactor and must not change behaviour.
+//
+//   node scripts/podium-workorder-smoke.mjs
+
+import handler from '../lib/handlers/workorder.js';
+
+let passed = 0;
+function check(name, cond, detail) {
+  if (!cond) throw new Error(`FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  passed += 1;
+  console.log(`  ✓ ${name}`);
+}
+
+// --- fakes ---------------------------------------------------------------------------
+// A pg-shaped client that answers by SQL pattern and RECORDS every statement, so a test
+// can assert on what the handler actually wrote (which log rows, which INSERTs) rather
+// than only on the response body.
+//
+// KNOWN LIMITS of this fake (so nobody over-trusts a green run):
+//  • ONE client object is shared with the recursive GET re-read, where production checks
+//    out a second pool client — so a leak in that path is invisible here.
+//  • Transactions are NOT modelled: ROLLBACK does not un-record statements. Asserting
+//    "wrote nothing" is only meaningful when the ROLLBACK precedes every write, as it
+//    does in the guard cases below.
+//  • Unmatched SQL returns an empty result rather than failing, so a newly added query
+//    will read as "no rows" instead of erroring.
+function fakeClient({ workorder, itemCountsBefore, itemCountsAfter }) {
+  const log = [];
+  let countCalls = 0;
+  const client = {
+    log,
+    released: false,
+    async query(sql, params) {
+      const text = String(sql);
+      log.push({ sql: text.replace(/\s+/g, ' ').trim(), params });
+
+      if (/^\s*(BEGIN|COMMIT|ROLLBACK)\s*$/i.test(text)) return { rows: [], rowCount: 0 };
+      if (/SELECT access FROM users/i.test(text)) return { rows: [{ access: 'staff' }], rowCount: 1 };
+      if (/SELECT \* FROM workorder WHERE workorder_id/i.test(text)) {
+        return workorder ? { rows: [workorder], rowCount: 1 } : { rows: [], rowCount: 0 };
+      }
+      // The same counts query runs before and after the item updates.
+      if (/COUNT\(\*\) FILTER \(WHERE status = 'Completed'\)/i.test(text)) {
+        countCalls += 1;
+        const c = countCalls === 1 ? itemCountsBefore : itemCountsAfter;
+        return { rows: [{ done: String(c.done), total: String(c.total) }], rowCount: 1 };
+      }
+      if (/SELECT status FROM workorder WHERE workorder_id/i.test(text)) {
+        return { rows: [{ status: workorder?.status ?? null }], rowCount: workorder ? 1 : 0 };
+      }
+      // The PUT ends by re-reading the resource through the GET branch.
+      if (/WITH base AS/i.test(text)) return { rows: [{ workorder_id: workorder.workorder_id }], rowCount: 1 };
+      return { rows: [], rowCount: 0 };
+    },
+    release() { client.released = true; },
+  };
+  return client;
+}
+
+function fakeRes() {
+  const res = { statusCode: null, payload: null, headers: {} };
+  res.status = (c) => { res.statusCode = c; return res; };
+  res.json = (p) => { res.payload = p; return res; };
+  res.end = () => res;
+  res.setHeader = (k, v) => { res.headers[k] = v; };
+  return res;
+}
+
+const WO = {
+  workorder_id: 41,
+  invoice_id: 'INV-41',
+  customer_id: 7,
+  status: 'Work Ordered',
+  outstanding_balance: 500,
+  delivery_state: 'VIC',
+  delivery_suburb: 'Altona North',
+  delivery_charged: 150,
+  notes: null,
+  delivery_type: 'Standard',
+  free_delivery: false,
+  cash_to_removalist: false,
+  installation_cost: null,
+};
+
+function events(client) {
+  return client.log
+    .filter((q) => /INSERT INTO workorder_logs/i.test(q.sql))
+    .map((q) => q.params[2]);
+}
+function deliveryInserts(client) {
+  return client.log.filter((q) => /INSERT INTO delivery/i.test(q.sql));
+}
+
+async function runPut(body, counts, wo = WO) {
+  const client = fakeClient({
+    workorder: { ...wo },
+    itemCountsBefore: counts.before,
+    itemCountsAfter: counts.after,
+  });
+  const req = { method: 'PUT', query: { id: '41' }, body, headers: { 'x-user-id': 'GA' } };
+  const res = fakeRes();
+  await handler(req, res, [], { getClient: async () => client });
+  return { client, res };
+}
+
+console.log('F21 workorder handler smoke — no DB, no network\n');
+
+console.log('dependency injection (the refactor itself):');
+{
+  const { client } = await runPut({ notes: 'hello' }, { before: { done: 0, total: 2 }, after: { done: 0, total: 2 } });
+  check('the handler runs entirely against an injected client', client.log.length > 0);
+  check('the injected client is released', client.released === true);
+  check('work is committed, not left open', client.log.some((q) => /^COMMIT$/i.test(q.sql)));
+  // If deps were dropped by the recursive GET re-read, that call would build a REAL pool
+  // client and this suite would hit the network instead of failing loudly.
+  check('the closing re-read also uses the injected client (deps survive recursion)',
+    client.log.some((q) => /WITH base AS/i.test(q.sql)));
+}
+
+console.log('\nitem-driven completion (§3) — the normal workshop path:');
+{
+  const { client } = await runPut({}, { before: { done: 1, total: 2 }, after: { done: 2, total: 2 } });
+  const ev = events(client);
+  check('the workorder is auto-completed', client.log.some((q) => /UPDATE workorder SET status = 'Completed'/i.test(q.sql)));
+  check('WORKORDER_COMPLETED is logged', ev.includes('WORKORDER_COMPLETED'));
+  check('WORKORDER_STATUS_CHANGED is logged alongside it', ev.includes('WORKORDER_STATUS_CHANGED'));
+  check('a delivery is created', deliveryInserts(client).length === 1);
+  check('DELIVERY_ORDER_CREATED is logged', ev.includes('DELIVERY_ORDER_CREATED'));
+  check('the delivery carries the workorder id', deliveryInserts(client)[0].params.includes(41));
+}
+
+console.log('\nalready-complete edit — must not fire the transition twice:');
+{
+  const { client } = await runPut({ notes: 'late note' },
+    { before: { done: 2, total: 2 }, after: { done: 2, total: 2 } },
+    { ...WO, status: 'Completed' });
+  const ev = events(client);
+  check('WORKORDER_COMPLETED is NOT logged again', !ev.includes('WORKORDER_COMPLETED'));
+  check('no second delivery is created', deliveryInserts(client).length === 0);
+}
+
+console.log('\nexplicit completion (§4) — F22, characterized not corrected:');
+{
+  // status='Completed' set directly while items are NOT all complete.
+  const { client } = await runPut({ status: 'Completed' },
+    { before: { done: 0, total: 2 }, after: { done: 0, total: 2 } });
+  const ev = events(client);
+  check('the status IS applied', client.log.some((q) => /UPDATE workorder SET status = \$1/i.test(q.sql)));
+  check('WORKORDER_STATUS_CHANGED is logged', ev.includes('WORKORDER_STATUS_CHANGED'));
+  // ⚠️ Both of these are the F22 gap. They pass because they assert TODAY'S behaviour.
+  check('⚠️ F22: WORKORDER_COMPLETED is NOT logged (journey under-reports)', !ev.includes('WORKORDER_COMPLETED'));
+  check('⚠️ F22: NO delivery is created (a completed order never reaches To Be Booked)',
+    deliveryInserts(client).length === 0);
+}
+
+console.log('\nexplicit completion WITH all items done — §3 covers for §4:');
+{
+  const { client } = await runPut({ status: 'Completed' },
+    { before: { done: 1, total: 2 }, after: { done: 2, total: 2 } });
+  const ev = events(client);
+  check('WORKORDER_COMPLETED IS logged (via §3)', ev.includes('WORKORDER_COMPLETED'));
+  check('a delivery IS created', deliveryInserts(client).length === 1);
+}
+
+console.log('\nexplicit completion as the SOLE cause of the delivery (§3 override):');
+{
+  // Items were ALREADY all complete before this request, so transitionedToCompletedViaItems
+  // is false and `explicitCompletedNow` is the only thing that can create the delivery.
+  // Without this case that override can be deleted with every other check still passing —
+  // and it is precisely the branch F22's decision is about.
+  const { client } = await runPut({ status: 'Completed' },
+    { before: { done: 2, total: 2 }, after: { done: 2, total: 2 } },
+    { ...WO, status: 'Work Ordered' });
+  check('the explicit override alone creates the delivery', deliveryInserts(client).length === 1);
+  check('DELIVERY_ORDER_CREATED is logged on that path', events(client).includes('DELIVERY_ORDER_CREATED'));
+  // Characterization, same F22 family: §3 logs the status change, then §4's condition is
+  // STILL true ('Completed' !== 'Work Ordered'), so it updates and logs a SECOND time.
+  check('⚠️ F22: WORKORDER_STATUS_CHANGED is logged TWICE (§3 then §4)',
+    events(client).filter((e) => e === 'WORKORDER_STATUS_CHANGED').length === 2);
+}
+
+console.log('\nempty workorder — the totalAfter > 0 guard:');
+{
+  // Cancelling the last item leaves done=0,total=0. Without the guard 0 === 0 reads as
+  // "all complete", so an EMPTY workorder would auto-complete and drop a phantom delivery
+  // into To Be Booked for logistics to try to book.
+  const { client } = await runPut({}, { before: { done: 0, total: 1 }, after: { done: 0, total: 0 } });
+  check('an empty workorder is NOT auto-completed',
+    !client.log.some((q) => /UPDATE workorder SET status = 'Completed'/i.test(q.sql)));
+  check('and creates no delivery', deliveryInserts(client).length === 0);
+  check('and logs no completion', !events(client).includes('WORKORDER_COMPLETED'));
+}
+
+console.log('\nno-op status write — must not pollute the append-only log:');
+{
+  // Same status in as out. workorder_logs is append-only, so a spurious row can't be undone.
+  const { client } = await runPut({ status: 'Work Ordered' },
+    { before: { done: 0, total: 2 }, after: { done: 0, total: 2 } });
+  check('no redundant UPDATE is issued', !client.log.some((q) => /UPDATE workorder SET status = \$1/i.test(q.sql)));
+  check('no spurious WORKORDER_STATUS_CHANGED row', !events(client).includes('WORKORDER_STATUS_CHANGED'));
+}
+
+console.log('\nguards:');
+{
+  const client = fakeClient({ workorder: null, itemCountsBefore: { done: 0, total: 0 }, itemCountsAfter: { done: 0, total: 0 } });
+  const res = fakeRes();
+  await handler({ method: 'PUT', query: { id: '999' }, body: {}, headers: {} }, res, [], { getClient: async () => client });
+  check('an unknown workorder is 404', res.statusCode === 404);
+  check('and is rolled back, not left in a transaction', client.log.some((q) => /^ROLLBACK$/i.test(q.sql)));
+
+  const bad = await runPut({ status: 'Banana' }, { before: { done: 0, total: 1 }, after: { done: 0, total: 1 } });
+  check('an invalid status is 400', bad.res.statusCode === 400);
+  check('and writes nothing', !bad.client.log.some((q) => /UPDATE workorder SET status/i.test(q.sql)));
+}
+
+console.log(`\n✅ workorder smoke: ${passed} checks passed`);


### PR DESCRIPTION
## What & why

`lib/handlers/workorder.js` is **the busiest write path in the portal** — 890 lines covering inventory, per-item status, auto-completion, delivery creation and the append-only `workorder_logs` feed that F6's Customer-360 reads. It had **zero test coverage**, because it built its own pg client and so could not be driven offline. That is exactly where the F8c code review found a real bug (the explicit-completion path silently missed a trigger).

This is the enablement, plus the first suite over the completion logic.

## Pure test-enablement — no behaviour change

- `handler(req, res, sub = [], deps = {})` + `getClient = deps.getClient || getClientWithTimezone` — the pattern `lib/handlers/leads.js` already uses.
  - `sub` is unused today but kept in **leads.js's argument position** on purpose: the router passes `parts.slice(1)` as **arg 3** to every other sub-path handler, so if this route ever gains one (`/api/workorder/:id/history` is the obvious candidate), arg 3 would land in `deps`, `deps.getClient` would be `undefined`, and it would **silently fall back to the real pool** instead of failing loudly.
- `deps` passed through the handler's **one recursive self-call** (PUT ends by re-reading the resource through its own GET branch). Without this, an injected client is dropped halfway and an "offline" test quietly hits the network.

**Production is unaffected:** `api/[...path].js` calls it with two arguments, so `deps` is `{}` and the real pool is used exactly as before. Bundle is byte-identical (162.49 kB) — backend-only.

## The suite — `scripts/podium-workorder-smoke.mjs` (30 checks)

Drives the **real handler** through a fake pg client that **records every statement**, so assertions are about what was actually written — which log rows, which INSERTs — not just the response body.

Covered: dependency injection itself (incl. deps surviving the recursion), item-driven completion, the already-complete no-op, explicit completion, the `explicitCompletedNow` delivery override in isolation, the empty-workorder guard, the no-op status write, and the 404/400/ROLLBACK guards.

## ⚠️ These are CHARACTERIZATION tests — they pin today's behaviour, including F22

Two assertions pin behaviour that is **arguably wrong**. They are tracked as **F22** (a decision for Nick), and F21 must not change them — only make them visible:

1. **Explicit `status='Completed'` with items incomplete** logs **no `WORKORDER_COMPLETED`** and creates **no delivery**, unlike the item-driven path. So the journey feed under-reports completions, and a completed order never reaches **To Be Booked**.
2. When it *does* go through the item path, **`WORKORDER_STATUS_CHANGED` is logged twice** (§3, then §4's condition is still true) — two identical rows per request in the feed Customer-360 reads.

Both are marked with ⚠️ and named as F22 in the test output, so no future reader mistakes them for a specification. **F22 now has runnable evidence instead of needing an investigation.**

## Code review — mutation-tested, no Critical

The review ran mutation testing and found **three branches that could be deleted with every check still passing**. All three are now covered:

| Deleted branch | What it would have let through |
|---|---|
| `\|\| explicitCompletedNow` (delivery override) | **The branch F22 is actually about** — the suite pinned nothing about the one thing it existed to give evidence on |
| `totalAfter > 0` guard | Cancelling the last item makes an **empty workorder auto-complete** and drop a **phantom delivery** into To Be Booked |
| §4's `status !== beforeWO.status` guard | Re-saving the same status writes a spurious row into an **append-only** log that cannot be cleaned up |

Re-ran all four mutants (those three plus dropping `deps` from the recursion) against the final suite: **all caught**.

Also applied: the `sub`-position fix above, `workorder?.status` guard in the fake, and a documented list of the fake's limits (one shared client vs production's two; transactions not modelled; unmatched SQL returns empty rather than failing).

## Known gaps (deliberately not covered here)

DELETE; `adjustProductStock` and the insufficient-stock 409 / not-found 404 / invalid-math 400 mapping; the item loop (§2); `add_items` / `delete_item_ids`; POST; and the `selling_price` visibility gate (the fake always returns access `'staff'`). Ranked roughly by risk of the uncovered write — DELETE is the highest.

## Verification

- workorder smoke **30/30**; **all 15 suites green**; `CI=true npm run build` exit 0; bundle **byte-identical**.

## Reviewer checklist
- [ ] Agree this is behaviour-preserving for production (2-arg call → `deps = {}` → real pool).
- [ ] Agree the two ⚠️ F22 assertions describe what you want *pinned*, not what you want *kept* — **F22 is still yours to decide**.
- [ ] Approve & merge, or leave feedback.

_Note: F24's CI workflow (#77) isn't merged yet, so no GitHub Actions run fires on this PR — verified locally instead. Merging #77 would also start running this suite automatically._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
