### PR TITLE
Lock the delivery-booked customer SMS to superadmin (temporary, pending copy sign-off)

### DIFF
--- a/lib/handlers/delivery.js
+++ b/lib/handlers/delivery.js
@@ -7,7 +7,7 @@ import {
   notifyDeliveryBooked,
   declineDeliveryBookedSms,
 } from '../deliveryNotify.js';
-import { getAuthUser } from '../rbac.js';
+import { requireRoles, BOOKING_SMS_ROLES } from '../rbac.js';
 
 const CUSTOMER_COLLECT_ID = 15;
 
@@ -37,17 +37,28 @@ export default async function handler(req, res) {
     //
     // Unlike the rest of this handler (legacy, ungated, identifies the actor from a body
     // field), this one REQUIRES a valid login token: it texts a customer, so the actor
-    // must be real and attributable. Safe to gate because its only caller is new UI that
-    // sends the token. Not role-gated beyond authentication — the `logistics` role isn't
-    // assigned to anyone yet, and gating on it would lock out the admins who book
-    // deliveries today. Tighten once roles are rolled out (F9).
+    // must be real and attributable.
+    //
+    // ⛔ TEMPORARY LOCKDOWN — SUPERADMIN ONLY (Nick, 20 Jul 2026).
+    // This was originally authentication-only: any logged-in staff member could send the
+    // text. That was an acceptable trade while everything was mock-first — but on 20 Jul
+    // we confirmed `PODIUM_MOCK=false` on Production with live Podium credentials, so
+    // this endpoint now sends a REAL SMS to a REAL customer, using copy that has never
+    // been signed off. Until that sign-off happens, only superadmin may send or decline.
+    //
+    // `skip` is gated too, not just `send`: it writes an audit row attributing the
+    // decision to a person, so it is not a harmless read.
+    //
+    // TO LIFT: widen BOOKING_SMS_ROLES in lib/rbac.js (and the matching client list in
+    // src/pages/delivery_operations/to-be-booked.js) once the SMS copy is approved and the
+    // logistics role is actually assigned to the people who book deliveries.
     if ((req.query?.resource || '') === 'booking-sms') {
       if (method !== 'POST') {
         res.setHeader('Allow', ['POST']);
         return res.status(405).json({ error: 'Method not allowed for booking-sms' });
       }
-      const auth = getAuthUser(req);
-      if (!auth) return res.status(401).json({ error: 'Not authenticated' });
+      const gate = requireRoles(req, BOOKING_SMS_ROLES);
+      if (!gate.ok) return res.status(gate.status).json({ error: gate.error });
       if (!id) return res.status(400).json({ error: 'Missing delivery_id' });
 
       const action = String(body?.action || '');
@@ -56,11 +67,11 @@ export default async function handler(req, res) {
       }
 
       if (action === 'skip') {
-        const outcome = await declineDeliveryBookedSms(client, id, { actorId: auth.id });
+        const outcome = await declineDeliveryBookedSms(client, id, { actorId: gate.auth.id });
         return res.status(200).json({ message: 'No text sent', outcome });
       }
 
-      const outcome = await notifyDeliveryBooked(client, id, { actorId: auth.id });
+      const outcome = await notifyDeliveryBooked(client, id, { actorId: gate.auth.id });
       if (outcome.alreadySent) {
         return res.status(409).json({ error: 'That text has already been sent', outcome });
       }
@@ -310,8 +321,11 @@ export default async function handler(req, res) {
 
       // F8b: created straight as booked → offer the text, don't send it. Best-effort:
       // a preview failure must never fail the creation the caller just made.
+      // ⛔ 20 Jul 2026: the preview carries the customer's PHONE NUMBER and the
+      // un-signed-off SMS body, so it is withheld from anyone who could not send it
+      // anyway. Fails closed — no token, no preview, no panel, no text.
       let booking_sms = null;
-      if (r.rows[0].delivery_status === 'Booked for Delivery') {
+      if (r.rows[0].delivery_status === 'Booked for Delivery' && requireRoles(req, BOOKING_SMS_ROLES).ok) {
         try { booking_sms = await previewDeliveryBookedSms(client, r.rows[0].delivery_id); }
         catch (e) { console.error('delivery-booked preview (post-create) failed:', e); }
       }
@@ -440,8 +454,9 @@ export default async function handler(req, res) {
       // F8b: just became booked → return the text for confirmation. NOT sent here — the
       // UI shows it to logistics, who send or decline. Best-effort: a preview failure must
       // never fail the booking that has already committed.
+      // ⛔ 20 Jul 2026: withheld from callers who could not send it — see the POST path.
       let booking_sms = null;
-      if (becameBooked) {
+      if (becameBooked && requireRoles(req, BOOKING_SMS_ROLES).ok) {
         try { booking_sms = await previewDeliveryBookedSms(client, id); }
         catch (e) { console.error('delivery-booked preview (post-update) failed:', e); }
       }

--- a/lib/rbac.js
+++ b/lib/rbac.js
@@ -77,6 +77,23 @@ export async function syncUserRoles(client, userId, roles, grantedBy) {
   }
 }
 
+/**
+ * Who may send or decline the delivery-booked customer SMS.
+ *
+ * ⛔ TEMPORARY LOCKDOWN (Nick, 20 Jul 2026). Was authentication-only, which was fine
+ * while PODIUM_MOCK=true meant nothing actually sent. On 20 Jul we confirmed
+ * PODIUM_MOCK=false on Production with live Podium credentials, so that endpoint now
+ * texts real customers using copy nobody has signed off.
+ *
+ * Declared here, once, because three places have to agree: the server gate
+ * (lib/handlers/delivery.js), the client's decision to show the panel
+ * (src/pages/delivery_operations/to-be-booked.js), and the smoke that pins both.
+ * TO LIFT: add 'logistics' here once the SMS copy is approved AND the logistics role is
+ * actually assigned — then update the client list to match. The smoke asserts against
+ * this constant, so widening it will not read as a test regression.
+ */
+export const BOOKING_SMS_ROLES = ['superadmin'];
+
 /** Pure check: does this role set include `role`? Case-insensitive. */
 export function hasRole(roles, role) {
   if (!roles) return false;

--- a/scripts/podium-rbac-smoke.mjs
+++ b/scripts/podium-rbac-smoke.mjs
@@ -14,7 +14,7 @@
 process.env.JWT_SECRET = 'test-secret-for-rbac-smoke';
 
 const jwt = (await import('jsonwebtoken')).default;
-const { requireRoles, syncUserRoles, hasAnyRole, primaryRole, sanitizeRoles } = await import('../lib/rbac.js');
+const { requireRoles, syncUserRoles, hasAnyRole, primaryRole, sanitizeRoles, BOOKING_SMS_ROLES } = await import('../lib/rbac.js');
 
 let passed = 0;
 function check(name, cond, detail) {
@@ -126,6 +126,115 @@ console.log('\ngate is actually WIRED IN (not just sound in isolation):');
   // If someone gates reads, these pages must start sending authHeaders() first.
   check('GET /api/users is deliberately left ungated (see the F9 report)',
     !/method === 'GET'[\s\S]{0,400}requireRoles/.test(usersBlock));
+}
+
+console.log('\ndelivery-booked SMS is superadmin-only (temporary lockdown, 20 Jul 2026):');
+{
+  // WHY: PODIUM_MOCK=false on Production (found 20 Jul), so this endpoint sends REAL
+  // texts to REAL customers with copy that has not been signed off. Until it is, only
+  // superadmin may send or decline one. F8b originally gated on authentication ALONE —
+  // deliberately, because the `logistics` role wasn't assigned to anyone yet — which
+  // means every logged-in staff member could text a customer.
+  const fs = await import('node:fs/promises');
+  const url = await import('node:url');
+
+  const handlerSrc = await fs.readFile(
+    url.fileURLToPath(new URL('../lib/handlers/delivery.js', import.meta.url)), 'utf8');
+
+  check('delivery handler imports requireRoles + the shared role list',
+    /import\s*\{[^}]*requireRoles[^}]*BOOKING_SMS_ROLES[^}]*\}\s*from\s*'\.\.\/rbac\.js'/.test(handlerSrc));
+
+  // STRUCTURAL, not presence-based. An earlier version of this block sliced out the
+  // booking-sms branch and asked "does a gate appear inside it?" — which a reviewer
+  // defeated twice: once by adding a SECOND, ungated dispatch above the real one using
+  // double quotes to dodge the string anchor, and once by leaving the guard's tokens in
+  // place while moving them out of the `if`. Both let a non-superadmin send, and both
+  // passed 46/46. So the assertions below count call sites across the WHOLE file.
+  const dispatches = handlerSrc.match(/resource[^=]*===\s*['"]booking-sms['"]/g) || [];
+  check('exactly ONE booking-sms dispatch exists in the file', dispatches.length === 1,
+    `found ${dispatches.length} — a second dispatch could bypass the gate entirely`);
+
+  const sendCalls = handlerSrc.match(/notifyDeliveryBooked\s*\(/g) || [];
+  const skipCalls = handlerSrc.match(/declineDeliveryBookedSms\s*\(/g) || [];
+  check('notifyDeliveryBooked is called exactly once in the file', sendCalls.length === 1, `found ${sendCalls.length}`);
+  check('declineDeliveryBookedSms is called exactly once in the file', skipCalls.length === 1, `found ${skipCalls.length}`);
+
+  const start = handlerSrc.indexOf("=== 'booking-sms'");
+  check('booking-sms branch exists', start > -1);
+  // indexOf returning -1 would make slice(start,-1) silently mean "rest of the file",
+  // quietly widening every assertion below — so require the end marker explicitly.
+  const end = handlerSrc.indexOf("if (method === 'GET')", start);
+  check('the booking-sms block has a locatable end marker', end > start,
+    'without this the block silently widens to the rest of the file');
+  const smsBlock = handlerSrc.slice(start, end);
+
+  check('booking-sms gates on the shared role list',
+    /requireRoles\(req,\s*BOOKING_SMS_ROLES\)/.test(smsBlock),
+    'without this, any logged-in user can text a customer');
+  check('booking-sms returns the gate status (401 vs 403), not a blanket 401',
+    /gate\.status/.test(smsBlock));
+  check('booking-sms no longer relies on bare getAuthUser for authorisation',
+    !/getAuthUser\(req\)/.test(smsBlock));
+  check('the acting superadmin is recorded on the envelope',
+    (smsBlock.match(/actorId:\s*gate\.auth\.id/g) || []).length === 2,
+    'both send and skip must attribute the decision to the gated user');
+
+  // Both actions must be behind the gate — 'skip' writes an audit row attributing the
+  // decision to a person, so it is not a harmless read.
+  const gateIdx = smsBlock.search(/requireRoles\(req,\s*BOOKING_SMS_ROLES\)/);
+  check('the gate precedes BOTH send and skip',
+    gateIdx > -1 && gateIdx < smsBlock.indexOf('declineDeliveryBookedSms')
+      && gateIdx < smsBlock.indexOf('notifyDeliveryBooked'));
+
+  // The preview carries the customer's phone number and the un-signed-off copy, so it
+  // must not be handed to a caller who could not send it. Both emit sites are gated.
+  const previewGates = handlerSrc.match(/requireRoles\(req,\s*BOOKING_SMS_ROLES\)\.ok/g) || [];
+  check('both booking_sms preview emit sites are gated', previewGates.length === 2,
+    `found ${previewGates.length} — POST-create and PUT-update must both withhold it`);
+
+  // Client side: don't offer a button the server will 403.
+  const pageSrc = await fs.readFile(
+    url.fileURLToPath(new URL('../src/pages/delivery_operations/to-be-booked.js', import.meta.url)), 'utf8');
+  check('to-be-booked imports the role helpers', /from\s*'\.\.\/\.\.\/utils\/auth'/.test(pageSrc));
+
+  // Pin the guarded STATEMENT, and require it to be the only way the panel opens —
+  // otherwise the guard can be left present-but-bypassed.
+  check('the confirmation panel only opens for the allowed roles',
+    /if \(data\?\.booking_sms && hasAnyRole\(getRoles\(\), BOOKING_SMS_ROLES\)\) \{/.test(pageSrc),
+    'a non-superadmin must never be shown the send/skip panel');
+  const opens = pageSrc.match(/setBookingSms\(\{\s*\.\.\.data\.booking_sms/g) || [];
+  check('there is exactly one place the panel is opened from a response', opens.length === 1,
+    `found ${opens.length}`);
+  check('the client role list is declared once, as a constant',
+    /^const BOOKING_SMS_ROLES = \['superadmin'\];$/m.test(pageSrc));
+  check('the booking save sends the token (else superadmins lose the preview too)',
+    /headers: authHeaders\(\{ 'Content-Type': 'application\/json' \}\)/.test(pageSrc));
+  check('a 403 closes the panel instead of looping on a raw role string',
+    /res\.status === 403\b/.test(pageSrc) && /restricted to an administrator/.test(pageSrc));
+}
+
+console.log('\nbehaviour: the delivery-SMS gate, asserted against the shared constant:');
+{
+  // Asserted against BOOKING_SMS_ROLES rather than a hardcoded ['superadmin'], so
+  // LIFTING the lockdown (adding 'logistics') does not read as a test regression.
+  check('BOOKING_SMS_ROLES is a non-empty array', Array.isArray(BOOKING_SMS_ROLES) && BOOKING_SMS_ROLES.length > 0);
+  check('superadmin is always allowed', requireRoles(reqWith(tokenFor(['superadmin'])), BOOKING_SMS_ROLES).ok === true);
+
+  // Every role NOT on the list must be refused. Written as a sweep so a future widening
+  // is a one-line constant change, not a rewrite of the expectations.
+  for (const role of ['staff', 'sales', 'logistics', 'technician', 'workshop']) {
+    const expectAllowed = BOOKING_SMS_ROLES.includes(role);
+    const r = requireRoles(reqWith(tokenFor([role])), BOOKING_SMS_ROLES);
+    check(`${role} alone → ${expectAllowed ? 'allowed' : '403'}`,
+      expectAllowed ? r.ok === true : (r.ok === false && r.status === 403));
+  }
+
+  check('a listed role held alongside others still passes (P10 multi-role)',
+    requireRoles(reqWith(tokenFor(['logistics', ...BOOKING_SMS_ROLES])), BOOKING_SMS_ROLES).ok === true);
+  check('no token → 401, not 403 (fails closed)',
+    requireRoles({ headers: {} }, BOOKING_SMS_ROLES).status === 401);
+  check('a forged token claiming the role → 401, never a pass',
+    requireRoles(reqWith(jwt.sign({ id: 'XX', roles: BOOKING_SMS_ROLES }, 'wrong-secret')), BOOKING_SMS_ROLES).status === 401);
 }
 
 console.log('\nrole helpers (used by the nav + gates):');

--- a/src/pages/delivery_operations/to-be-booked.js
+++ b/src/pages/delivery_operations/to-be-booked.js
@@ -3,7 +3,13 @@ import { createPortal } from 'react-dom';
 import { useNavigate, useLocation } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import DeliveryTabs from '../../components/DeliveryTabs';
-import { authHeaders } from '../../utils/auth';
+import { authHeaders, getRoles, hasAnyRole } from '../../utils/auth';
+
+// ⛔ TEMPORARY LOCKDOWN (Nick, 20 Jul 2026): only these roles are offered the
+// delivery-booked customer SMS. Must stay in step with BOOKING_SMS_ROLES in lib/rbac.js —
+// the server is the real gate; this only decides what to show. (Kept as a literal rather
+// than imported: lib/ is server-side and is not part of the CRA client bundle.)
+const BOOKING_SMS_ROLES = ['superadmin'];
 
 const EDITABLE_STATUSES = ['To Be Booked', 'Booked for Delivery'];
 const ORDERED_STATES = ['VIC', 'NSW', 'QLD', 'ACT', 'WA', 'SA', 'TAS', 'NT'];
@@ -394,9 +400,13 @@ export default function ToBeBookedDeliveriesPage() {
     const toastId = startToast('saveDelivery', deliveryId);
     setSavingIds((prev) => new Set(prev).add(deliveryId));
     try {
+      // The token is sent so the server can decide whether to hand back the booking-text
+      // preview (it carries the customer's phone number and the un-signed-off copy).
+      // The booking itself is NOT gated on it — this legacy endpoint still identifies the
+      // actor from `user_id` — so an expired session still books, it just gets no panel.
       const res = await fetch(`/api/delivery?id=${encodeURIComponent(deliveryId)}`, {
         method: 'PUT',
-        headers: { 'Content-Type': 'application/json' },
+        headers: authHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({ ...patch, user_id: currentUserId }),
       });
       const data = await res.json().catch(() => ({}));
@@ -404,7 +414,15 @@ export default function ToBeBookedDeliveriesPage() {
 
       // F8b: the booking just saved and the server handed back the text it WOULD send.
       // Ask before anything goes out.
-      if (data?.booking_sms) setBookingSms({ ...data.booking_sms, delivery_id: deliveryId });
+      //
+      // ⛔ TEMPORARY LOCKDOWN (Nick, 20 Jul 2026): superadmin only. The send endpoint is
+      // gated server-side, so this is presentation only — but without it a non-superadmin
+      // would be shown a panel whose buttons both 403. The booking itself is unaffected:
+      // it has already saved. The customer simply gets no text until the SMS copy is
+      // signed off. Widen this and the server gate together when lifting.
+      if (data?.booking_sms && hasAnyRole(getRoles(), BOOKING_SMS_ROLES)) {
+        setBookingSms({ ...data.booking_sms, delivery_id: deliveryId });
+      }
 
       setDeliveries((list) => {
         if ('delivery_status' in patch && patch.delivery_status !== 'To Be Booked') {
@@ -459,6 +477,15 @@ export default function ToBeBookedDeliveriesPage() {
       // closing with "No text sent" here would be a lie.
       if (res.status === 409 && data?.outcome?.alreadySent) {
         toast('That text was already sent', { icon: 'ℹ️' });
+        setBookingSms(null);
+        return;
+      }
+      // 403: the lockdown (booking texts are superadmin-only until the copy is signed
+      // off). Reachable from a stale tab or a role change mid-session. Close the panel —
+      // retrying cannot succeed, and repeating a raw "Requires one of: superadmin"
+      // leaks the role name and reads as a bug.
+      if (res.status === 403) {
+        toast('Booking texts are restricted to an administrator for now', { icon: 'ℹ️' });
         setBookingSms(null);
         return;
       }


### PR DESCRIPTION
## Why

Requested directly after we confirmed **`PODIUM_MOCK=false` on Production** with live Podium credentials.

The delivery-booked SMS endpoint was gated on **authentication only** — *any* logged-in staff member could text a customer. That was a reasonable trade while everything was mock-first and the `logistics` role was unassigned. It stopped being reasonable the moment Production turned out to be live: it now sends a **real SMS to a real customer** using copy nobody has signed off.

**This PR is intended for Production**, not just review — it reduces who can send, so it lowers risk rather than adding any.

## What changes

**Server — the real boundary**
- `lib/rbac.js`: new **`BOOKING_SMS_ROLES = ['superadmin']`**, declared once because three places must agree (the gate, the client's show/hide, and the smoke).
- `lib/handlers/delivery.js`: `booking-sms` uses `requireRoles(req, BOOKING_SMS_ROLES)`. Returns `gate.status`, so a real user lacking the role gets **403**, not a misleading 401. **Both** actions gated — `skip` writes an audit row attributing the decision to a person, so it isn't a harmless read.
- The **`booking_sms` preview is withheld too**, at both emit sites. It carries the customer's **phone number** and the un-signed-off body, and was being returned to any caller who could reach the endpoint. Hiding it server-side is what makes the client guard more than cosmetic.

**Client — so nobody is offered a button that will 403**
- The panel only opens for `BOOKING_SMS_ROLES`.
- The booking save now sends `authHeaders()`. **Required** — without it the server can't tell who's asking, so even superadmins would lose the preview. The booking itself is *not* gated on the token (that legacy endpoint still identifies the actor from `user_id`), so an expired session still books normally; it just gets no panel.
- A **403** closes the panel with plain English instead of looping forever on the raw `Requires one of: superadmin`.

## Effect

Only **GS (Nick)**, **GA (Vincent Ly)** and **WB ("Website", a system account)** can send or decline a booking text — that's every superadmin on Production today.

Everyone else books deliveries **exactly as before** and is simply never offered the text. Verified: the booking still succeeds, no error toast, no stuck spinner, no console error — `getRoles`/`hasAnyRole` are total and return `[]`/`false` on a missing token.

⚠️ **Worth knowing:** F8b's existing gap — booked, no text, no audit row, no way to re-ask — becomes the **normal path for everyone except three accounts**, rather than an edge case. A re-entry point ("send booking text" on the delivery row) is now considerably more valuable than it was.

⚠️ **WB is a system account with superadmin.** If any automation holds a WB token, this gate is no obstacle to it. Worth confirming nothing logs in as WB.

## Tests — the first version of these was weak, and a reviewer beat it

rbac smoke **31 → 59**.

My initial assertions were presence-based, and the code reviewer got **two sends past them**:
1. a **second, ungated dispatch** inserted above the real one, using double quotes to dodge a single-quoted string anchor;
2. the client guard left **present but moved out of its `if`**.

Both let a non-superadmin send. Both passed 46/46. I reproduced both before fixing.

The assertions are now **structural**: they count `booking-sms` dispatches and `notifyDeliveryBooked`/`declineDeliveryBookedSms` call sites across the **whole file**, pin the guarded statement, require exactly one panel-open site, guard the block-slice end marker, and assert behaviour against `BOOKING_SMS_ROLES` rather than a hardcoded literal — so **lifting the lockdown won't read as a test failure**. Six mutants re-run, all caught.

| Check | Result |
|---|---|
| `CI=true npm run build` | exit 0 |
| All suites | 14 suites, **593 checks**, 0 failures |
| Mutants (gate removed / widened / dup dispatch / guard bypassed / preview ungated / auth header dropped / 403 removed) | all caught |
| Migration / new function / dependency | none |

## Considered and not done

A reviewer suggested an env kill-switch (`DELIVERY_SMS_ENABLED`) instead of, or alongside, the role gate — one Vercel variable to lift, no code deploy, and it can't be defeated by muscle memory. **That is arguably the better instrument if the goal is "nothing goes out until sign-off"**, since a role gate is access control, not an off switch: Nick and Vincent still see a red **Send text** button with the unapproved copy.

Not built, because the instruction was specifically "only allow for superadmin roles for now" — but say the word and it's a few lines, and the two combine well.

## To lift later

Add `'logistics'` to `BOOKING_SMS_ROLES` in `lib/rbac.js` **and** the matching literal in `to-be-booked.js`. The smoke asserts against the constant, so it won't fight you.
