### PR TITLE
F8a kill switch: no waitlist SMS is sent unless explicitly armed (default off)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,17 @@ JWT_SECRET=
 FEATURE_MYOB=false          # quote/payment seam stubs stay off until the MYOB phase
 PODIUM_MOCK=true            # mock-first until live Podium credentials are wired
 
+# --- Customer SMS kill switch (F8a) ---
+# The waitlist back-in-stock text is the ONE customer automation with no human in the
+# loop — it fires straight off an apply-inventory. It sends NOTHING unless this is
+# exactly 'true' (unset = off). Suppression writes no audit row and does not retire the
+# waitlist row, so nobody is permanently silenced.
+# ⚠️ BUT SUPPRESSED IS NOT DEFERRED: the trigger is a one-shot 0 → positive stock edge, so
+# arming this later does NOT re-notify anyone whose restock was already suppressed. Arm it
+# BEFORE the next restock, and ring anyone who was missed.
+# ARM ONLY AFTER the SMS copy in lib/waitlistNotify.js has been signed off.
+WAITLIST_SMS_ENABLED=false
+
 # --- Podium API (execution-plan §5; leave blank until the app is approved) ---
 PODIUM_CLIENT_ID=
 PODIUM_CLIENT_SECRET=

--- a/lib/handlers/collections.js
+++ b/lib/handlers/collections.js
@@ -285,7 +285,12 @@ export default async function handler(req, res) {
 
           // F8a: waitlist back-in-stock SMS — AFTER commit, BEST-EFFORT. Never throws, so
           // a Podium/SMS failure can't undo the inventory we just applied. Mock-first.
-          let waitlistNotified = { notified: 0, skipped: 0, failed: 0 };
+          // `suppressed` > 0 means the F8a kill switch is off (WAITLIST_SMS_ENABLED is not
+          // 'true'): those customers were NOT texted and NOT recorded, and their waitlist
+          // rows are still Active. ⚠️ They are NOT queued — this restock's 0 → positive
+          // edge is spent, so arming the switch later will not notify them. They need a
+          // phone call, or the next genuine restock of that SKU.
+          let waitlistNotified = { notified: 0, skipped: 0, failed: 0, suppressed: 0 };
           try {
             waitlistNotified = await notifyWaitlistBackInStock(client, backInStockSkus, { collectionId: Number(id) });
           } catch (notifyErr) {

--- a/lib/waitlistNotify.js
+++ b/lib/waitlistNotify.js
@@ -21,6 +21,27 @@
 import { sendSystemSms } from './podium.js';
 
 /**
+ * ⛔ KILL SWITCH — F8a sends nothing unless WAITLIST_SMS_ENABLED === 'true'.
+ * Defaults to OFF, including when the variable is absent entirely.
+ *
+ * Added 20 Jul 2026 (Nick) after PODIUM_MOCK was found to be `false` on Production.
+ * F8a is the only customer-facing automation with NO human in the loop — F8b asks
+ * logistics to confirm each text, whereas this one fires straight off an
+ * apply-inventory — so the next restock of a waitlisted SKU would have texted real
+ * customers using copy nobody had signed off.
+ *
+ * A ROLE GATE WOULD BE THE WRONG INSTRUMENT here: the trigger is a routine warehouse
+ * action, not a "send text" button, so restricting who may apply inventory would break
+ * daily operations without making the copy any more approved.
+ *
+ * TO ARM: sign off the SMS copy in backInStockMessage(), then set
+ * WAITLIST_SMS_ENABLED=true on the Vercel Production environment. No code deploy needed.
+ */
+export function isWaitlistSmsEnabled() {
+  return String(process.env.WAITLIST_SMS_ENABLED ?? '').trim().toLowerCase() === 'true';
+}
+
+/**
  * The customer-facing SMS copy. On brand: phone 1300 769 556 primary; no "used /
  * second-hand" language. Copy is a sensible default — flagged for human sign-off before
  * live send (the send itself is gated behind PODIUM_MOCK=false, a human config flip).
@@ -35,12 +56,12 @@ export function backInStockMessage(productName) {
  * @param {object} client  an OPEN pg client (used post-commit; each statement autocommits)
  * @param {string[]} skus  SKUs that just transitioned back into stock
  * @param {object} [opts]  { collectionId, send } — send lets the smoke inject a fake sender
- * @returns {Promise<{notified:number, skipped:number, failed:number}>}
+ * @returns {Promise<{notified:number, skipped:number, failed:number, suppressed:number}>}
  */
 export async function notifyWaitlistBackInStock(client, skus, opts = {}) {
   const { collectionId = null, send } = opts;
   const sendSms = send || sendSystemSms;
-  const out = { notified: 0, skipped: 0, failed: 0 };
+  const out = { notified: 0, skipped: 0, failed: 0, suppressed: 0 };
 
   const list = [...new Set((skus || []).map((s) => String(s).toUpperCase()).filter(Boolean))];
   if (!list.length) return out;
@@ -64,6 +85,38 @@ export async function notifyWaitlistBackInStock(client, skus, opts = {}) {
   } catch (err) {
     // waitlist/customers/product absent (bare DB) or any query error — degrade silently.
     if (err?.code !== '42P01') console.error('waitlist notify: lookup failed', err);
+    return out;
+  }
+
+  // ⛔ KILL SWITCH. Deliberately placed AFTER the read-only lookup and BEFORE the claim
+  // loop, for two reasons:
+  //   - running the lookup gives an honest `suppressed` count, so the operator can see
+  //     "3 customers would have been texted" instead of silence;
+  //   - stopping before the claim is essential. The claim row is the at-most-once gate,
+  //     so writing one now would PERMANENTLY silence that customer for this waitlist
+  //     entry — the text would never arrive, even after the switch is turned on. For the
+  //     same reason the Active → Notified flip must not happen either.
+  //
+  // ⚠️ SUPPRESSED IS *NOT* DEFERRED — READ THIS BEFORE ARMING THE SWITCH.
+  // The trigger is a one-shot edge: collections.js pushes a SKU only on a 0 → positive
+  // stock transition. A suppressed run CONSUMES that edge. Arming WAITLIST_SMS_ENABLED
+  // later does NOT catch anyone up — there is no sweeper, and re-applying the collection
+  // is blocked by inventory_applied_at (and `reset-inventory-apply` does not decrement
+  // product.stock, so forcing a re-apply would double-credit stock AND still not fire,
+  // because the SKU is no longer at 0).
+  // The rows stay Active and notifiable, but only by the NEXT genuine restock of that
+  // SKU — which for a one-off refurbished machine may be months away, or never.
+  // ⇒ Arm this BEFORE the next restock, and ring anyone whose restock was suppressed.
+  if (!isWaitlistSmsEnabled()) {
+    out.suppressed = rows.length;
+    if (rows.length) {
+      console.warn(
+        `waitlist notify: SUPPRESSED ${rows.length} back-in-stock SMS — WAITLIST_SMS_ENABLED is not 'true'. `
+        + 'Nothing was sent and nothing was recorded. These rows stay Active, but this restock '
+        + 'will NOT be re-notified when the switch is armed — CALL THESE CUSTOMERS. '
+        + `(collection ${collectionId ?? 'n/a'}, skus ${list.join(', ')})`
+      );
+    }
     return out;
   }
 

--- a/scripts/podium-waitlist-smoke.mjs
+++ b/scripts/podium-waitlist-smoke.mjs
@@ -14,7 +14,17 @@
 
 process.env.PODIUM_MOCK = 'true'; // real sendSystemSms short-circuits to the typed mock
 
-const { notifyWaitlistBackInStock, backInStockMessage } = await import('../lib/waitlistNotify.js');
+// ⛔ F8a is DISABLED BY DEFAULT (Nick, 20 Jul 2026) — see the kill-switch block at the
+// bottom of this file. Every test above that block is about what happens when sending is
+// switched ON, so opt in explicitly here. If this line is deleted, those tests fail
+// loudly rather than silently asserting nothing.
+process.env.WAITLIST_SMS_ENABLED = 'true';
+
+const {
+  notifyWaitlistBackInStock,
+  backInStockMessage,
+  isWaitlistSmsEnabled,
+} = await import('../lib/waitlistNotify.js');
 
 let passed = 0;
 function check(name, cond, detail) {
@@ -159,6 +169,101 @@ console.log('\nend-to-end through the REAL sendSystemSms (mock mode):');
   const client = okClient([activeRow()]);
   const out = await notifyWaitlistBackInStock(client, ['TM-95T']); // no injected send → real mock
   check('real mock send path notifies without error', out.notified === 1 && out.failed === 0);
+}
+
+// ---------------------------------------------------------------------------
+// ⛔ KILL SWITCH — F8a sends NOTHING unless WAITLIST_SMS_ENABLED === 'true'
+//
+// WHY: F8a is the only customer-facing automation with NO human in the loop. F8b asks
+// logistics to confirm; F8a fires straight off an apply-inventory. On 20 Jul 2026 we
+// found PODIUM_MOCK=false on Production, which means the next restock of a waitlisted
+// SKU would have texted real customers using copy nobody had signed off.
+//
+// A role gate is the wrong instrument here — the trigger is a routine warehouse action,
+// not a "send text" button — so the control is a flag that defaults to OFF.
+//
+// The critical property: suppression must leave NO trace that would block a later
+// legitimate send. No claim row (the claim is the at-most-once gate, so claiming now
+// would permanently silence that customer) and no Active → Notified flip.
+//
+// ⚠️ Note what these tests do NOT claim: suppressed is not DEFERRED. The trigger is a
+// one-shot 0 → positive stock edge, so a suppressed restock is not re-sent when the
+// switch is armed — those customers need a phone call. See lib/waitlistNotify.js.
+// ---------------------------------------------------------------------------
+console.log('\nkill switch (F8a is off unless explicitly enabled):');
+{
+  const saved = process.env.WAITLIST_SMS_ENABLED;
+
+  check('exported flag reader exists', typeof isWaitlistSmsEnabled === 'function');
+
+  delete process.env.WAITLIST_SMS_ENABLED;
+  check('unset ⇒ disabled (safe default)', isWaitlistSmsEnabled() === false);
+  process.env.WAITLIST_SMS_ENABLED = 'false';
+  check("'false' ⇒ disabled", isWaitlistSmsEnabled() === false);
+  process.env.WAITLIST_SMS_ENABLED = 'yes';
+  check("'yes' ⇒ disabled (only the exact word 'true' arms it)", isWaitlistSmsEnabled() === false);
+  process.env.WAITLIST_SMS_ENABLED = '1';
+  check("'1' ⇒ disabled", isWaitlistSmsEnabled() === false);
+  process.env.WAITLIST_SMS_ENABLED = 'TRUE';
+  check("'TRUE' ⇒ enabled (case-insensitive)", isWaitlistSmsEnabled() === true);
+  process.env.WAITLIST_SMS_ENABLED = ' true ';
+  check("' true ' ⇒ enabled (whitespace tolerated)", isWaitlistSmsEnabled() === true);
+
+  // --- behaviour when disabled -------------------------------------------------
+  delete process.env.WAITLIST_SMS_ENABLED;
+  {
+    let sendCalls = 0;
+    const client = okClient([activeRow(), activeRow({ waitlist_id: 2, customer_id: 77 })]);
+    const out = await notifyWaitlistBackInStock(client, ['TM-95T'], {
+      send: async () => { sendCalls += 1; return { status: 'sent' }; },
+    });
+
+    check('disabled ⇒ NOTHING is sent', sendCalls === 0);
+    check('disabled ⇒ nobody counted as notified', out.notified === 0, JSON.stringify(out));
+    check('disabled ⇒ reports how many were suppressed', out.suppressed === 2, JSON.stringify(out));
+
+    const sql = client.calls.map((c) => c.sql).join('\n');
+    check('disabled ⇒ NO claim row is written (a claim would silence them permanently)',
+      !/INSERT INTO integration_sync_log/i.test(sql), sql);
+    check('disabled ⇒ waitlist rows stay Active (they must still be notifiable later)',
+      !/UPDATE waitlist/i.test(sql), sql);
+    check('disabled ⇒ the read-only lookup still runs, so the count is real',
+      /FROM waitlist/i.test(sql));
+
+    // STRICTLY STRONGER than the two negative regexes above, and the reason they are not
+    // enough on their own: a code reviewer silenced every suppressed customer by writing
+    // the real claim row with a QUOTED identifier ("integration_sync_log"), which slips
+    // past a /INSERT INTO integration_sync_log/i text match — 41/41 still passed while the
+    // catastrophe this design exists to prevent was happening. Counting queries closes the
+    // whole class: any write at all, under any spelling, fails this.
+    check('disabled ⇒ EXACTLY one query total (the read-only lookup) — no writes, any spelling',
+      client.calls.length === 1, `got ${client.calls.length}: ${sql}`);
+  }
+
+  // --- and the switch genuinely re-arms it -------------------------------------
+  process.env.WAITLIST_SMS_ENABLED = 'true';
+  {
+    let sendCalls = 0;
+    const client = okClient([activeRow()]);
+    const out = await notifyWaitlistBackInStock(client, ['TM-95T'], {
+      send: async () => { sendCalls += 1; return { status: 'sent' }; },
+    });
+    check('enabled ⇒ sends again', sendCalls === 1 && out.notified === 1, JSON.stringify(out));
+    check('enabled ⇒ suppressed count is zero', !out.suppressed);
+  }
+
+  // A disabled run must not be mistaken for "everyone already notified".
+  delete process.env.WAITLIST_SMS_ENABLED;
+  {
+    const client = okClient([activeRow()]);
+    const out = await notifyWaitlistBackInStock(client, ['TM-95T'], { send: async () => ({ status: 'sent' }) });
+    check('disabled ⇒ not counted as skipped (skipped means already-claimed/no-phone)',
+      out.skipped === 0, JSON.stringify(out));
+    check('disabled ⇒ not counted as failed', out.failed === 0, JSON.stringify(out));
+  }
+
+  if (saved === undefined) delete process.env.WAITLIST_SMS_ENABLED;
+  else process.env.WAITLIST_SMS_ENABLED = saved;
 }
 
 console.log(`\n✅ waitlist smoke: ${passed} checks passed`);


### PR DESCRIPTION
## Why

Companion to #82, and the **bigger** of the two exposures.

F8a is the **only customer-facing automation with no human in the loop**. F8b asks logistics to confirm each text; this one fires straight off an apply-inventory. With `PODIUM_MOCK=false` on Production, the next restock of a waitlisted SKU would have texted real customers using copy nobody has signed off — **8 Active rows across 7 SKUs**.

## Why not a role gate

Because it demonstrably wouldn't have helped. Apply-inventory is **already superadmin-only** (`requireSuperadmin`, `collections.js:150`) — the maximal role gate was in place and prevented nothing, because the problem isn't who pressed the button, it's that the copy is unapproved.

`PODIUM_MOCK=true` would also work, but it takes out the **inbox** staff use all day and would silently mock F8b too.

So: a dedicated flag, **default OFF**.

## What changes

- **`isWaitlistSmsEnabled()`** — true only when `WAITLIST_SMS_ENABLED` is exactly `'true'` (trimmed, case-insensitive). Unset, `''`, `'1'`, `'yes'`, `'false'` all mean OFF, so **the safe state requires no configuration**.
- Placed **after the read-only lookup, before the claim loop**. Both halves matter:
  - running the lookup gives an honest `suppressed` count instead of silence;
  - stopping before the claim is *the* safety property. The claim row is the at-most-once gate, so writing one while suppressed would **permanently silence** that customer for that waitlist entry — the text could never arrive, even after arming. Same reason the `Active → Notified` flip must not happen.
  - Suppression performs **exactly one query**, and it's a plain `SELECT`.
- `collections.js` returns `suppressed` in its counts; `.env.example` documents the flag.

## ⚠️ Suppressed is NOT deferred — I had this wrong

My first draft asserted, in the code comment, the env docs *and* the test header, that suppressed customers would be "notified once it is armed". **That is false**, and code review caught it. It's the kind of claim you'd have acted on, so it's worth stating plainly:

The trigger is a **one-shot 0 → positive stock edge**. A suppressed run consumes it. Arming the flag later catches nobody up — there's no sweeper, re-applying is blocked by `inventory_applied_at`, and `reset-inventory-apply` doesn't decrement `product.stock`, so forcing a re-apply would **double-credit stock and still not fire**.

All three places now say: **arm it before the next restock, and ring anyone who was missed.**

## ✅ Nobody has been missed

Checked read-only against Production — **all 7 waitlisted SKUs are currently at stock 0**:

| SKU | Product | Stock | Waiting |
|---|---|---|---|
| WB-PRO | Wattbike Pro | 0 | 1 |
| KIZ-M3i | Keiser M3i Spin Bike | 0 | 1 |
| SCI-RB02 | SCIFIT Stepone Recumbent Stepper | 0 | 1 |
| TEC-RK3512 | Technogym Power Personal Half Rack | 0 | 1 |
| WOO-TR2819 | Woodway 4front Treadmill | 0 | 1 |
| NUT-PEC01 | Nautilus Pec Deck Fly | 0 | **2** |
| PRE-DSL606 | Precor Discovery Prone Leg Curl | 0 | 1 |

No restock edge has been spent, so **no phone calls are needed** — arming the flag before the next restock protects all 8.

## Tests — including one the review broke

waitlist smoke **24 → 42**. Six mutants caught, including the one the reviewer found that I'd missed: writing the **real claim row with a quoted identifier** (`"integration_sync_log"`), which slipped past my negative SQL regexes and **passed 41/41 while permanently silencing every suppressed customer**.

That whole class is now closed by asserting the disabled path issues **exactly one query** — strictly stronger than any text match, and it catches a write under any spelling, table name, or CTE.

| Check | Result |
|---|---|
| `CI=true npm run build` | exit 0 |
| All suites | 14 suites, **583 checks**, 0 failures |
| Mutants | 6/6 caught |
| Migration / new function / dependency | none |

## To arm, later

1. Sign off the SMS copy in `backInStockMessage()` (`lib/waitlistNotify.js`).
2. Set `WAITLIST_SMS_ENABLED=true` on Vercel **Production**. No code deploy needed.
3. Do it **before** the next restock.

## Known gap, not fixed here

Suppression is invisible in the portal — `waitlistNotified` is returned in the JSON but **no UI reads it**, so whoever applies inventory gets no on-screen signal that customers weren't texted (it's a `console.warn` in the Vercel logs, which have short retention). Worth a follow-up toast on the apply-inventory result. Called out rather than bundled in.
