### PR TITLE
F25 - React component tests: the harness, the first suite, and the CI step that runs them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,3 +37,13 @@ jobs:
       # Every scripts/*-smoke.mjs, discovered automatically. A red suite fails this step.
       - name: Smoke suites
         run: npm run smoke
+
+      # React component tests (src/**/*.test.js), which the smoke runner does NOT discover —
+      # it only walks scripts/*-smoke.mjs, so before this step an RTL test ran nowhere.
+      # Deliberately WITHOUT --passWithNoTests: if the suites ever disappear, that is a
+      # regression this gate should fail on, not skip past. Same reasoning as the smoke
+      # runner refusing to report success on 0 suites.
+      - name: Component tests
+        run: npm run test:ci
+        env:
+          CI: true

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "build": "react-scripts build",
     "postbuild": "node scripts/stamp-service-worker.mjs",
     "test": "react-scripts test",
+    "test:ci": "react-scripts test --watchAll=false",
     "eject": "react-scripts eject",
     "smoke": "node scripts/smoke-runner.mjs",
     "smoke:labels": "node scripts/lot-label-smoke.mjs",
@@ -42,6 +43,12 @@
       "react-app",
       "react-app/jest"
     ]
+  },
+  "jest": {
+    "moduleNameMapper": {
+      "^react-router-dom$": "<rootDir>/node_modules/react-router-dom/dist/index.js",
+      "^react-router/dom$": "<rootDir>/node_modules/react-router/dist/development/dom-export.js"
+    }
   },
   "browserslist": {
     "production": [

--- a/src/pages/__tests__/composeModal.test.js
+++ b/src/pages/__tests__/composeModal.test.js
@@ -32,9 +32,13 @@ function renderModal(props = {}) {
   return { onSubmit, onClose, ...utils };
 }
 
+// Labels are matched ANCHORED. An unanchored /to/ would also match a future "Total",
+// "History" or "Store" label and throw on multiple matches — a failure that reads as though
+// the new field broke these tests, when really the query was always too loose.
 const startButton = () => screen.getByRole('button', { name: /start conversation|starting/i });
-const recipientBox = () => screen.getByLabelText(/to|recipient|phone|email/i);
-const messageBox = () => screen.getByLabelText(/message/i);
+const recipientBox = () => screen.getByLabelText(/^to$/i);
+const messageBox = () => screen.getByLabelText(/^message$/i);
+const backdrop = () => screen.getByTestId('compose-backdrop');
 
 describe('ComposeModal — Start button gating', () => {
   test('Start is disabled before anything is typed', () => {
@@ -108,7 +112,7 @@ describe('ComposeModal — while a send is in flight', () => {
   // prop captured at render. Inbox.submitCompose guards it synchronously with
   // `composeSendingRef`. If that ref is ever removed, this test will still pass; that is why
   // the Inbox-level test is called out as a backlog row above rather than assumed covered.
-  test('a click after the parent reports sending does not submit again', async () => {
+  test('the disabled Start button cannot be re-clicked once sending', async () => {
     const { onSubmit, rerender } = renderModal();
     await userEvent.type(recipientBox(), '0412345678');
     await userEvent.type(messageBox(), 'Your rack is ready.');
@@ -134,10 +138,36 @@ describe('ComposeModal — closing without losing a draft', () => {
     expect(onClose).not.toHaveBeenCalled();
   });
 
+  // This positive case is what stops the negative one below from rotting into a no-op: if
+  // backdrop-close stops working altogether (or the testid moves), THIS test goes red loudly.
+  // Without it, deleting the whole closeOnBackdrop body left all 11 earlier tests green.
+  test('a backdrop click closes an untouched modal', async () => {
+    const { onClose } = renderModal();
+    await userEvent.click(backdrop());
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
   test('a backdrop click discards nothing once the rep has typed', async () => {
-    const { onClose, container } = renderModal();
+    const { onClose } = renderModal();
     await userEvent.type(messageBox(), 'Half a quote');
-    await userEvent.click(container.firstChild);
+    await userEvent.click(backdrop());
     expect(onClose).not.toHaveBeenCalled();
+  });
+
+  // The backdrop guard above is only safe BECAUSE these two exits always remain — block the
+  // backdrop without them and a typed draft is trapped in a modal with no way out but a
+  // reload. Untested, that guarantee is a comment; tested, it's a constraint.
+  test('Cancel closes even when the rep has typed', async () => {
+    const { onClose } = renderModal();
+    await userEvent.type(messageBox(), 'Half a quote');
+    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('the × closes even when the rep has typed', async () => {
+    const { onClose } = renderModal();
+    await userEvent.type(messageBox(), 'Half a quote');
+    await userEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/pages/__tests__/composeModal.test.js
+++ b/src/pages/__tests__/composeModal.test.js
@@ -1,0 +1,143 @@
+// F25 — the repo's first React component test.
+//
+// WHY THIS FILE EXISTS: @testing-library/react, jest-dom and user-event have been in
+// `dependencies` since the project started, and until now there was not one `*.test.js` in
+// `src/`. Every finding in the F20 increment-2 code review lived in this component, and none
+// of them could have been caught by a test: the pure helpers (src/utils/compose.js) are well
+// covered by scripts/podium-compose-smoke.mjs, the UI that USES them was not covered at all.
+//
+// SCOPE: ComposeModal only — the modal a rep types a new conversation into. The behaviour
+// that matters here is the Start button's gating, because the modal is one click away from
+// texting a real customer, and the channel it derives decides which way that text goes.
+//
+// NOT COVERED HERE (named, not silently skipped — see MEMORY.md backlog):
+//   - Inbox.submitCompose's `composeSendingRef` double-submit guard, `openConversationById`
+//     being called after a compose, and its 401/timeout branches. Those live in the Inbox
+//     page component, which needs a router + an authenticated fetch surface to render; that
+//     is a bigger harness than this increment, and it gets its own backlog row rather than a
+//     shallow mock that would assert nothing real.
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ComposeModal } from '../inbox';
+
+// Rendering helper: the three props ComposeModal takes, with jest spies for the callbacks.
+function renderModal(props = {}) {
+  const onSubmit = jest.fn();
+  const onClose = jest.fn();
+  const utils = render(
+    <ComposeModal sending={false} onSubmit={onSubmit} onClose={onClose} {...props} />,
+  );
+  return { onSubmit, onClose, ...utils };
+}
+
+const startButton = () => screen.getByRole('button', { name: /start conversation|starting/i });
+const recipientBox = () => screen.getByLabelText(/to|recipient|phone|email/i);
+const messageBox = () => screen.getByLabelText(/message/i);
+
+describe('ComposeModal — Start button gating', () => {
+  test('Start is disabled before anything is typed', () => {
+    renderModal();
+    expect(startButton()).toBeDisabled();
+  });
+
+  test('Start stays disabled when the recipient is not a phone or an email', async () => {
+    renderModal();
+    await userEvent.type(recipientBox(), 'not-a-contact');
+    await userEvent.type(messageBox(), 'Your rack is ready for pickup.');
+    // "not-a-contact" has no @-domain and fewer than MIN_PHONE_DIGITS digits, so there is
+    // nowhere for this message to go. Sending it would 400 at best.
+    expect(startButton()).toBeDisabled();
+  });
+
+  test('Start stays disabled when the message is only whitespace', async () => {
+    renderModal();
+    await userEvent.type(recipientBox(), '0412345678');
+    await userEvent.type(messageBox(), '   ');
+    expect(startButton()).toBeDisabled();
+  });
+
+  test('Start enables once the recipient and the message are both valid', async () => {
+    renderModal();
+    await userEvent.type(recipientBox(), '0412345678');
+    await userEvent.type(messageBox(), 'Your rack is ready for pickup.');
+    expect(startButton()).toBeEnabled();
+  });
+});
+
+describe('ComposeModal — what it submits', () => {
+  test('a phone recipient submits channel "phone", trimmed', async () => {
+    const { onSubmit } = renderModal();
+    await userEvent.type(recipientBox(), '  0412 345 678  ');
+    await userEvent.type(messageBox(), '  Your rack is ready.  ');
+    await userEvent.click(startButton());
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+    expect(onSubmit).toHaveBeenCalledWith({
+      to: '0412 345 678',
+      channel: 'phone',
+      body: 'Your rack is ready.',
+    });
+  });
+
+  test('an email recipient submits channel "email"', async () => {
+    const { onSubmit } = renderModal();
+    await userEvent.type(recipientBox(), 'nick@graysfitness.com.au');
+    await userEvent.type(messageBox(), 'Quote attached.');
+    await userEvent.click(startButton());
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ channel: 'email', to: 'nick@graysfitness.com.au' }),
+    );
+  });
+});
+
+describe('ComposeModal — while a send is in flight', () => {
+  test('Start is disabled and reads "Starting…" once the parent reports sending', () => {
+    renderModal({ sending: true });
+    expect(startButton()).toBeDisabled();
+    expect(startButton()).toHaveTextContent(/starting/i);
+  });
+
+  // The customer-visible risk: a second dispatch is a second text. Once the parent has
+  // flipped `sending`, further clicks must not reach onSubmit.
+  //
+  // The narrower race — two clicks landing BEFORE React re-renders with sending=true — is
+  // deliberately not this component's job and cannot be fixed here, because `sending` is a
+  // prop captured at render. Inbox.submitCompose guards it synchronously with
+  // `composeSendingRef`. If that ref is ever removed, this test will still pass; that is why
+  // the Inbox-level test is called out as a backlog row above rather than assumed covered.
+  test('a click after the parent reports sending does not submit again', async () => {
+    const { onSubmit, rerender } = renderModal();
+    await userEvent.type(recipientBox(), '0412345678');
+    await userEvent.type(messageBox(), 'Your rack is ready.');
+    await userEvent.click(startButton());
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+
+    rerender(<ComposeModal sending onSubmit={onSubmit} onClose={jest.fn()} />);
+    await userEvent.click(startButton());
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('ComposeModal — closing without losing a draft', () => {
+  test('Escape closes an untouched modal', async () => {
+    const { onClose } = renderModal();
+    await userEvent.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('Escape does not close mid-send, which would drop the draft', async () => {
+    const { onClose } = renderModal({ sending: true });
+    await userEvent.keyboard('{Escape}');
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  test('a backdrop click discards nothing once the rep has typed', async () => {
+    const { onClose, container } = renderModal();
+    await userEvent.type(messageBox(), 'Half a quote');
+    await userEvent.click(container.firstChild);
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -1790,7 +1790,10 @@ function WorkorderModal({ workorderId, detail, loading, onClose }) {
 //
 // The recipient is validated in the browser only to catch a typo before the round-trip;
 // src/utils/compose.js mirrors the server's rule and the smoke asserts they agree.
-function ComposeModal({ sending, onSubmit, onClose }) {
+// Exported for src/pages/__tests__/composeModal.test.js (F25). The Inbox renders it below;
+// the export exists so the modal can be driven directly in a test without standing up the
+// whole authenticated page, and is deliberately NOT imported anywhere else in the app.
+export function ComposeModal({ sending, onSubmit, onClose }) {
   const [to, setTo] = useState('');
   const [body, setBody] = useState('');
 

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -1829,6 +1829,7 @@ export function ComposeModal({ sending, onSubmit, onClose }) {
 
   return (
     <div
+      data-testid="compose-backdrop"
       className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4"
       onClick={closeOnBackdrop}
     >

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -1,0 +1,19 @@
+// Loaded automatically by react-scripts before every test file (CRA convention:
+// setupFilesAfterEnv), so everything here is in place before a test module is imported.
+//
+// jest-dom's matchers (toBeDisabled, toHaveTextContent, …) let component tests assert on the
+// rendered DOM the way a rep experiences it, rather than on React internals.
+import '@testing-library/jest-dom';
+
+// ---- jsdom gaps that block react-router v7 -------------------------------------
+// CRA 5 pins jest 27 / jsdom 16, which predates TextEncoder/TextDecoder being global in the
+// browser-like environment. react-router v7 reads them at MODULE level, so without these any
+// test that imports a page (every page imports react-router-dom) dies on import with
+// "ReferenceError: TextEncoder is not defined" — before a single assertion runs.
+//
+// Assigned only when missing, so a future CRA/jsdom upgrade that ships its own silently takes
+// over instead of being shadowed by node's.
+import { TextEncoder, TextDecoder } from 'node:util';
+
+if (typeof global.TextEncoder === 'undefined') global.TextEncoder = TextEncoder;
+if (typeof global.TextDecoder === 'undefined') global.TextDecoder = TextDecoder;

--- a/src/setupTests.js
+++ b/src/setupTests.js
@@ -5,6 +5,18 @@
 // rendered DOM the way a rep experiences it, rather than on React internals.
 import '@testing-library/jest-dom';
 
+// ---- see also: the jest.moduleNameMapper block in package.json -----------------
+// package.json cannot carry a comment, so the explanation lives here. That mapper points
+// `react-router-dom` and `react-router/dom` at the CJS files those packages actually ship,
+// because react-router-dom@7.7.1 declares a "main" it does not ship and jest 27 (pinned by
+// CRA 5) predates the "exports" field that saves Node.
+//
+// ⚠️ It is pinned to react-router's INTERNAL dist layout (`dist/development/dom-export.js`),
+// which is not public API. `npm ci` installs from the lockfile so CI is stable, but a
+// react-router major bump may move those files. The failure is loud, not silent — tests die
+// with "Cannot find module" — so if that appears after a dependency update, re-check the
+// paths in package.json against the package's real dist/ contents rather than the exports map.
+
 // ---- jsdom gaps that block react-router v7 -------------------------------------
 // CRA 5 pins jest 27 / jsdom 16, which predates TextEncoder/TextDecoder being global in the
 // browser-like environment. react-router v7 reads them at MODULE level, so without these any


### PR DESCRIPTION
## What and why

The repo has shipped `@testing-library/react`, `jest-dom` and `user-event` in `dependencies` since day one and had **not one `*.test.js` in `src/`**. That was not an oversight anyone chose — it was blocked, for three independent reasons, and nobody had hit them because nobody had tried.

Every finding in the F20 increment-2 review lived in `ComposeModal`. None of them could have been caught by a test. The pure helpers (`src/utils/compose.js`) are well covered by the smoke suites; the UI that uses them was covered by nothing.

## What was actually in the way

Found by watching it fail, not by guessing:

1. **`react-router-dom@7.7.1` declares `main: ./dist/main.js` — a file it does not ship.** It ships `dist/index.js` (CJS) and `dist/index.mjs` (ESM). Node resolves through the `exports` map and is fine; CRA 5 pins jest 27, which predates `exports`, falls back to the broken `main`, and dies with `Cannot find module`. Mapped it and the `react-router/dom` subpath to the CJS files the packages really ship.
2. **jsdom 16 has no global `TextEncoder`/`TextDecoder`.** react-router v7 reads them at module scope, so importing *any* page died on import, before the first assertion.
3. **`ComposeModal` was module-local.** Exported it — and only it — so the modal can be driven without standing up the whole authenticated page.

`moduleNameMapper` is the right lever rather than a shortcut: CRA's `supportedKeys` does not include `resolver`, so a proper `exports`-aware resolver is unavailable without ejecting. CRA merges (rather than replaces) the mapper object, so its built-in CSS-module mapping survives.

## Tests

14 tests over the component that is one click from texting a real customer:

- **Start-button gating** — invalid recipient, whitespace-only body, both-valid.
- **What it submits** — trimming, and phone vs email channel derivation.
- **In-flight state** — disabled + Starting… once the parent reports `sending`.
- **Closing without losing a draft** — Escape (and not mid-send), backdrop (both directions), Cancel, ×.

**Mutation-tested rather than trusted — twice.** Round 1 ran 6 mutants, all caught. The code review then found that deleting the **entire** `closeOnBackdrop` body left all 11 tests green: the backdrop test paired a positional selector (`container.firstChild`) with a *negative* assertion, so it could rot into a permanently-green no-op. Reproduced before fixing. Round 2 runs **10 mutants, 0 survivors**, including that one and two scoped to `ComposeModal`s own ×/Cancel handlers.

## CI

New **Component tests** step. The smoke runner only walks `scripts/*-smoke.mjs`, so before this these would have run nowhere. Deliberately **without** `--passWithNoTests` — verified empirically that jest exits 1 on zero suites, so if the suites ever vanish this gate fails rather than skips. Same stance as the smoke runner refusing to report success on 0 suites.

## Deliberately NOT covered (named, not skipped)

The backlog row also named `composeSendingRef` double-submit, `openConversationById`-after-compose, 401/timeout handling, and the `composeResultMessage` toast. **All four live in `Inbox.submitCompose`**, which needs a router plus an authenticated fetch surface to render — a genuinely different harness that would have doubled this diff and buried the deliverable. Filed as its own backlog row rather than dropped.

Note the real double-submit race is **not fixable in this component** — `sending` is a prop captured at render. `Inbox.submitCompose` guards it synchronously with `composeSendingRef`. If that ref is ever removed, these tests still pass; that is exactly why the Inbox-level row exists.

## Production blast radius

One `export` keyword and one `data-testid`. No behaviour change, no bundle consequence (`ComposeModal` is referenced within its own module, so webpack retained it either way).

## Verification

- `npm run test:ci` → **14/14**
- `npm run smoke` → **19/19 suites**
- `CI=true npm run build` → **compiled successfully** (CRA treats warnings as errors under CI)
- Mutation round 2 → **10/10 caught, 0 survivors**

## Reviewer checklist

- [ ] Preview loads and `/inbox` still opens a new conversation exactly as before (the only prod changes are an `export` and a `data-testid`).
- [ ] CI shows a **Component tests** step, green, running 14 tests.
- [ ] Sanity-check the deferral: is an Inbox-level harness the right second increment, or would you rather it had been forced into this PR?
- [ ] The `package.json` mapper is pinned to react-router **internal** dist paths. Fails loudly (not silently) on a major bump — see the note in `src/setupTests.js`.

## Heads-up, unrelated to this PR

While verifying resolution, the reviewer established that **every** condition in react-router 7.7.1's `exports` map — including `default` and `import` — points at `dist/development/*`. There is no production branch in the map, so the app bundles react-router's **development** build into production today. That is a pre-existing bundle-size question, deliberately not touched here; it is going on the backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)