### PR TITLE
RECOVERY: restore F26 + F27 to main (they merged into their stack bases, not main)

### DIFF
--- a/src/hooks/useDialog.js
+++ b/src/hooks/useDialog.js
@@ -1,0 +1,97 @@
+// F26 — the focus behaviour every true modal in the portal needs, in one place.
+//
+// Written as a hook rather than a <Modal> wrapper component on purpose: the four overlays in
+// the inbox have quite different chrome (a form, two read-only panels, a popover) and
+// rewriting them into a shared shell would be a large refactor of a file that is under
+// active review. A hook changes each modal by two lines and leaves its markup alone.
+//
+// WHAT THIS DOES NOT DO: it does not own Escape. ComposeModal must refuse Escape while a send
+// is in flight (or the rep loses a typed draft with a request already on the wire), while the
+// read-only lookups should always close. That difference is real, so each modal keeps its own
+// Escape handler and this hook stays focused on focus.
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+// Tab order, as the browser sees it. `:not([disabled])` matters — ComposeModal disables its
+// Cancel button mid-send, and a trap that tried to focus a disabled element would land
+// nowhere and effectively drop the user out of the dialog.
+const FOCUSABLE = [
+  'a[href]',
+  'button:not([disabled])',
+  'input:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+function focusableWithin(root) {
+  if (!root) return [];
+  // Filtered on ATTRIBUTES, not on layout. The obvious check here is `offsetParent !== null`
+  // to skip display:none — and it is a trap: jsdom has no layout engine, so offsetParent is
+  // ALWAYS null and that filter silently discards every candidate. The trap is quiet, because
+  // the two dialogs whose first control carries autoFocus still looked like they focused
+  // correctly while this hook was doing nothing at all. Attributes behave the same in jsdom
+  // and in the browser, and these dialogs don't hide controls with CSS anyway.
+  return Array.from(root.querySelectorAll(FOCUSABLE)).filter(
+    (el) => !el.hasAttribute('hidden') && el.getAttribute('aria-hidden') !== 'true',
+  );
+}
+
+/**
+ * Wires up modal focus behaviour and returns the ref to put on the dialog element.
+ *
+ * - moves focus into the dialog when it opens (first focusable, else the dialog itself)
+ * - keeps Tab / Shift+Tab inside it
+ * - restores focus to whatever was focused before it opened, when it unmounts
+ */
+export default function useDialog() {
+  const ref = useRef(null);
+  // Captured during the FIRST RENDER via a lazy useState initialiser — deliberately not in the
+  // effect below. React applies `autoFocus` during commit, which is BEFORE effects run, so
+  // capturing in the effect records whichever control inside the dialog just took focus
+  // instead of the opener outside it. Restoring then targets a node that is about to be
+  // detached, `document.contains` says no, the restore is skipped, and focus silently falls to
+  // <body>. That is a real bug this hook shipped with for exactly one test run.
+  const [restoreTo] = useState(() => (typeof document === 'undefined' ? null : document.activeElement));
+
+  useEffect(() => {
+    const node = ref.current;
+    const first = focusableWithin(node)[0];
+    if (first) first.focus();
+    else if (node) node.focus();
+
+    return () => {
+      // Only restore if the opener is still in the document — it may have been removed by the
+      // very action that closed the dialog, and focusing a detached node throws focus to
+      // <body>, which is worse than leaving it alone.
+      if (restoreTo && typeof restoreTo.focus === 'function' && document.contains(restoreTo)) {
+        restoreTo.focus();
+      }
+    };
+  }, [restoreTo]);
+
+  const onKeyDown = useCallback((e) => {
+    if (e.key !== 'Tab') return;
+    const items = focusableWithin(ref.current);
+    if (items.length === 0) {
+      // Nothing to move to — keep focus here rather than letting it escape to the page behind.
+      e.preventDefault();
+      return;
+    }
+    const firstItem = items[0];
+    const lastItem = items[items.length - 1];
+    const active = document.activeElement;
+
+    // Wrap at both ends. The `!contains` case matters: if focus somehow starts outside (a
+    // click on the backdrop, say), Tab pulls it back in rather than continuing down the page.
+    if (e.shiftKey && (active === firstItem || !ref.current?.contains(active))) {
+      e.preventDefault();
+      lastItem.focus();
+    } else if (!e.shiftKey && (active === lastItem || !ref.current?.contains(active))) {
+      e.preventDefault();
+      firstItem.focus();
+    }
+  }, []);
+
+  return { ref, onKeyDown };
+}

--- a/src/hooks/useDialog.js
+++ b/src/hooks/useDialog.js
@@ -56,9 +56,23 @@ export default function useDialog() {
 
   useEffect(() => {
     const node = ref.current;
-    const first = focusableWithin(node)[0];
-    if (first) first.focus();
-    else if (node) node.focus();
+
+    // Do NOT steal focus if the dialog has already placed it. Two of these modals mark their
+    // text input `autoFocus`, and React honours that during commit — i.e. BEFORE this effect.
+    // Blindly focusing the first focusable would drag the caret out of the "To" / search box
+    // and onto the Close button, costing every rep a keystroke on every open and leaving them
+    // one Enter from dismissing the modal. That is a regression this hook shipped with, and
+    // the containment-only assertion in the first draft of the tests was too weak to catch it.
+    //
+    // Note `[autofocus]` cannot be queried for here: React sets autofocus imperatively and
+    // never renders the attribute, so the DOM has no record of the intent. Deferring to
+    // "focus is already inside me" is what actually works.
+    const alreadyInside = node && node.contains(document.activeElement) && document.activeElement !== node;
+    if (!alreadyInside) {
+      const first = focusableWithin(node)[0];
+      if (first) first.focus();
+      else if (node) node.focus();
+    }
 
     return () => {
       // Only restore if the opener is still in the document — it may have been removed by the
@@ -82,8 +96,11 @@ export default function useDialog() {
     const lastItem = items[items.length - 1];
     const active = document.activeElement;
 
-    // Wrap at both ends. The `!contains` case matters: if focus somehow starts outside (a
-    // click on the backdrop, say), Tab pulls it back in rather than continuing down the page.
+    // Wrap at both ends. The `!contains` cases are the ones that matter most in a real
+    // browser: when focus has fallen outside the dialog, Tab pulls it back in rather than
+    // continuing down the page behind. They are only reachable because this handler is bound
+    // to the document (see below) — on an element handler they would be dead code, since a
+    // keydown targeted at <body> would never reach it.
     if (e.shiftKey && (active === firstItem || !ref.current?.contains(active))) {
       e.preventDefault();
       lastItem.focus();
@@ -93,5 +110,23 @@ export default function useDialog() {
     }
   }, []);
 
-  return { ref, onKeyDown };
+  // Bound to the DOCUMENT in the capture phase, deliberately NOT to the dialog element.
+  //
+  // On the element, the trap has a hole you hit by accident: in a real browser a mousedown on
+  // any non-focusable part of the dialog (the heading, the padding, a results row) blurs the
+  // active element to <body>. A Tab keydown then targets <body>, never reaches a handler
+  // mounted on the dialog, and focus walks straight out into the inbox behind — the exact bug
+  // this feature exists to fix. Focus arriving from the browser chrome behaves the same way.
+  //
+  // ⚠️ jsdom does not reproduce blur-to-body, so NO test here can prove this. It is reasoned
+  // from the DOM event model and wants a keyboard check in a real browser.
+  useEffect(() => {
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [onKeyDown]);
+
+  // Only the ref. The Tab handler is deliberately NOT returned for the caller to spread onto
+  // the element: with the document-capture listener above it would fire a second time for the
+  // same keystroke and advance focus twice.
+  return { ref };
 }

--- a/src/pages/__tests__/inboxComposerReset.test.js
+++ b/src/pages/__tests__/inboxComposerReset.test.js
@@ -1,0 +1,174 @@
+// F27 — switching conversations must not carry the composer across.
+//
+// THE BUG (live on Production): clicking a different conversation in the list set the new
+// selection but left `draft`, `attachments`, `composerMode` and `showTemplates` untouched. So
+// a half-typed reply to customer A survived into customer B's thread — and if the composer
+// was in internal-note mode, the next Send posted B's thread as an internal note instead of a
+// reply, or vice versa. Sending A's text to B is a genuine mis-send: the wrong customer
+// receives a real SMS.
+//
+// F20 increment 2 extracted `resetComposerState()` and wired it into `openConversationById`
+// (the new compose / deep-link path). This is the same fix on the older list-click path,
+// which F20 left alone as an out-of-scope pre-existing bug.
+//
+// THE HARNESS: this is the first test that renders the whole Inbox page rather than one
+// modal, because `openConversation` is a closure inside `Inbox` and cannot be reached any
+// other way. It needs a router, a logged-in token and a fetch surface. Kept deliberately
+// small — it mocks only the endpoints the page actually calls on mount — and it is the seam
+// the rest of F28's Inbox-level coverage will build on.
+
+import React from 'react';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import Inbox from '../inbox';
+
+// Shaped as the list actually consumes it: the row label is
+// `c.identity?.displayName || convTitle(c)`, so `identity.displayName` is what a rep reads.
+const CONVERSATIONS = [
+  {
+    uid: 'conv-alice',
+    status: 'open',
+    channel: { type: 'sms', identifier: '0400000001' },
+    identity: { displayName: 'Alice Adams' },
+    lastMessageAt: '2026-07-20T10:00:00.000Z',
+  },
+  {
+    uid: 'conv-bob',
+    status: 'open',
+    channel: { type: 'sms', identifier: '0400000002' },
+    identity: { displayName: 'Bob Brown' },
+    lastMessageAt: '2026-07-20T09:00:00.000Z',
+  },
+];
+
+const threadFor = (uid) => ({
+  data: [
+    {
+      uid: `${uid}-m1`,
+      direction: 'inbound',
+      body: `Message in ${uid}`,
+      createdAt: '2026-07-20T09:00:00.000Z',
+    },
+  ],
+  serverTime: '2026-07-20T10:00:00.000Z',
+});
+
+// Routes a request to a canned response by URL. Anything unmatched returns an empty 200 so a
+// stray best-effort fetch can't fail the test for the wrong reason.
+function mockFetch() {
+  return jest.fn(async (url) => {
+    const u = String(url);
+    const json = (body, ok = true) => ({
+      ok,
+      status: ok ? 200 : 500,
+      json: async () => body,
+      text: async () => JSON.stringify(body),
+      headers: { get: () => 'application/json' },
+    });
+
+    if (u.includes('resource=conversations')) {
+      return json({ data: CONVERSATIONS, serverTime: '2026-07-20T10:00:00.000Z' });
+    }
+    if (u.includes('resource=messages')) {
+      const uid = u.includes('conv-bob') ? 'conv-bob' : 'conv-alice';
+      return json(threadFor(uid));
+    }
+    if (u.includes('resource=templates')) return json({ data: [] });
+    if (u.includes('resource=reps')) return json({ data: [] });
+    if (u.includes('/api/podium/status')) return json({ podiumUserId: 'pod-me' });
+    if (u.includes('/api/podium/assign')) return json({ assignees: [] });
+    if (u.includes('/api/podium/contact')) return json({ customer: null, workorders: [] });
+    if (u.includes('/api/products')) return json({ data: [] });
+    return json({});
+  });
+}
+
+function renderInbox() {
+  return render(
+    <MemoryRouter>
+      <Inbox />
+    </MemoryRouter>,
+  );
+}
+
+const conversationButton = (name) => screen.getByText(name).closest('button') || screen.getByText(name);
+const composer = () => screen.getByPlaceholderText(/type a reply…|write an internal note…/i);
+
+beforeEach(() => {
+  localStorage.setItem('token', 'test-token');
+  localStorage.setItem('user', JSON.stringify({ id: 'GS', name: 'Tester', roles: ['sales'] }));
+  global.fetch = mockFetch();
+});
+
+afterEach(() => {
+  localStorage.clear();
+  jest.resetAllMocks();
+});
+
+describe('F27 — switching conversations resets the composer', () => {
+  test('a half-typed reply to one customer does not follow into another thread', async () => {
+    renderInbox();
+
+    // Open Alice and start typing a reply we never send.
+    await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+    await userEvent.click(conversationButton('Alice Adams'));
+    await waitFor(() => expect(composer()).toBeInTheDocument());
+    await userEvent.type(composer(), 'Alice, your rack is ready');
+    expect(composer()).toHaveValue('Alice, your rack is ready');
+
+    // Switch to Bob by clicking the list — the path this feature fixes.
+    await userEvent.click(conversationButton('Bob Brown'));
+    await waitFor(() => expect(screen.getByText(/Message in conv-bob/i)).toBeInTheDocument());
+
+    // The draft addressed to Alice must NOT be sitting in Bob's composer.
+    expect(composer()).toHaveValue('');
+  });
+
+  test('internal-note mode does not follow into another thread', async () => {
+    renderInbox();
+
+    await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+    await userEvent.click(conversationButton('Alice Adams'));
+    await waitFor(() => expect(composer()).toBeInTheDocument());
+
+    // Put the composer into internal-note mode on Alice's thread.
+    await userEvent.click(screen.getByRole('button', { name: /internal note/i }));
+    expect(screen.getByPlaceholderText(/write an internal note…/i)).toBeInTheDocument();
+
+    await userEvent.click(conversationButton('Bob Brown'));
+    await waitFor(() => expect(screen.getByText(/Message in conv-bob/i)).toBeInTheDocument());
+
+    // If note mode survived, the next Send posts a team-only note instead of replying to the
+    // customer (or the reverse) — silent, and wrong in both directions.
+    expect(screen.getByPlaceholderText(/type a reply…/i)).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/write an internal note…/i)).not.toBeInTheDocument();
+  });
+
+  test('re-clicking the SAME conversation does not wipe a draft in progress', async () => {
+    renderInbox();
+
+    await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+    await userEvent.click(conversationButton('Alice Adams'));
+    await waitFor(() => expect(composer()).toBeInTheDocument());
+    await userEvent.type(composer(), 'Half a sentence');
+
+    // A rep re-clicking the thread they are already in (or a list re-render) must not be
+    // treated as a switch — that would discard their work with no undo, which is the same
+    // class of harm this feature exists to prevent, just pointed the other way.
+    await userEvent.click(conversationButton('Alice Adams'));
+    await waitFor(() => expect(screen.getByText(/Message in conv-alice/i)).toBeInTheDocument());
+
+    expect(composer()).toHaveValue('Half a sentence');
+  });
+});
+
+// Keeps the panel/thread queries above honest: if the list stops rendering both customers,
+// every assertion in this file becomes vacuous.
+test('harness sanity: both conversations render in the list', async () => {
+  renderInbox();
+  await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+  expect(screen.getByText('Bob Brown')).toBeInTheDocument();
+  const list = screen.getByText('Alice Adams').closest('button');
+  expect(within(list).getByText('Alice Adams')).toBeInTheDocument();
+});

--- a/src/pages/__tests__/inboxComposerReset.test.js
+++ b/src/pages/__tests__/inboxComposerReset.test.js
@@ -18,7 +18,7 @@
 // the rest of F28's Inbox-level coverage will build on.
 
 import React from 'react';
-import { render, screen, waitFor, within } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import Inbox from '../inbox';
@@ -75,11 +75,14 @@ function mockFetch() {
       return json(threadFor(uid));
     }
     if (u.includes('resource=templates')) return json({ data: [] });
-    if (u.includes('resource=reps')) return json({ data: [] });
+    // Shapes matter even when empty. The page reads `d.reps` here and a BARE ARRAY from
+    // /api/products — returning `{data: []}` for either would leave those features
+    // permanently empty in every future test while looking correct.
+    if (u.includes('resource=reps')) return json({ reps: [] });
     if (u.includes('/api/podium/status')) return json({ podiumUserId: 'pod-me' });
     if (u.includes('/api/podium/assign')) return json({ assignees: [] });
     if (u.includes('/api/podium/contact')) return json({ customer: null, workorders: [] });
-    if (u.includes('/api/products')) return json({ data: [] });
+    if (u.includes('/api/products')) return json([]);
     return json({});
   });
 }
@@ -92,13 +95,26 @@ function renderInbox() {
   );
 }
 
-const conversationButton = (name) => screen.getByText(name).closest('button') || screen.getByText(name);
+// No `|| getByText(name)` fallback on purpose: if a list row ever stops being a <button>,
+// this should fail with "no button found", not silently click a <div> and fail later with a
+// confusing assertion about draft text.
+const conversationButton = (name) => {
+  const row = screen.getByText(name).closest('button');
+  if (!row) throw new Error(`Conversation row for "${name}" is not a <button>`);
+  return row;
+};
 const composer = () => screen.getByPlaceholderText(/type a reply…|write an internal note…/i);
 
 beforeEach(() => {
   localStorage.setItem('token', 'test-token');
   localStorage.setItem('user', JSON.stringify({ id: 'GS', name: 'Tester', roles: ['sales'] }));
   global.fetch = mockFetch();
+
+  // jsdom 16 (pinned by CRA 5) implements NEITHER of these. The composer revokes attachment
+  // object URLs on unmount, so without the stubs any test that attaches a file dies in
+  // cleanup rather than in the assertion.
+  URL.createObjectURL = jest.fn(() => 'blob:mock-url');
+  URL.revokeObjectURL = jest.fn();
 });
 
 afterEach(() => {
@@ -145,6 +161,33 @@ describe('F27 — switching conversations resets the composer', () => {
     expect(screen.queryByPlaceholderText(/write an internal note…/i)).not.toBeInTheDocument();
   });
 
+  // The backlog row names four states; draft and composerMode are covered above. This is the
+  // one that matters most and was the biggest hole in my first mutation set: an image or
+  // quote PDF attached for Alice, following into Bob's composer and being SENT. Worse than
+  // stray text, because a rep skims the textarea before sending but not the attachment chips.
+  test('an attachment picked for one customer does not follow into another thread', async () => {
+    renderInbox();
+
+    await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+    await userEvent.click(conversationButton('Alice Adams'));
+    await waitFor(() => expect(composer()).toBeInTheDocument());
+
+    const file = new File(['fake-image-bytes'], 'alice-quote.png', { type: 'image/png' });
+    const input = document.querySelector('input[type="file"]');
+    expect(input).toBeTruthy();
+    await userEvent.upload(input, file);
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: /remove attachment/i })).toBeInTheDocument(),
+    );
+
+    await userEvent.click(conversationButton('Bob Brown'));
+    await waitFor(() => expect(screen.getByText(/Message in conv-bob/i)).toBeInTheDocument());
+
+    expect(screen.queryByRole('button', { name: /remove attachment/i })).not.toBeInTheDocument();
+    // The blob must be released too, not just dropped from state.
+    expect(URL.revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
+  });
+
   test('re-clicking the SAME conversation does not wipe a draft in progress', async () => {
     renderInbox();
 
@@ -163,12 +206,13 @@ describe('F27 — switching conversations resets the composer', () => {
   });
 });
 
-// Keeps the panel/thread queries above honest: if the list stops rendering both customers,
-// every assertion in this file becomes vacuous.
-test('harness sanity: both conversations render in the list', async () => {
+// Keeps every assertion above honest: if the list stopped rendering both customers, the
+// switch-thread tests would pass vacuously. Asserts the EXACT row count too, so a duplicate
+// -row regression (the 8s poll appending rather than replacing) fails here rather than
+// somewhere confusing.
+test('harness sanity: the list renders exactly the two seeded conversations', async () => {
   renderInbox();
   await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
   expect(screen.getByText('Bob Brown')).toBeInTheDocument();
-  const list = screen.getByText('Alice Adams').closest('button');
-  expect(within(list).getByText('Alice Adams')).toBeInTheDocument();
+  expect(screen.getAllByText(/Alice Adams|Bob Brown/)).toHaveLength(2);
 });

--- a/src/pages/__tests__/modalA11y.test.js
+++ b/src/pages/__tests__/modalA11y.test.js
@@ -99,6 +99,36 @@ describe('true modals — dialog semantics', () => {
     expect(dialog).toContainElement(document.activeElement);
   });
 
+  // Containment alone is far too weak, and it cost me a real regression: the hook focused the
+  // FIRST focusable, which in two of these dialogs is the Close button sitting above the
+  // input. Focus stayed "inside the dialog", the test passed, and every rep lost the caret out
+  // of the field they were about to type in — one Enter away from dismissing the modal.
+  // These assert the SPECIFIC element, so moving focus anywhere else fails.
+  test('ComposeModal leaves the caret in the recipient field, not on Close', async () => {
+    renderWithOpener((onClose) => (
+      <ComposeModal sending={false} onSubmit={jest.fn()} onClose={onClose} />
+    ));
+    await userEvent.click(opener());
+    expect(screen.getByLabelText(/^to$/i)).toHaveFocus();
+  });
+
+  test('ProductLookupModal leaves the caret in the search box, not on Close', async () => {
+    renderWithOpener((onClose) => (
+      <ProductLookupModal products={[]} loaded search="" setSearch={jest.fn()} onClose={onClose} />
+    ));
+    await userEvent.click(opener());
+    expect(screen.getByLabelText(/search products/i)).toHaveFocus();
+  });
+
+  // WorkorderModal has no autoFocus of its own, so here the hook SHOULD place focus.
+  test('WorkorderModal, which has no autoFocus, gets focus placed by the hook', async () => {
+    renderWithOpener((onClose) => (
+      <WorkorderModal workorderId="WO123" detail={null} loading={false} onClose={onClose} />
+    ));
+    await userEvent.click(opener());
+    expect(screen.getByRole('button', { name: /close/i })).toHaveFocus();
+  });
+
   // The actual reported bug: Tab must not walk out into the inbox behind the modal.
   test.each(cases)('$name keeps Tab inside the dialog', async ({ render: r }) => {
     renderWithOpener(r);
@@ -194,11 +224,39 @@ describe('assign picker — a popover, NOT a modal', () => {
 
   test('the trigger advertises the popover it controls', async () => {
     renderPicker();
-    expect(trigger()).toHaveAttribute('aria-haspopup');
     expect(trigger()).toHaveAttribute('aria-expanded', 'false');
 
     await userEvent.click(trigger());
     expect(trigger()).toHaveAttribute('aria-expanded', 'true');
+    // aria-controls must point at the popup that actually exists.
+    const controls = trigger().getAttribute('aria-controls');
+    expect(controls).toBeTruthy();
+    expect(document.getElementById(controls)).toBeInTheDocument();
+  });
+
+  // aria-haspopup="true" is defined as EXACTLY equivalent to "menu": a screen reader announces
+  // "menu button" and the user presses Down Arrow expecting menu navigation. There is no
+  // role="menu" here and no arrow-key handling, so the promise would be false. Asserting its
+  // ABSENCE, because the first draft asserted only that the attribute existed — which passes
+  // for any value, including a wrong one.
+  test('the trigger does not claim to open a menu it has not built', async () => {
+    renderPicker();
+    expect(trigger()).not.toHaveAttribute('aria-haspopup');
+  });
+
+  test('each rep toggle exposes its assigned state, and the tick is not announced', async () => {
+    renderPicker({ assignees: [{ podiumUserId: 'p1', portalId: 'AA', name: 'Alex Rep' }] });
+    await userEvent.click(trigger());
+
+    const alex = screen.getByRole('button', { name: /alex rep/i });
+    const bo = screen.getByRole('button', { name: /bo rep/i });
+    expect(alex).toHaveAttribute('aria-pressed', 'true');
+    expect(bo).toHaveAttribute('aria-pressed', 'false');
+
+    // The decorative ✓ renders for both (transparent when unchecked) and must not reach the
+    // accessibility tree, or every rep sounds assigned.
+    expect(alex).toHaveAccessibleName('Alex Rep');
+    expect(bo).toHaveAccessibleName('Bo Rep');
   });
 
   test('Escape closes it and puts focus back on the trigger', async () => {

--- a/src/pages/__tests__/modalA11y.test.js
+++ b/src/pages/__tests__/modalA11y.test.js
@@ -1,0 +1,223 @@
+// F26 — dialog semantics and focus management for the inbox overlays.
+//
+// THE BUG: none of the inbox modals set role="dialog"/aria-modal, none trapped focus, and
+// none returned focus to the control that opened them. A keyboard or screen-reader user can
+// Tab straight out of an open modal into the inbox behind it — reading and operating
+// controls that are visually covered, with no way to tell where they are.
+//
+// A DELIBERATE SPLIT, worth reading before changing anything here:
+//
+//   WorkorderModal, ProductLookupModal and ComposeModal are TRUE MODALS — full-screen
+//   backdrop, nothing behind them is meant to be reachable. They get role="dialog",
+//   aria-modal="true", a labelling heading, a focus trap, and focus restore.
+//
+//   The assign picker (AssigneeBar) is NOT a modal. It is a small popover anchored to its
+//   button, with no backdrop, and the page behind it stays live by design. Giving it
+//   aria-modal or a focus trap would be WRONG — it would lie to a screen reader about the
+//   rest of the page being inert, and trap a keyboard user in a dropdown. It gets popover
+//   semantics instead: aria-haspopup/aria-expanded, Escape to close, and focus restore.
+//
+// The backlog row asked for "all four modals" in one pass. Three are modals; the fourth is a
+// popover, and is treated as one.
+
+import React, { useState } from 'react';
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { ComposeModal, WorkorderModal, ProductLookupModal, AssigneeBar } from '../inbox';
+
+// Renders a modal behind a real opener button, so focus restore can be asserted against the
+// element that actually had focus — not a synthetic stand-in.
+function renderWithOpener(renderModal) {
+  function Harness() {
+    const [open, setOpen] = useState(false);
+    return (
+      <>
+        <button type="button" onClick={() => setOpen(true)}>Open it</button>
+        <button type="button">Somewhere else</button>
+        {open ? renderModal(() => setOpen(false)) : null}
+      </>
+    );
+  }
+  return render(<Harness />);
+}
+
+const opener = () => screen.getByRole('button', { name: /open it/i });
+
+describe('true modals — dialog semantics', () => {
+  const cases = [
+    {
+      name: 'ComposeModal',
+      heading: /new conversation/i,
+      render: (onClose) => <ComposeModal sending={false} onSubmit={jest.fn()} onClose={onClose} />,
+    },
+    {
+      name: 'WorkorderModal',
+      heading: /workorder/i,
+      render: (onClose) => (
+        <WorkorderModal workorderId="WO123" detail={null} loading={false} onClose={onClose} />
+      ),
+    },
+    {
+      name: 'ProductLookupModal',
+      heading: /product price/i,
+      render: (onClose) => (
+        <ProductLookupModal
+          products={[]}
+          loaded
+          search=""
+          setSearch={jest.fn()}
+          onClose={onClose}
+        />
+      ),
+    },
+  ];
+
+  test.each(cases)('$name exposes role="dialog" and aria-modal', async ({ render: r }) => {
+    renderWithOpener(r);
+    await userEvent.click(opener());
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+  });
+
+  // Without a name, a screen reader announces "dialog" and nothing else — the user has no
+  // idea which one opened.
+  test.each(cases)('$name is named by its own heading', async ({ render: r, heading }) => {
+    renderWithOpener(r);
+    await userEvent.click(opener());
+
+    const dialog = screen.getByRole('dialog');
+    expect(within(dialog).getByRole('heading')).toHaveTextContent(heading);
+    expect(dialog).toHaveAccessibleName(heading);
+  });
+
+  test.each(cases)('$name moves focus inside itself when it opens', async ({ render: r }) => {
+    renderWithOpener(r);
+    await userEvent.click(opener());
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toContainElement(document.activeElement);
+  });
+
+  // The actual reported bug: Tab must not walk out into the inbox behind the modal.
+  test.each(cases)('$name keeps Tab inside the dialog', async ({ render: r }) => {
+    renderWithOpener(r);
+    await userEvent.click(opener());
+    const dialog = screen.getByRole('dialog');
+
+    // Enough tabs to leave any of these dialogs several times over if the trap is absent.
+    for (let i = 0; i < 12; i += 1) {
+      await userEvent.tab();
+      expect(dialog).toContainElement(document.activeElement);
+    }
+  });
+
+  test.each(cases)('$name keeps Shift+Tab inside the dialog', async ({ render: r }) => {
+    renderWithOpener(r);
+    await userEvent.click(opener());
+    const dialog = screen.getByRole('dialog');
+
+    for (let i = 0; i < 12; i += 1) {
+      await userEvent.tab({ shift: true });
+      expect(dialog).toContainElement(document.activeElement);
+    }
+  });
+
+  // Closing without restoring focus dumps a keyboard user back at the top of the document,
+  // losing their place in a long conversation list.
+  test.each(cases)('$name returns focus to the opener when it closes', async ({ render: r }) => {
+    renderWithOpener(r);
+    await userEvent.click(opener());
+    await userEvent.keyboard('{Escape}');
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(opener()).toHaveFocus();
+  });
+});
+
+describe('true modals — Escape', () => {
+  // ComposeModal already guarded Escape (never mid-send, or the draft is lost). These two are
+  // read-only lookups with nothing to lose, and had NO Escape handling at all.
+  test('WorkorderModal closes on Escape', async () => {
+    const onClose = jest.fn();
+    render(<WorkorderModal workorderId="WO123" detail={null} loading={false} onClose={onClose} />);
+    await userEvent.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('ProductLookupModal closes on Escape', async () => {
+    const onClose = jest.fn();
+    render(
+      <ProductLookupModal products={[]} loaded search="" setSearch={jest.fn()} onClose={onClose} />,
+    );
+    await userEvent.keyboard('{Escape}');
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  // Regression guard on the behaviour F20's review specifically asked for: a stalled send must
+  // not let Escape discard the draft.
+  test('ComposeModal still refuses Escape mid-send', async () => {
+    const onClose = jest.fn();
+    render(<ComposeModal sending onSubmit={jest.fn()} onClose={onClose} />);
+    await userEvent.keyboard('{Escape}');
+    expect(onClose).not.toHaveBeenCalled();
+  });
+});
+
+describe('assign picker — a popover, NOT a modal', () => {
+  const reps = [
+    { id: 'AA', name: 'Alex Rep', linked: true },
+    { id: 'BB', name: 'Bo Rep', linked: true },
+  ];
+
+  function renderPicker(props = {}) {
+    const onToggle = jest.fn();
+    function Harness() {
+      const [show, setShow] = useState(false);
+      return (
+        <AssigneeBar
+          assignees={[]}
+          reps={reps}
+          myPodiumUid={null}
+          show={show}
+          setShow={setShow}
+          onToggle={onToggle}
+          saving={false}
+          {...props}
+        />
+      );
+    }
+    return { onToggle, ...render(<Harness />) };
+  }
+
+  const trigger = () => screen.getByRole('button', { name: /assign/i });
+
+  test('the trigger advertises the popover it controls', async () => {
+    renderPicker();
+    expect(trigger()).toHaveAttribute('aria-haspopup');
+    expect(trigger()).toHaveAttribute('aria-expanded', 'false');
+
+    await userEvent.click(trigger());
+    expect(trigger()).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  test('Escape closes it and puts focus back on the trigger', async () => {
+    renderPicker();
+    await userEvent.click(trigger());
+    expect(screen.getByText('Alex Rep')).toBeInTheDocument();
+
+    await userEvent.keyboard('{Escape}');
+    expect(screen.queryByText('Alex Rep')).not.toBeInTheDocument();
+    expect(trigger()).toHaveFocus();
+  });
+
+  // The point of the split. If someone "fixes" this by reaching for the modal helper, this
+  // fails — which is the intent.
+  test('it is NOT announced as a modal dialog', async () => {
+    renderPicker();
+    await userEvent.click(trigger());
+
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(document.querySelector('[aria-modal="true"]')).toBeNull();
+  });
+});

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -42,8 +42,9 @@
 // request/response — nothing is written to the database. The panel reads/writes only
 // CRM metadata (customer / workorder / delivery / lead), never message text.
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import useDialog from '../hooks/useDialog';
 import toast from 'react-hot-toast';
 import BackButton from '../components/backbutton';
 import HomeButton from '../components/homebutton';
@@ -1562,8 +1563,25 @@ function CustomerPanel({
 // rep as "You", and lets a salesperson add/remove reps (the picker manages portal reps;
 // reps who haven't linked their Podium account are shown disabled). A conversation can be
 // assigned to one OR MORE reps — Podium's assignees endpoint is plural.
-function AssigneeBar({ assignees, reps, myPodiumUid, show, setShow, onToggle, saving }) {
+export function AssigneeBar({ assignees, reps, myPodiumUid, show, setShow, onToggle, saving }) {
   const assignedPortalIds = new Set(assignees.map((a) => a.portalId).filter(Boolean));
+  const triggerRef = useRef(null);
+  const menuId = useId();
+
+  // F26 — popover semantics, NOT modal ones. This dropdown has no backdrop and the page
+  // behind it stays live by design, so aria-modal would lie to a screen reader and a focus
+  // trap would strand a keyboard user in a dropdown. What it DOES need is a way out that
+  // isn't the mouse: Escape closes it and hands focus back to the trigger.
+  useEffect(() => {
+    if (!show) return undefined;
+    const onKey = (e) => {
+      if (e.key !== 'Escape') return;
+      setShow(false);
+      triggerRef.current?.focus();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [show, setShow]);
   return (
     <div className="mt-1 flex items-center gap-1.5 flex-wrap">
       <span className="text-[11px] text-gray-400">Assigned:</span>
@@ -1582,6 +1600,10 @@ function AssigneeBar({ assignees, reps, myPodiumUid, show, setShow, onToggle, sa
       <div className="relative">
         <button
           type="button"
+          ref={triggerRef}
+          aria-haspopup="true"
+          aria-expanded={show}
+          aria-controls={show ? menuId : undefined}
           onClick={() => setShow(!show)}
           disabled={saving || reps.length === 0}
           className="text-[11px] px-2 py-0.5 rounded-full border border-gray-300 text-gray-600 hover:bg-gray-50 disabled:opacity-40"
@@ -1590,7 +1612,7 @@ function AssigneeBar({ assignees, reps, myPodiumUid, show, setShow, onToggle, sa
           {saving ? 'Saving…' : 'Assign ▾'}
         </button>
         {show && reps.length > 0 && (
-          <div className="absolute top-full mt-1 left-0 z-20 w-60 max-h-64 overflow-y-auto bg-white border border-gray-200 rounded-lg shadow-lg py-1">
+          <div id={menuId} className="absolute top-full mt-1 left-0 z-20 w-60 max-h-64 overflow-y-auto bg-white border border-gray-200 rounded-lg shadow-lg py-1">
             {reps.map((r) => {
               const checked = assignedPortalIds.has(r.id);
               return (
@@ -1682,7 +1704,18 @@ function FunnelTimeline({ history }) {
 // a read-only, scrollable log of every workorder_logs entry (oldest → newest). Fed by
 // GET /api/workorder?id= (which omits selling_price for a non-superadmin actor), so a
 // sales rep sees item name/qty/condition/status + workorder-level payment only.
-function WorkorderModal({ workorderId, detail, loading, onClose }) {
+export function WorkorderModal({ workorderId, detail, loading, onClose }) {
+  const dialog = useDialog();
+  const titleId = useId();
+
+  // F26 — this read-only panel had no Escape at all. Unlike ComposeModal there is no draft to
+  // lose here, so Escape always closes.
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
   const items = Array.isArray(detail?.items) ? detail.items : [];
   // The endpoint returns activity newest-first; the log field reads oldest-first.
   const activity = Array.isArray(detail?.activity) ? detail.activity.slice().reverse() : [];
@@ -1703,12 +1736,17 @@ function WorkorderModal({ workorderId, detail, loading, onClose }) {
   return (
     <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4" onClick={onClose}>
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        ref={dialog.ref}
+        onKeyDown={dialog.onKeyDown}
         className="bg-white rounded-lg shadow-lg w-full max-w-2xl max-h-[90vh] flex flex-col"
         onClick={(e) => e.stopPropagation()}
       >
         <header className="flex items-center justify-between px-5 py-3 border-b border-gray-200">
           <div className="flex items-center gap-2">
-            <h2 className="text-lg font-bold">Workorder #{workorderId}</h2>
+            <h2 id={titleId} className="text-lg font-bold">Workorder #{workorderId}</h2>
             {detail?.status && (
               <span className="text-xs font-semibold px-2 py-0.5 rounded-full bg-gray-100 text-gray-700">{detail.status}</span>
             )}
@@ -1796,6 +1834,8 @@ function WorkorderModal({ workorderId, detail, loading, onClose }) {
 export function ComposeModal({ sending, onSubmit, onClose }) {
   const [to, setTo] = useState('');
   const [body, setBody] = useState('');
+  const dialog = useDialog();
+  const titleId = useId();
 
   const target = classifyComposeTarget(to);
   const touched = to.trim().length > 0;
@@ -1834,12 +1874,17 @@ export function ComposeModal({ sending, onSubmit, onClose }) {
       onClick={closeOnBackdrop}
     >
       <form
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        ref={dialog.ref}
+        onKeyDown={dialog.onKeyDown}
         className="bg-white rounded-lg shadow-lg w-full max-w-md flex flex-col"
         onClick={(e) => e.stopPropagation()}
         onSubmit={submit}
       >
         <header className="flex items-center justify-between px-5 py-3 border-b border-gray-200">
-          <h2 className="text-lg font-bold">New conversation</h2>
+          <h2 id={titleId} className="text-lg font-bold">New conversation</h2>
           <button
             type="button"
             onClick={onClose}
@@ -1929,7 +1974,17 @@ export function ComposeModal({ sending, onSubmit, onClose }) {
 // this modal only filters it in the browser. Retail price + stock only — no cost.
 const PRODUCT_RESULT_CAP = 60; // render at most this many matches (the table has ~1,000 rows)
 
-function ProductLookupModal({ products, loaded, search, setSearch, onClose }) {
+export function ProductLookupModal({ products, loaded, search, setSearch, onClose }) {
+  const dialog = useDialog();
+  const titleId = useId();
+
+  // F26 — as with WorkorderModal: a read-only lookup with nothing to lose, so Escape closes.
+  useEffect(() => {
+    const onKey = (e) => { if (e.key === 'Escape') onClose(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
   // Token-based, order-independent match — mirrors the product page's search
   // (src/pages/products/index.js): split on spaces, every keyword must appear
   // somewhere in "sku name brand" so "Life Treadmill SE3 HD" matches
@@ -1947,11 +2002,16 @@ function ProductLookupModal({ products, loaded, search, setSearch, onClose }) {
   return (
     <div className="fixed inset-0 z-50 bg-black/40 flex items-center justify-center p-4" onClick={onClose}>
       <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        ref={dialog.ref}
+        onKeyDown={dialog.onKeyDown}
         className="bg-white rounded-lg shadow-lg w-full max-w-xl max-h-[85vh] flex flex-col"
         onClick={(e) => e.stopPropagation()}
       >
         <header className="flex items-center justify-between px-5 py-3 border-b border-gray-200">
-          <h2 className="text-lg font-bold">Product price &amp; stock</h2>
+          <h2 id={titleId} className="text-lg font-bold">Product price &amp; stock</h2>
           <button type="button" onClick={onClose} className="text-gray-400 hover:text-gray-700 text-xl leading-none" aria-label="Close">×</button>
         </header>
 

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -148,6 +148,11 @@ export default function Inbox() {
   const [searchTruncated, setSearchTruncated] = useState(false);
 
   const [selectedId, setSelectedId] = useState(null);
+  // F27 — mirrors `selectedId` for synchronous reads. The composer-reset guard in
+  // openConversation must compare against the CURRENT selection, not the one captured when
+  // this render ran; see the comment there. Kept in sync by the effect below rather than at
+  // each call site, so a future setSelectedId cannot forget to update it.
+  const selectedIdRef = useRef(null);
   const [selectedConv, setSelectedConv] = useState(null);
   const [messages, setMessages] = useState([]);
   const [loadingThread, setLoadingThread] = useState(false);
@@ -382,6 +387,8 @@ export default function Inbox() {
     }
   }, [navigate, loadThread, loadPanel, loadAssignees, resetComposerState]);
 
+  useEffect(() => { selectedIdRef.current = selectedId; }, [selectedId]);
+
   // Fetch the timeline whenever the panel resolves a lead.
   useEffect(() => {
     loadLeadHistory(panel?.lead?.lead_id || null);
@@ -589,7 +596,12 @@ export default function Inbox() {
     // Guarded on the id CHANGING on purpose: re-clicking the thread you are already in, or a
     // list re-render, must not discard work in progress. Wiping a draft with no undo is the
     // same class of harm, just pointed the other way.
-    if (c.uid !== selectedId) resetComposerState();
+    // Read through a REF, not the render-closure state. `openConversationById` sets
+    // `selectedId` inside an async continuation, so a click landing before that commit would
+    // read a stale value, judge it a switch, and reset a composer the rep is still using —
+    // costing them a draft, which is precisely what the guard exists to prevent. Same hazard
+    // and same remedy as `composeSendingRef` above.
+    if (c.uid !== selectedIdRef.current) resetComposerState();
     setSelectedId(c.uid);
     setSelectedConv(c);
     loadThread(c.uid);

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -579,6 +579,17 @@ export default function Inbox() {
   };
 
   const openConversation = (c) => {
+    // F27 — clear the composer when the rep moves to a DIFFERENT thread. Without this a
+    // half-typed reply to customer A followed them into customer B's thread, one Send away
+    // from the wrong customer receiving it; and an active internal-note mode followed too, so
+    // the next Send posted a team-only note instead of a reply (or the reverse). Both are
+    // silent. openConversationById (compose / deep-link) already did this since F20 incr 2 —
+    // this is the same fix on the older list-click path.
+    //
+    // Guarded on the id CHANGING on purpose: re-clicking the thread you are already in, or a
+    // list re-render, must not discard work in progress. Wiping a draft with no undo is the
+    // same class of harm, just pointed the other way.
+    if (c.uid !== selectedId) resetComposerState();
     setSelectedId(c.uid);
     setSelectedConv(c);
     loadThread(c.uid);

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -1598,10 +1598,16 @@ export function AssigneeBar({ assignees, reps, myPodiumUid, show, setShow, onTog
         );
       })}
       <div className="relative">
+        {/* Deliberately NO aria-haspopup. Per ARIA 1.2 `aria-haspopup="true"` is EXACTLY
+            equivalent to "menu": screen readers announce "menu button" and the user presses
+            Down Arrow expecting menu navigation. This popup is a plain list of toggle buttons
+            — no role="menu", no menuitem children, no roving tabindex — so nothing would
+            happen. "listbox"/"dialog" would be equally untrue. What this IS, is the APG
+            Disclosure pattern: a button with aria-expanded + aria-controls revealing content.
+            Claiming a menu we have not built is worse than claiming nothing. */}
         <button
           type="button"
           ref={triggerRef}
-          aria-haspopup="true"
           aria-expanded={show}
           aria-controls={show ? menuId : undefined}
           onClick={() => setShow(!show)}
@@ -1619,12 +1625,18 @@ export function AssigneeBar({ assignees, reps, myPodiumUid, show, setShow, onTog
                 <button
                   key={r.id}
                   type="button"
+                  aria-pressed={checked}
                   onClick={() => onToggle(r)}
                   disabled={saving || !r.linked}
                   className="w-full flex items-center gap-2 text-left px-3 py-1.5 hover:bg-gray-50 disabled:opacity-50"
                   title={r.linked ? '' : 'This rep has not linked their Podium account'}
                 >
-                  <span className={`w-4 h-4 shrink-0 rounded border flex items-center justify-center text-[10px] ${checked ? 'bg-blue-500 border-blue-500 text-white' : 'border-gray-300 text-transparent'}`}>✓</span>
+                  {/* aria-hidden: the tick is decorative and CSS-only. Unchecked it renders
+                      `text-transparent`, and transparent text is STILL in the accessibility
+                      tree (only display:none / visibility:hidden / aria-hidden remove it), so
+                      a screen reader announced a "✓" beside EVERY rep — assigned or not. The
+                      real state is carried by aria-pressed on the button. */}
+                  <span aria-hidden="true" className={`w-4 h-4 shrink-0 rounded border flex items-center justify-center text-[10px] ${checked ? 'bg-blue-500 border-blue-500 text-white' : 'border-gray-300 text-transparent'}`}>✓</span>
                   <span className="min-w-0 flex-1">
                     <span className="block text-xs text-gray-800 truncate">{r.name}</span>
                     {!r.linked && <span className="block text-[10px] text-gray-400">Not linked to Podium</span>}
@@ -1739,8 +1751,8 @@ export function WorkorderModal({ workorderId, detail, loading, onClose }) {
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
+        tabIndex={-1}
         ref={dialog.ref}
-        onKeyDown={dialog.onKeyDown}
         className="bg-white rounded-lg shadow-lg w-full max-w-2xl max-h-[90vh] flex flex-col"
         onClick={(e) => e.stopPropagation()}
       >
@@ -1877,8 +1889,8 @@ export function ComposeModal({ sending, onSubmit, onClose }) {
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
+        tabIndex={-1}
         ref={dialog.ref}
-        onKeyDown={dialog.onKeyDown}
         className="bg-white rounded-lg shadow-lg w-full max-w-md flex flex-col"
         onClick={(e) => e.stopPropagation()}
         onSubmit={submit}
@@ -2005,8 +2017,8 @@ export function ProductLookupModal({ products, loaded, search, setSearch, onClos
         role="dialog"
         aria-modal="true"
         aria-labelledby={titleId}
+        tabIndex={-1}
         ref={dialog.ref}
-        onKeyDown={dialog.onKeyDown}
         className="bg-white rounded-lg shadow-lg w-full max-w-xl max-h-[85vh] flex flex-col"
         onClick={(e) => e.stopPropagation()}
       >


### PR DESCRIPTION
## What happened — F26 and F27 merged, but not into `main`

This is a **recovery PR**. It contains no new work: it restores code you already reviewed and merged.

The three PRs were stacked, and each one's base was the branch below it. When you merged them, GitHub merged each into **its own base branch** rather than into `main`:

| PR | Merged into | Result |
|---|---|---|
| [#84](https://github.com/GraysSupport/grays-internal/pull/84) F25 | `main` ✅ | Landed correctly, deployed to Production |
| [#85](https://github.com/GraysSupport/grays-internal/pull/85) F26 | `feat/podium-f25-component-tests` ❌ | Landed on a branch that had *already* merged to main 3 minutes earlier |
| [#86](https://github.com/GraysSupport/grays-internal/pull/86) F27 | `feat/podium-f26-modal-a11y` ❌ | Same |

All three PRs correctly show "Merged", which is why nothing looked wrong. But `main` only ever received F25, and both intermediate branches were auto-deleted afterwards — so F26 and F27 ended up in unreferenced merge commits.

**Nothing was lost.** GitHub retains merge commits from a merged PR, so `ce71094` (the #86 merge) still holds the whole stack. This branch is that commit, with current `main` merged in.

**This is my fault, not yours.** I stacked three PRs on one file and told you the merge order, but GitHub only auto-retargets a stacked PR when its base is merged *and* the retarget happens before you merge the child. Merging quickly down the chain beat the retarget. I should have either opened all three against `main`, or told you to wait for each base to retarget before merging the next.

## What this restores

```
 src/hooks/useDialog.js                         | 132 ++++++++++++
 src/pages/__tests__/modalA11y.test.js          | 281 +++++++++++++++++++++++++
 src/pages/__tests__/inboxComposerReset.test.js | 218 +++++++++++++++++++
 src/pages/inbox.js                             | 113 +++++++++-
 4 files changed, 735 insertions(+), 9 deletions(-)
```

Exactly F26 + F27 — **the diff between `main` and the stack tip, nothing else**. Same commits you already reviewed:

- `14b61b6` F26 — dialog semantics and focus management
- `b4fb4e5` F26 review fixes
- `87ce7e3` F27 — composer reset on conversation switch
- `7e75741` F27 review fixes

## Why it matters that this lands

**F27 fixes a live customer-facing mis-send** — a draft, internal-note mode, or attachment meant for customer A follows the rep into customer B's thread. That bug is on Production **right now**, because F27 never reached `main`.

F26 (modal focus management / screen-reader semantics) is likewise not live.

## Verification on the merged result

Not assumed from the earlier PRs — re-run on this exact branch after merging current `main`:

- `main` merged in cleanly, **no conflicts**
- `npm run test:ci` → **48/48 passed**, 3 suites
- `npm run smoke` → **19/19 suites**
- `CI=true npm run build` → **Compiled successfully**

## Reviewer checklist

- [ ] Diff is exactly the 4 files above — no F25 content (already on `main`), no surprises
- [ ] CI green on this PR
- [ ] Merge this **directly to `main`** — there is no stack this time, nothing to sequence
- [ ] After merge, confirm Production redeploys and spot-check `/inbox`: type a reply, switch conversation, composer must be **empty**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
