### PR TITLE
F27 - Reset the composer when the rep switches conversations (fixes a live mis-send)

### DIFF
--- a/src/pages/__tests__/inboxComposerReset.test.js
+++ b/src/pages/__tests__/inboxComposerReset.test.js
@@ -1,0 +1,174 @@
+// F27 — switching conversations must not carry the composer across.
+//
+// THE BUG (live on Production): clicking a different conversation in the list set the new
+// selection but left `draft`, `attachments`, `composerMode` and `showTemplates` untouched. So
+// a half-typed reply to customer A survived into customer B's thread — and if the composer
+// was in internal-note mode, the next Send posted B's thread as an internal note instead of a
+// reply, or vice versa. Sending A's text to B is a genuine mis-send: the wrong customer
+// receives a real SMS.
+//
+// F20 increment 2 extracted `resetComposerState()` and wired it into `openConversationById`
+// (the new compose / deep-link path). This is the same fix on the older list-click path,
+// which F20 left alone as an out-of-scope pre-existing bug.
+//
+// THE HARNESS: this is the first test that renders the whole Inbox page rather than one
+// modal, because `openConversation` is a closure inside `Inbox` and cannot be reached any
+// other way. It needs a router, a logged-in token and a fetch surface. Kept deliberately
+// small — it mocks only the endpoints the page actually calls on mount — and it is the seam
+// the rest of F28's Inbox-level coverage will build on.
+
+import React from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import Inbox from '../inbox';
+
+// Shaped as the list actually consumes it: the row label is
+// `c.identity?.displayName || convTitle(c)`, so `identity.displayName` is what a rep reads.
+const CONVERSATIONS = [
+  {
+    uid: 'conv-alice',
+    status: 'open',
+    channel: { type: 'sms', identifier: '0400000001' },
+    identity: { displayName: 'Alice Adams' },
+    lastMessageAt: '2026-07-20T10:00:00.000Z',
+  },
+  {
+    uid: 'conv-bob',
+    status: 'open',
+    channel: { type: 'sms', identifier: '0400000002' },
+    identity: { displayName: 'Bob Brown' },
+    lastMessageAt: '2026-07-20T09:00:00.000Z',
+  },
+];
+
+const threadFor = (uid) => ({
+  data: [
+    {
+      uid: `${uid}-m1`,
+      direction: 'inbound',
+      body: `Message in ${uid}`,
+      createdAt: '2026-07-20T09:00:00.000Z',
+    },
+  ],
+  serverTime: '2026-07-20T10:00:00.000Z',
+});
+
+// Routes a request to a canned response by URL. Anything unmatched returns an empty 200 so a
+// stray best-effort fetch can't fail the test for the wrong reason.
+function mockFetch() {
+  return jest.fn(async (url) => {
+    const u = String(url);
+    const json = (body, ok = true) => ({
+      ok,
+      status: ok ? 200 : 500,
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+      headers: { get: () => 'application/json' },
+    });
+
+    if (u.includes('resource=conversations')) {
+      return json({ data: CONVERSATIONS, serverTime: '2026-07-20T10:00:00.000Z' });
+    }
+    if (u.includes('resource=messages')) {
+      const uid = u.includes('conv-bob') ? 'conv-bob' : 'conv-alice';
+      return json(threadFor(uid));
+    }
+    if (u.includes('resource=templates')) return json({ data: [] });
+    if (u.includes('resource=reps')) return json({ data: [] });
+    if (u.includes('/api/podium/status')) return json({ podiumUserId: 'pod-me' });
+    if (u.includes('/api/podium/assign')) return json({ assignees: [] });
+    if (u.includes('/api/podium/contact')) return json({ customer: null, workorders: [] });
+    if (u.includes('/api/products')) return json({ data: [] });
+    return json({});
+  });
+}
+
+function renderInbox() {
+  return render(
+    <MemoryRouter>
+      <Inbox />
+    </MemoryRouter>,
+  );
+}
+
+const conversationButton = (name) => screen.getByText(name).closest('button') || screen.getByText(name);
+const composer = () => screen.getByPlaceholderText(/type a reply…|write an internal note…/i);
+
+beforeEach(() => {
+  localStorage.setItem('token', 'test-token');
+  localStorage.setItem('user', JSON.stringify({ id: 'GS', name: 'Tester', roles: ['sales'] }));
+  global.fetch = mockFetch();
+});
+
+afterEach(() => {
+  localStorage.clear();
+  jest.resetAllMocks();
+});
+
+describe('F27 — switching conversations resets the composer', () => {
+  test('a half-typed reply to one customer does not follow into another thread', async () => {
+    renderInbox();
+
+    // Open Alice and start typing a reply we never send.
+    await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+    await userEvent.click(conversationButton('Alice Adams'));
+    await waitFor(() => expect(composer()).toBeInTheDocument());
+    await userEvent.type(composer(), 'Alice, your rack is ready');
+    expect(composer()).toHaveValue('Alice, your rack is ready');
+
+    // Switch to Bob by clicking the list — the path this feature fixes.
+    await userEvent.click(conversationButton('Bob Brown'));
+    await waitFor(() => expect(screen.getByText(/Message in conv-bob/i)).toBeInTheDocument());
+
+    // The draft addressed to Alice must NOT be sitting in Bob's composer.
+    expect(composer()).toHaveValue('');
+  });
+
+  test('internal-note mode does not follow into another thread', async () => {
+    renderInbox();
+
+    await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+    await userEvent.click(conversationButton('Alice Adams'));
+    await waitFor(() => expect(composer()).toBeInTheDocument());
+
+    // Put the composer into internal-note mode on Alice's thread.
+    await userEvent.click(screen.getByRole('button', { name: /internal note/i }));
+    expect(screen.getByPlaceholderText(/write an internal note…/i)).toBeInTheDocument();
+
+    await userEvent.click(conversationButton('Bob Brown'));
+    await waitFor(() => expect(screen.getByText(/Message in conv-bob/i)).toBeInTheDocument());
+
+    // If note mode survived, the next Send posts a team-only note instead of replying to the
+    // customer (or the reverse) — silent, and wrong in both directions.
+    expect(screen.getByPlaceholderText(/type a reply…/i)).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/write an internal note…/i)).not.toBeInTheDocument();
+  });
+
+  test('re-clicking the SAME conversation does not wipe a draft in progress', async () => {
+    renderInbox();
+
+    await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+    await userEvent.click(conversationButton('Alice Adams'));
+    await waitFor(() => expect(composer()).toBeInTheDocument());
+    await userEvent.type(composer(), 'Half a sentence');
+
+    // A rep re-clicking the thread they are already in (or a list re-render) must not be
+    // treated as a switch — that would discard their work with no undo, which is the same
+    // class of harm this feature exists to prevent, just pointed the other way.
+    await userEvent.click(conversationButton('Alice Adams'));
+    await waitFor(() => expect(screen.getByText(/Message in conv-alice/i)).toBeInTheDocument());
+
+    expect(composer()).toHaveValue('Half a sentence');
+  });
+});
+
+// Keeps the panel/thread queries above honest: if the list stops rendering both customers,
+// every assertion in this file becomes vacuous.
+test('harness sanity: both conversations render in the list', async () => {
+  renderInbox();
+  await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+  expect(screen.getByText('Bob Brown')).toBeInTheDocument();
+  const list = screen.getByText('Alice Adams').closest('button');
+  expect(within(list).getByText('Alice Adams')).toBeInTheDocument();
+});

--- a/src/pages/__tests__/inboxComposerReset.test.js
+++ b/src/pages/__tests__/inboxComposerReset.test.js
@@ -18,7 +18,7 @@
 // the rest of F28's Inbox-level coverage will build on.
 
 import React from 'react';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import Inbox from '../inbox';
@@ -75,11 +75,14 @@ function mockFetch() {
       return json(threadFor(uid));
     }
     if (u.includes('resource=templates')) return json({ data: [] });
-    if (u.includes('resource=reps')) return json({ data: [] });
+    // Shapes matter even when empty. The page reads `d.reps` here and a BARE ARRAY from
+    // /api/products — returning `{data: []}` for either would leave those features
+    // permanently empty in every future test while looking correct.
+    if (u.includes('resource=reps')) return json({ reps: [] });
     if (u.includes('/api/podium/status')) return json({ podiumUserId: 'pod-me' });
     if (u.includes('/api/podium/assign')) return json({ assignees: [] });
     if (u.includes('/api/podium/contact')) return json({ customer: null, workorders: [] });
-    if (u.includes('/api/products')) return json({ data: [] });
+    if (u.includes('/api/products')) return json([]);
     return json({});
   });
 }
@@ -92,13 +95,26 @@ function renderInbox() {
   );
 }
 
-const conversationButton = (name) => screen.getByText(name).closest('button') || screen.getByText(name);
+// No `|| getByText(name)` fallback on purpose: if a list row ever stops being a <button>,
+// this should fail with "no button found", not silently click a <div> and fail later with a
+// confusing assertion about draft text.
+const conversationButton = (name) => {
+  const row = screen.getByText(name).closest('button');
+  if (!row) throw new Error(`Conversation row for "${name}" is not a <button>`);
+  return row;
+};
 const composer = () => screen.getByPlaceholderText(/type a reply…|write an internal note…/i);
 
 beforeEach(() => {
   localStorage.setItem('token', 'test-token');
   localStorage.setItem('user', JSON.stringify({ id: 'GS', name: 'Tester', roles: ['sales'] }));
   global.fetch = mockFetch();
+
+  // jsdom 16 (pinned by CRA 5) implements NEITHER of these. The composer revokes attachment
+  // object URLs on unmount, so without the stubs any test that attaches a file dies in
+  // cleanup rather than in the assertion.
+  URL.createObjectURL = jest.fn(() => 'blob:mock-url');
+  URL.revokeObjectURL = jest.fn();
 });
 
 afterEach(() => {
@@ -145,6 +161,33 @@ describe('F27 — switching conversations resets the composer', () => {
     expect(screen.queryByPlaceholderText(/write an internal note…/i)).not.toBeInTheDocument();
   });
 
+  // The backlog row names four states; draft and composerMode are covered above. This is the
+  // one that matters most and was the biggest hole in my first mutation set: an image or
+  // quote PDF attached for Alice, following into Bob's composer and being SENT. Worse than
+  // stray text, because a rep skims the textarea before sending but not the attachment chips.
+  test('an attachment picked for one customer does not follow into another thread', async () => {
+    renderInbox();
+
+    await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+    await userEvent.click(conversationButton('Alice Adams'));
+    await waitFor(() => expect(composer()).toBeInTheDocument());
+
+    const file = new File(['fake-image-bytes'], 'alice-quote.png', { type: 'image/png' });
+    const input = document.querySelector('input[type="file"]');
+    expect(input).toBeTruthy();
+    await userEvent.upload(input, file);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /remove attachment/i })).toBeInTheDocument(),
+    );
+
+    await userEvent.click(conversationButton('Bob Brown'));
+    await waitFor(() => expect(screen.getByText(/Message in conv-bob/i)).toBeInTheDocument());
+
+    expect(screen.queryByRole('button', { name: /remove attachment/i })).not.toBeInTheDocument();
+    // The blob must be released too, not just dropped from state.
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+
   test('re-clicking the SAME conversation does not wipe a draft in progress', async () => {
     renderInbox();
 
@@ -163,12 +206,13 @@ describe('F27 — switching conversations resets the composer', () => {
   });
 });
 
-// Keeps the panel/thread queries above honest: if the list stops rendering both customers,
-// every assertion in this file becomes vacuous.
-test('harness sanity: both conversations render in the list', async () => {
+// Keeps every assertion above honest: if the list stopped rendering both customers, the
+// switch-thread tests would pass vacuously. Asserts the EXACT row count too, so a duplicate
+// -row regression (the 8s poll appending rather than replacing) fails here rather than
+// somewhere confusing.
+test('harness sanity: the list renders exactly the two seeded conversations', async () => {
   renderInbox();
   await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
   expect(screen.getByText('Bob Brown')).toBeInTheDocument();
-  const list = screen.getByText('Alice Adams').closest('button');
-  expect(within(list).getByText('Alice Adams')).toBeInTheDocument();
+  expect(screen.getAllByText(/Alice Adams|Bob Brown/)).toHaveLength(2);
 });

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -148,6 +148,11 @@ export default function Inbox() {
   const [searchTruncated, setSearchTruncated] = useState(false);
 
   const [selectedId, setSelectedId] = useState(null);
+  // F27 — mirrors `selectedId` for synchronous reads. The composer-reset guard in
+  // openConversation must compare against the CURRENT selection, not the one captured when
+  // this render ran; see the comment there. Kept in sync by the effect below rather than at
+  // each call site, so a future setSelectedId cannot forget to update it.
+  const selectedIdRef = useRef(null);
   const [selectedConv, setSelectedConv] = useState(null);
   const [messages, setMessages] = useState([]);
   const [loadingThread, setLoadingThread] = useState(false);
@@ -382,6 +387,8 @@ export default function Inbox() {
     }
   }, [navigate, loadThread, loadPanel, loadAssignees, resetComposerState]);
 
+  useEffect(() => { selectedIdRef.current = selectedId; }, [selectedId]);
+
   // Fetch the timeline whenever the panel resolves a lead.
   useEffect(() => {
     loadLeadHistory(panel?.lead?.lead_id || null);
@@ -589,7 +596,12 @@ export default function Inbox() {
     // Guarded on the id CHANGING on purpose: re-clicking the thread you are already in, or a
     // list re-render, must not discard work in progress. Wiping a draft with no undo is the
     // same class of harm, just pointed the other way.
-    if (c.uid !== selectedId) resetComposerState();
+    // Read through a REF, not the render-closure state. `openConversationById` sets
+    // `selectedId` inside an async continuation, so a click landing before that commit would
+    // read a stale value, judge it a switch, and reset a composer the rep is still using —
+    // costing them a draft, which is precisely what the guard exists to prevent. Same hazard
+    // and same remedy as `composeSendingRef` above.
+    if (c.uid !== selectedIdRef.current) resetComposerState();
     setSelectedId(c.uid);
     setSelectedConv(c);
     loadThread(c.uid);

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -579,6 +579,17 @@ export default function Inbox() {
   };
 
   const openConversation = (c) => {
+    // F27 — clear the composer when the rep moves to a DIFFERENT thread. Without this a
+    // half-typed reply to customer A followed them into customer B's thread, one Send away
+    // from the wrong customer receiving it; and an active internal-note mode followed too, so
+    // the next Send posted a team-only note instead of a reply (or the reverse). Both are
+    // silent. openConversationById (compose / deep-link) already did this since F20 incr 2 —
+    // this is the same fix on the older list-click path.
+    //
+    // Guarded on the id CHANGING on purpose: re-clicking the thread you are already in, or a
+    // list re-render, must not discard work in progress. Wiping a draft with no undo is the
+    // same class of harm, just pointed the other way.
+    if (c.uid !== selectedId) resetComposerState();
     setSelectedId(c.uid);
     setSelectedConv(c);
     loadThread(c.uid);


### PR DESCRIPTION
> ⚠️ **STACKED PR — base is `feat/podium-f26-modal-a11y` ([#85](https://github.com/GraysSupport/grays-internal/pull/85)), which is itself stacked on F25 ([#84](https://github.com/GraysSupport/grays-internal/pull/84)).** **Merge order: #84 → #85 → this.** GitHub retargets automatically as each lands.

## 🔴 This is a live customer-facing bug, on Production right now

`openConversation(c)` — the conversation-list click path — set the new selection but left the composer state (`draft`, `attachments`, `composerMode`, `showTemplates`) untouched. So:

- **A half-typed reply to customer A followed the rep into customer B's thread.** One Send and **the wrong customer receives a real SMS.**
- **An active internal-note mode followed too**, so the next Send posted a team-only note instead of a customer reply — or the reverse, publishing an internal note *to the customer*.
- **An attachment picked for A followed into B's composer.** Worse than stray text: a rep skims the textarea before sending, but not the attachment chips.

All three are silent. Nothing on screen says the composer is carrying the previous thread's content.

F20 increment 2 extracted `resetComposerState()` and wired it into `openConversationById` (the compose/deep-link path); this is the same fix on the older click path, which F20 explicitly left as an out-of-scope pre-existing bug.

## The fix

One guarded line in `openConversation`:

```js
if (c.uid !== selectedIdRef.current) resetComposerState();
```

**The guard is the interesting part, in two ways:**

1. **It compares uids, not objects.** The 8-second poll calls `loadConversations({silent:true})`, which replaces every object in the list. A guard written as `c !== selectedConv` would have started shredding drafts on every poll tick.
2. **It reads a ref, not render-closure state.** `openConversationById` sets `selectedId` inside an async continuation, so a click landing before that commit would read a stale value, judge it a switch, and reset a composer still in use — **costing the rep a draft, which is precisely the harm the guard exists to prevent.** Same hazard and same remedy as the existing `composeSendingRef` a few lines below.

Re-clicking the thread you are already in must **not** discard work in progress — that has its own test.

## TDD

The two mis-send tests were **RED first** — the draft arrived in Bob's thread, and note mode survived the switch — while the same-thread guard test **passed from the start**, which is what it should do for behaviour that was already correct.

## New: the first Inbox-level test harness

`openConversation` is a closure inside `Inbox` and is unreachable any other way, so this adds the first test that renders the whole page: `MemoryRouter` + a token in `localStorage` + a `fetch` mock covering only the endpoints the page calls on mount.

This is the seam **F28** builds on, so F28 is now narrower than when it was filed. Two things worth knowing for whoever picks it up:

- **jsdom 16 implements neither `URL.createObjectURL` nor `URL.revokeObjectURL`.** The composer revokes attachment object URLs on unmount, so without stubs any test touching attachments dies in cleanup rather than in the assertion.
- The mock is currently a flat function; F28 should parameterise it (`mockFetch({overrides})`) for the 401/timeout paths rather than copy-pasting.

## Code review — what it caught

No Critical. Two mutants my own set missed, and one of them mattered:

- **`clearAttachments()` could be deleted with every test still green.** For a row whose whole justification is "the wrong customer receives this", the attachment carry-over path was unguarded by the suite. Now tested end-to-end, including that the blob is actually revoked and not merely dropped from state.
- **Two fetch-mock shapes were wrong in a silently-disabling way** — the page reads `d.reps` and a *bare array* from `/api/products`; the mock returned `{data: []}` for both. Harmless today because both are empty either way, which is exactly what makes it a trap.
- The sanity test's final assertion was tautological (found the row *by* Alice's text, then asserted Alice's text was in it). Now asserts the exact row count, so a duplicate-row regression from the poll fails there.

The reviewer also argued against moving this to a `useEffect` keyed on `selectedId`, and I agree: `openConversationById` resets *before* its fetch deliberately, so a failed open still leaves a clean composer — an effect only fires when the selection actually lands, which would silently drop that. The better long-term shape is funnelling all paths through one `selectConversation()` helper that owns the guard; noted as a follow-up, not done here.

## Verification

- **5 F27 tests** · **48 tests total** · **19/19 smoke suites** · `CI=true npm run build` clean
- **Mutation round 2: 8 mutants, all CAUGHT, 0 survivors** — including both the reviewer proved survived round 1, and the stale-closure guard itself
- All four `setSelectedId` call sites traced: `openConversationById` (resets), `clearSelection` (resets), `openConversation` (now resets). There is no fourth path left open.

## Filed, not fixed (out of scope)

**F31** — `switchBucket`/`switchStatus` call `clearSelection()`, which resets the composer **unconditionally**. A rep with a half-typed reply who clicks the "Closed" filter loses it silently, no undo. Same harm as F27, different control. Deliberately not bundled into this PR.

## Reviewer checklist

- [ ] `/inbox`: type a reply to one customer, click a **different** conversation → **the composer must be empty**.
- [ ] Switch to **Internal note** mode, then click a different conversation → the composer must be back to **reply** mode (placeholder "Type a reply…").
- [ ] Attach an image, then click a different conversation → **the attachment chip must be gone**.
- [ ] Type a draft, then click the **same** conversation again → **the draft must survive** (this is the guard, and it's the one that would be a regression if it broke).
- [ ] Leave the inbox open ~10s so the poll ticks while a draft is in progress → the draft must survive.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
