### PR TITLE
F19 (incr 2a) - the portal is navigable on a phone: mobile nav drawer

### DIFF
--- a/scripts/podium-nav-smoke.mjs
+++ b/scripts/podium-nav-smoke.mjs
@@ -1,0 +1,113 @@
+// scripts/podium-nav-smoke.mjs — offline smoke for F19 increment 2a (portal navigation).
+//
+// F19 incr 2 is the mobile-usable pass over the portal. The first thing it has to fix is the
+// worst one: the dashboard sidebar is `hidden md:block`, and it is the ONLY navigation in the
+// portal — so on a phone there are NO links at all. Increment 1 made the portal installable,
+// which makes this sharper, not softer: an installed PWA runs standalone with no browser URL
+// bar, so a rep who lands on the dashboard has no links AND no address bar to type one.
+//
+// The fix renders the same nav twice (desktop sidebar + mobile drawer), so the item list has
+// to come from ONE place or the two will drift and a role will end up gated in one and not the
+// other. That one place is src/utils/nav.js, and this smoke is its contract: WHICH ITEMS EACH
+// ROLE SEES. It is JSX-free and importable in node, the same arrangement as
+// src/utils/compose.js and src/utils/lotLabels.js.
+//
+// The server is always the real authority (lib/rbac.js). These rules only decide what to SHOW,
+// so a bug here is a usability bug, not a security hole — except in the other direction: a
+// link that disappears for a role that should have it makes a whole feature unreachable on a
+// phone, which is exactly what this increment exists to prevent.
+//
+//   node scripts/podium-nav-smoke.mjs
+
+import { buildNavItems, NAV_KEYS } from '../src/utils/nav.js';
+
+let passed = 0;
+function check(name, cond, detail) {
+  if (!cond) throw new Error(`FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  passed += 1;
+  console.log(`  ✓ ${name}`);
+}
+
+const keysFor = (user, roles) => buildNavItems({ user, roles }).map((i) => i.key);
+const superadmin = { id: 'NK', name: 'Nick', access: 'superadmin' };
+const staff = { id: 'ST', name: 'Staff', access: 'staff' };
+const technician = { id: 'TE', name: 'Tech', access: 'technician' };
+const workshop = { id: 'WK', name: 'Workshop', access: 'workshop' };
+
+console.log('F19 nav smoke — pure, no DOM, no network\n');
+
+console.log('always-present items:');
+{
+  for (const user of [superadmin, staff, technician, workshop]) {
+    const keys = keysFor(user, [user.access]);
+    check(`${user.access} sees Dashboard`, keys.includes('dashboard'));
+    check(`${user.access} sees Account Settings`, keys.includes('settings'));
+    check(`${user.access} sees Delivery Operations`, keys.includes('delivery'));
+    check(`${user.access} sees Logout last`, keys[keys.length - 1] === 'logout');
+  }
+}
+
+console.log('\nrole-gated items (mirrors the server gates on /api/podium/inbox, /api/leads, /api/logistics, /api/integrations):');
+{
+  const salesKeys = keysFor({ id: 'AM', name: 'Amelia', access: 'staff' }, ['staff', 'sales']);
+  check('a sales user sees Inbox', salesKeys.includes('inbox'));
+  check('a sales user sees Lead Funnel', salesKeys.includes('leads'));
+  check('a sales user does NOT see Awaiting Workorder', !salesKeys.includes('logistics'));
+  check('a sales user does NOT see Integrations', !salesKeys.includes('integrations'));
+
+  const logisticsKeys = keysFor({ id: 'LO', name: 'Logi', access: 'staff' }, ['staff', 'logistics']);
+  check('a logistics user sees Awaiting Workorder', logisticsKeys.includes('logistics'));
+  check('a logistics user does NOT see Inbox', !logisticsKeys.includes('inbox'));
+
+  const plainKeys = keysFor(staff, ['staff']);
+  check('a plain staff user sees neither Inbox nor Lead Funnel', !plainKeys.includes('inbox') && !plainKeys.includes('leads'));
+
+  const adminKeys = keysFor(superadmin, ['superadmin']);
+  for (const k of ['inbox', 'leads', 'logistics', 'integrations', 'peloton', 'register']) {
+    check(`superadmin sees ${k}`, adminKeys.includes(k));
+  }
+  check('a staff user does NOT see Register New User', !plainKeys.includes('register'));
+  check('a staff user does NOT see Peloton', !plainKeys.includes('peloton'));
+}
+
+console.log('\ntechnician restrictions (unchanged from the pre-F19 sidebar):');
+{
+  const keys = keysFor(technician, ['technician']);
+  for (const k of ['products', 'customers', 'waitlist']) {
+    check(`technician does NOT see ${k}`, !keys.includes(k));
+  }
+  check('technician still sees Delivery Operations', keys.includes('delivery'));
+  const staffKeys = keysFor(staff, ['staff']);
+  for (const k of ['products', 'customers', 'waitlist']) {
+    check(`staff DOES see ${k}`, staffKeys.includes(k));
+  }
+}
+
+console.log('\nthe WK workshop account routes Delivery Operations to /workshop:');
+{
+  const wkItem = buildNavItems({ user: workshop, roles: ['workshop'] }).find((i) => i.key === 'delivery');
+  check('WK goes to /workshop', wkItem.to === '/workshop');
+  const staffItem = buildNavItems({ user: staff, roles: ['staff'] }).find((i) => i.key === 'delivery');
+  check('everyone else goes to /delivery_operations', staffItem.to === '/delivery_operations');
+}
+
+console.log('\nshape + robustness (it renders during the pre-auth loading window and on a stale session):');
+{
+  // Guard against the crash-instead-of-empty failure: dashboard.js renders before `user` is
+  // set, and a session written before F0b has no `roles` at all.
+  const none = buildNavItems({ user: null, roles: null });
+  check('a null user yields items without throwing', Array.isArray(none) && none.length > 0);
+  check('a null user sees no role-gated items', !none.some((i) => ['inbox', 'leads', 'logistics', 'integrations', 'register', 'peloton'].includes(i.key)));
+
+  const legacy = buildNavItems({ user: { id: 'OL', access: 'superadmin' }, roles: [] });
+  check('an empty roles[] still resolves superadmin-only items from user.access', legacy.some((i) => i.key === 'register'));
+
+  const all = buildNavItems({ user: superadmin, roles: ['superadmin'] });
+  check('every item has key + label', all.every((i) => i.key && i.label));
+  check('every item except logout has a `to`', all.every((i) => i.key === 'logout' || typeof i.to === 'string'));
+  check('logout is an action, not a link', all.find((i) => i.key === 'logout').to === undefined);
+  check('keys are unique', new Set(all.map((i) => i.key)).size === all.length);
+  check('NAV_KEYS lists every key the builder can emit', all.every((i) => NAV_KEYS.includes(i.key)));
+}
+
+console.log(`\n✅ nav smoke: ${passed} checks passed`);

--- a/src/components/PortalNav.js
+++ b/src/components/PortalNav.js
@@ -1,0 +1,158 @@
+// src/components/PortalNav.js — F19 increment 2a: the portal nav, rendered twice.
+//
+// The desktop sidebar and the mobile drawer show the SAME items (src/utils/nav.js decides
+// which), so the markup for a nav item lives here once. Below md the sidebar is hidden and the
+// drawer is the only navigation there is — in an installed PWA there is no URL bar to fall
+// back on, so "no nav" means "stuck".
+
+import React, { useEffect } from 'react';
+import { Link } from 'react-router-dom';
+import useDialog from '../hooks/useDialog';
+
+const ITEM_CLASS = 'text-gray-700 hover:bg-gray-200 p-2 rounded';
+
+/**
+ * The list of nav links for a set of items from buildNavItems().
+ * `onNavigate` fires when a link is followed — the drawer uses it to close itself.
+ */
+export function NavList({ items = [], onLogout, onNavigate, testId, className = '' }) {
+  return (
+    <nav data-testid={testId} className={`flex flex-col space-y-2 ${className}`}>
+      {items.map((item) => {
+        if (item.key === 'logout') {
+          return (
+            <button key={item.key} type="button" onClick={onLogout} className={`${ITEM_CLASS} text-left`}>
+              {item.label}
+            </button>
+          );
+        }
+        return (
+          <Link
+            key={item.key}
+            to={item.to}
+            onClick={onNavigate}
+            className={[
+              ITEM_CLASS,
+              item.emphasis ? 'font-semibold' : '',
+              item.dot ? 'flex items-center gap-2' : '',
+            ].filter(Boolean).join(' ')}
+          >
+            {item.dot ? <span className="inline-block w-2 h-2 rounded-full bg-black flex-shrink-0" /> : null}
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+/**
+ * The mobile drawer. A TRUE modal by F26's split: it has a full backdrop and nothing behind it
+ * is meant to be reachable while it is open, so it gets role="dialog", aria-modal, the focus
+ * trap from useDialog, and focus restore to the menu button.
+ *
+ * Escape is owned here rather than by the hook (F26 convention) — a menu should always close
+ * on Escape, unlike ComposeModal which refuses while a send is in flight.
+ */
+export function MobileNavDrawer({ items, onLogout, onClose }) {
+  const { ref } = useDialog();
+
+  // Escape on the WINDOW, not on the dialog element — matching WorkorderModal, ComposeModal,
+  // ProductLookupModal and CreateCustomerModal. The difference is not stylistic: in a real
+  // browser a tap on a non-focusable part of the drawer (the "Grays Admin" heading, the p-4
+  // padding — both large targets here) blurs to <body>, and a keydown at <body> never reaches
+  // an element-bound handler, so Escape would silently stop working. jsdom does not reproduce
+  // blur-to-body, so no test here can catch that; the precedent is the evidence.
+  useEffect(() => {
+    const onKey = (e) => {
+      if (e.key === 'Escape') onClose();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [onClose]);
+
+  // Close if the viewport grows past the md breakpoint while the drawer is open — a phone
+  // rotated to landscape, or a window widened. The drawer is `md:hidden`, so above md it would
+  // otherwise stay MOUNTED but invisible, with useDialog's document-level Tab trap still live
+  // and cycling focus through display:none links: keyboard navigation dead for the whole page,
+  // with no visible control to escape it (the hamburger and backdrop are md:hidden too).
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') return undefined;
+    const mq = window.matchMedia('(min-width: 768px)');
+    if (mq.matches) onClose();
+    const onChange = (e) => { if (e.matches) onClose(); };
+    // addListener is the deprecated form; Safari only gained addEventListener on MediaQueryList
+    // in 14, and this is the iOS-facing feature.
+    if (mq.addEventListener) mq.addEventListener('change', onChange);
+    else if (mq.addListener) mq.addListener(onChange);
+    return () => {
+      if (mq.removeEventListener) mq.removeEventListener('change', onChange);
+      else if (mq.removeListener) mq.removeListener(onChange);
+    };
+  }, [onClose]);
+
+  return (
+    // z-[60] deliberately exceeds the portal's shared z-50 overlay layer. The F19 install
+    // banner (src/components/PwaPrompts.js) is `fixed bottom-4 left-4 z-50`, rendered globally
+    // from App.js — i.e. OUTSIDE this page's tree and after it in DOM order — and it lands
+    // inside the drawer's footprint. At z-50 it covers the bottom of the item list, which on a
+    // small phone is where Logout sits, so the tap hits "Install app" instead. That only bites
+    // a rep who has NOT installed the app yet — exactly the audience this increment is for.
+    <div className="fixed inset-0 z-[60] md:hidden">
+      <div
+        data-testid="mobile-nav-backdrop"
+        className="absolute inset-0 bg-black/40"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+      <div
+        ref={ref}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="mobile-nav-title"
+        tabIndex={-1}
+        className="absolute inset-y-0 left-0 w-72 max-w-[85vw] bg-white shadow-xl flex flex-col overflow-y-auto"
+      >
+        <div className="p-4 border-b flex items-center justify-between">
+          <span id="mobile-nav-title" className="font-bold text-lg">Grays Admin</span>
+          <button
+            type="button"
+            onClick={onClose}
+            aria-label="Close menu"
+            className="text-gray-500 hover:text-gray-800 text-2xl leading-none px-2"
+          >
+            ×
+          </button>
+        </div>
+        <NavList
+          testId="mobile-nav"
+          items={items}
+          onLogout={onLogout}
+          // Closing on navigate is not cosmetic: React Router swaps the page underneath without
+          // unmounting this drawer, so without it the rep lands on the page they asked for with
+          // the menu still covering it.
+          onNavigate={onClose}
+          className="p-4"
+        />
+      </div>
+    </div>
+  );
+}
+
+/** The hamburger. Hidden from md up, where the sidebar is visible instead. */
+export function MobileNavButton({ onClick }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label="Menu"
+      className="md:hidden text-gray-700 hover:bg-gray-200 rounded p-2 -ml-2"
+    >
+      <svg width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" aria-hidden="true">
+        <line x1="3" y1="6" x2="21" y2="6" />
+        <line x1="3" y1="12" x2="21" y2="12" />
+        <line x1="3" y1="18" x2="21" y2="18" />
+      </svg>
+    </button>
+  );
+}

--- a/src/pages/__tests__/dashboardNav.test.js
+++ b/src/pages/__tests__/dashboardNav.test.js
@@ -1,0 +1,248 @@
+// F19 increment 2a — the portal has to be navigable on a phone.
+//
+// THE BUG: the dashboard sidebar is `hidden md:block` and it is the portal's ONLY navigation.
+// Below 768px a logged-in user therefore sees a dashboard with no links to anywhere. F19
+// increment 1 shipped the installable PWA, which sharpens it: an installed app runs standalone
+// with no browser URL bar, so there is no address bar to fall back on either.
+//
+// WHAT THESE TESTS PIN, and why each one is here rather than being "obvious":
+//  - the two renderings of the nav (sidebar + drawer) show the SAME items for the same user —
+//    the whole reason the item list was extracted into src/utils/nav.js;
+//  - the drawer CLOSES when a link is followed. This is the one that bites: React Router
+//    swaps the page underneath without unmounting the drawer, so a drawer that stays open
+//    leaves the rep staring at the menu they just used, on top of the page they asked for;
+//  - Logout still works from the drawer — it is the only way out of an installed PWA;
+//  - the technician restriction survives the refactor (characterization, not new behaviour).
+
+import React from 'react';
+import { act, render, screen, within, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import Dashboard from '../dashboard';
+import { buildNavItems } from '../../utils/nav';
+
+// jsdom 16 (pinned by CRA 5) has no matchMedia at all. The drawer closes itself when the
+// viewport crosses the md breakpoint, so the tests need one that can be driven.
+function installMatchMedia(initialMatches = false) {
+  const listeners = new Set();
+  const mql = {
+    matches: initialMatches,
+    media: '(min-width: 768px)',
+    addEventListener: (_e, cb) => listeners.add(cb),
+    removeEventListener: (_e, cb) => listeners.delete(cb),
+  };
+  window.matchMedia = jest.fn(() => mql);
+  return {
+    /** Simulate the phone being rotated to landscape / the window being widened past md. */
+    growPastBreakpoint: () => {
+      mql.matches = true;
+      listeners.forEach((cb) => cb({ matches: true }));
+    },
+  };
+}
+
+function mockFetch() {
+  return jest.fn(async (url) => {
+    const u = String(url);
+    const json = (body) => ({ ok: true, status: 200, json: async () => body, text: async () => JSON.stringify(body) });
+    // Every dashboard dataset is consumed as a bare array (ensureArray tolerates more, but
+    // returning the real shape keeps the test honest about what the endpoints send).
+    if (u.includes('/api/products')) return json([]);
+    if (u.includes('/api/waitlist')) return json([]);
+    if (u.includes('/api/workorder')) return json([]);
+    if (u.includes('/api/delivery')) return json([]);
+    if (u.includes('/api/collections')) return json([]);
+    return json({});
+  });
+}
+
+function renderDashboard(user = { id: 'NK', name: 'Nick', access: 'superadmin', roles: ['superadmin'] }) {
+  localStorage.setItem('token', 'test-token');
+  localStorage.setItem('user', JSON.stringify(user));
+  return render(
+    <MemoryRouter>
+      <Dashboard />
+    </MemoryRouter>,
+  );
+}
+
+const menuButton = () => screen.getByRole('button', { name: /menu/i });
+// DOM order, not two role queries concatenated: the parity assertion below compares the two
+// renderings item-for-item, and a link/button split would compare a re-ordered list against a
+// re-ordered list and pass even if the real order had diverged.
+const labelsIn = (el) =>
+  Array.from(el.querySelectorAll('a[href], button'))
+    .map((n) => n.textContent.trim())
+    .filter(Boolean);
+
+beforeEach(() => {
+  global.fetch = mockFetch();
+  installMatchMedia(false);
+});
+
+afterEach(() => {
+  localStorage.clear();
+  jest.resetAllMocks();
+});
+
+describe('F19 — mobile navigation drawer', () => {
+  test('the dashboard offers a menu button (the only nav below md)', async () => {
+    renderDashboard();
+    await waitFor(() => expect(menuButton()).toBeInTheDocument());
+  });
+
+  test('the drawer shows exactly the same items as the desktop sidebar', async () => {
+    renderDashboard();
+    await waitFor(() => expect(menuButton()).toBeInTheDocument());
+
+    const sidebarLabels = labelsIn(screen.getByTestId('sidebar-nav'));
+    expect(sidebarLabels).toContain('Dashboard');
+    expect(sidebarLabels).toContain('Logout');
+
+    await userEvent.click(menuButton());
+    const drawerLabels = labelsIn(screen.getByTestId('mobile-nav'));
+
+    // Order included: the two renderings read the same list, so drift shows up here first.
+    expect(drawerLabels).toEqual(sidebarLabels);
+  });
+
+  test('the drawer is a dialog and takes focus (F26 convention)', async () => {
+    renderDashboard();
+    await waitFor(() => expect(menuButton()).toBeInTheDocument());
+    await userEvent.click(menuButton());
+
+    const dialog = screen.getByRole('dialog');
+    expect(dialog).toHaveAttribute('aria-modal', 'true');
+    expect(dialog).toHaveAccessibleName();
+    await waitFor(() => expect(dialog.contains(document.activeElement)).toBe(true));
+  });
+
+  test('Escape closes the drawer and focus returns to the menu button', async () => {
+    renderDashboard();
+    await waitFor(() => expect(menuButton()).toBeInTheDocument());
+    await userEvent.click(menuButton());
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    await userEvent.keyboard('{Escape}');
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+    expect(document.activeElement).toBe(menuButton());
+  });
+
+  test('following a link closes the drawer', async () => {
+    // Without this the router swaps the page underneath and the menu stays open on top of it.
+    renderDashboard();
+    await waitFor(() => expect(menuButton()).toBeInTheDocument());
+    await userEvent.click(menuButton());
+
+    const drawer = screen.getByTestId('mobile-nav');
+    await userEvent.click(within(drawer).getByRole('link', { name: 'Products' }));
+
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+
+  test('the backdrop closes the drawer', async () => {
+    renderDashboard();
+    await waitFor(() => expect(menuButton()).toBeInTheDocument());
+    await userEvent.click(menuButton());
+
+    await userEvent.click(screen.getByTestId('mobile-nav-backdrop'));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+
+  test('Logout works from the drawer — in an installed PWA it is the only way out', async () => {
+    renderDashboard();
+    await waitFor(() => expect(menuButton()).toBeInTheDocument());
+    await userEvent.click(menuButton());
+
+    const drawer = screen.getByTestId('mobile-nav');
+    // act-wrapped explicitly: the handler awaits the access-log POST and only then navigates,
+    // so the router's state update lands after userEvent's own act scope has closed.
+    await act(async () => {
+      await userEvent.click(within(drawer).getByRole('button', { name: 'Logout' }));
+    });
+
+    await waitFor(() => expect(localStorage.getItem('token')).toBeNull());
+    expect(localStorage.getItem('user')).toBeNull();
+    // The access-log row is what tells ops a session ended deliberately rather than expiring.
+    expect(global.fetch).toHaveBeenCalledWith('/api/access-log', expect.objectContaining({ method: 'POST' }));
+  });
+
+  test('every link actually points where the nav data says — in BOTH renderings', async () => {
+    // Without this the labels can be right and every href wrong: the code review proved
+    // `to={item.to}` could be hard-coded to "/dashboard" with all tests still green.
+    const user = { id: 'NK', name: 'Nick', access: 'superadmin', roles: ['superadmin'] };
+    renderDashboard(user);
+    await waitFor(() => expect(menuButton()).toBeInTheDocument());
+    await userEvent.click(menuButton());
+
+    const expected = buildNavItems({ user, roles: user.roles }).filter((i) => i.to);
+    for (const testId of ['sidebar-nav', 'mobile-nav']) {
+      const nav = screen.getByTestId(testId);
+      for (const item of expected) {
+        expect(within(nav).getByRole('link', { name: item.label })).toHaveAttribute('href', item.to);
+      }
+    }
+  });
+
+  test('the role set comes from the JWT, not just the legacy `access` value', async () => {
+    // A sales rep is `access: 'staff'` with `sales` only in the signed role set (F0b). If the
+    // roles wiring broke, they would silently lose Inbox and Lead Funnel on both renderings —
+    // and every other fixture here is entitled via `access`, so nothing else would notice.
+    renderDashboard({ id: 'AM', name: 'Amelia', access: 'staff', roles: ['staff', 'sales'] });
+    await waitFor(() => expect(menuButton()).toBeInTheDocument());
+    await userEvent.click(menuButton());
+
+    const drawer = screen.getByTestId('mobile-nav');
+    expect(within(drawer).getByRole('link', { name: 'Inbox' })).toBeInTheDocument();
+    expect(within(drawer).getByRole('link', { name: 'Lead Funnel' })).toBeInTheDocument();
+    expect(within(drawer).queryByRole('link', { name: 'Awaiting Workorder' })).not.toBeInTheDocument();
+  });
+
+  test('the × button closes the drawer', async () => {
+    // On a 375px phone the drawer is 288px wide, so the backdrop is an 87px strip — the × is
+    // the affordance a rep will actually aim for.
+    renderDashboard();
+    await waitFor(() => expect(menuButton()).toBeInTheDocument());
+    await userEvent.click(menuButton());
+
+    await userEvent.click(screen.getByRole('button', { name: /close menu/i }));
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+
+  test('growing past the md breakpoint closes the drawer (rotate to landscape)', async () => {
+    // Left open it would stay mounted but display:none, with useDialog's document-level Tab
+    // trap still cycling focus through invisible links — keyboard navigation dead page-wide.
+    const media = installMatchMedia(false);
+    renderDashboard();
+    await waitFor(() => expect(menuButton()).toBeInTheDocument());
+    await userEvent.click(menuButton());
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+
+    act(() => media.growPastBreakpoint());
+    await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
+  });
+
+  test('the two renderings stay on their own side of the md breakpoint', async () => {
+    // jsdom has no CSS, so these classes are the only evidence that desktop is unchanged —
+    // acceptance criterion 6. Without them, dropping `md:hidden` is invisible to every test.
+    renderDashboard();
+    await waitFor(() => expect(menuButton()).toBeInTheDocument());
+    expect(menuButton()).toHaveClass('md:hidden');
+    expect(screen.getByTestId('sidebar-nav').closest('aside')).toHaveClass('hidden', 'md:block');
+
+    await userEvent.click(menuButton());
+    expect(screen.getByTestId('mobile-nav-backdrop').parentElement).toHaveClass('md:hidden');
+  });
+
+  test('a technician sees no Products / Customers / Waitlist in the drawer either', async () => {
+    renderDashboard({ id: 'TE', name: 'Tech', access: 'technician', roles: ['technician'] });
+    await waitFor(() => expect(menuButton()).toBeInTheDocument());
+    await userEvent.click(menuButton());
+
+    const drawer = screen.getByTestId('mobile-nav');
+    for (const label of ['Products', 'Customers', 'Waitlist']) {
+      expect(within(drawer).queryByRole('link', { name: label })).not.toBeInTheDocument();
+    }
+    expect(within(drawer).getByRole('link', { name: 'Delivery Operations' })).toBeInTheDocument();
+  });
+});

--- a/src/pages/dashboard.js
+++ b/src/pages/dashboard.js
@@ -1,7 +1,9 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { Link, useNavigate } from 'react-router-dom';
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import toast from 'react-hot-toast';
-import { getRoles, hasAnyRole } from '../utils/auth';
+import { getRoles } from '../utils/auth';
+import { buildNavItems } from '../utils/nav';
+import { MobileNavButton, MobileNavDrawer, NavList } from '../components/PortalNav';
 
 /** Small inline bar chart (no external deps) */
 function BarChart({ data = [], onBarClick }) {
@@ -43,16 +45,13 @@ export default function Dashboard() {
   const [user, setUser] = useState(null);
   const [loading, setLoading] = useState(true);
   const isWorkshop = user?.email === 'workshop@graysfitness.com.au';
-  // F3/F5: the in-portal Inbox and lead funnel are sales tools (the server also gates
-  // /api/podium/inbox and /api/leads).
-  const canUseInbox = hasAnyRole(getRoles(), ['sales', 'superadmin']);
-  const canUseLeads = canUseInbox;
-  // F7b: the Awaiting-Workorder queue is a logistics tool (the server also gates
-  // /api/logistics). superadmin sees it too.
-  const canUseLogistics = hasAnyRole(getRoles(), ['logistics', 'superadmin']);
-  // F10: the Integrations log is an ops/observability tool (the server also gates
-  // /api/integrations to superadmin).
-  const canUseIntegrations = hasAnyRole(getRoles(), ['superadmin']);
+  // F19 incr 2a: the nav items — and every role gate that decides which ones appear — now live
+  // in utils/nav.js, because the desktop sidebar and the mobile drawer both render them.
+  const navItems = useMemo(() => buildNavItems({ user, roles: getRoles() }), [user]);
+  const [navOpen, setNavOpen] = useState(false);
+  // Stable identity: the drawer subscribes to Escape and to a matchMedia change with this in
+  // the dependency array, so an inline arrow would resubscribe on every dashboard render.
+  const closeNav = useCallback(() => setNavOpen(false), []);
 
   // base datasets
   const [products, setProducts] = useState([]);
@@ -96,6 +95,26 @@ export default function Dashboard() {
     end.setDate(start.getDate() + 7); // exclusive
     return { start, end };
   }, [weekBounds]);
+
+  // Lifted out of the sidebar's onClick so the drawer's Logout runs the SAME code, not a copy.
+  // In an installed PWA (F19 incr 1) this is the only way to sign out — there is no URL bar.
+  const handleLogout = useCallback(async () => {
+    const u = JSON.parse(localStorage.getItem('user') || 'null');
+    if (u) {
+      try {
+        await fetch('/api/access-log', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ userId: u.id, description: 'User manually logged out' }),
+        });
+      } catch {}
+    }
+    localStorage.removeItem('user');
+    localStorage.removeItem('token');
+    localStorage.removeItem('sessionExpiry');
+    toast('Logged out');
+    navigate('/');
+  }, [navigate]);
 
   useEffect(() => {
     const storedUser = localStorage.getItem('user');
@@ -259,120 +278,23 @@ export default function Dashboard() {
       {/* Sidebar */}
       <aside className="w-64 bg-white shadow-md hidden md:block">
         <div className="p-6 font-bold text-xl border-b">Grays Admin</div>
-        <nav className="mt-4 flex flex-col space-y-2 px-4">
-          {/* Always visible */}
-          <Link to="/dashboard" className="text-gray-700 hover:bg-gray-200 p-2 rounded">
-            Dashboard
-          </Link>
-          <Link to="/settings" className="text-gray-700 hover:bg-gray-200 p-2 rounded">
-            Account Settings
-          </Link>
-
-          {/* In-portal Inbox — sales/superadmin (F3) */}
-          {canUseInbox && (
-            <Link to="/inbox" className="text-gray-700 hover:bg-gray-200 p-2 rounded">
-              Inbox
-            </Link>
-          )}
-
-          {/* Lead funnel — sales/superadmin (F5) */}
-          {canUseLeads && (
-            <Link to="/leads" className="text-gray-700 hover:bg-gray-200 p-2 rounded">
-              Lead Funnel
-            </Link>
-          )}
-
-          {/* Awaiting-Workorder queue — logistics/superadmin (F7b) */}
-          {canUseLogistics && (
-            <Link to="/logistics/awaiting-workorder" className="text-gray-700 hover:bg-gray-200 p-2 rounded">
-              Awaiting Workorder
-            </Link>
-          )}
-
-          {/* Not visible to technician */}
-          {user?.access !== 'technician' && (
-            <>
-              <Link to="/products" className="text-gray-700 hover:bg-gray-200 p-2 rounded">
-                Products
-              </Link>
-              <Link to="/customers" className="text-gray-700 hover:bg-gray-200 p-2 rounded">
-                Customers
-              </Link>
-              <Link to="/waitlist" className="text-gray-700 hover:bg-gray-200 p-2 rounded">
-                Waitlist
-              </Link>
-            </>
-          )}
-
-          {/* Delivery Ops: visible to everyone */}
-          <Link
-            to={user?.id === 'WK' ? '/workshop' : '/delivery_operations'}
-            className="text-gray-700 hover:bg-gray-200 p-2 rounded"
-          >
-            Delivery Operations
-          </Link>
-
-          {/* Winnings 3PL — Peloton stock (superadmin only) */}
-          {user?.access === 'superadmin' && (
-            <Link to="/peloton" className="text-gray-700 hover:bg-gray-200 p-2 rounded flex items-center gap-2">
-              <span className="inline-block w-2 h-2 rounded-full bg-black flex-shrink-0" />
-              Peloton
-            </Link>
-          )}
-
-          {/* Integrations observability — superadmin (F10) */}
-          {canUseIntegrations && (
-            <Link to="/integrations" className="text-gray-700 hover:bg-gray-200 p-2 rounded">
-              Integrations
-            </Link>
-          )}
-
-          {/* Only superadmin */}
-          {user?.access === 'superadmin' && (
-            <Link
-              to="/register"
-              className="text-gray-700 hover:bg-gray-200 p-2 rounded font-semibold"
-            >
-              Register New User
-            </Link>
-          )}
-
-          {/* Logout */}
-          <button
-            onClick={async () => {
-              const u = JSON.parse(localStorage.getItem('user') || 'null');
-              if (u) {
-                try {
-                  await fetch('/api/access-log', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                      userId: u.id,
-                      description: 'User manually logged out',
-                    }),
-                  });
-                } catch {}
-              }
-              localStorage.removeItem('user');
-              localStorage.removeItem('token');
-              localStorage.removeItem('sessionExpiry');
-              toast('Logged out');
-              navigate('/');
-            }}
-            className="text-gray-700 hover:bg-gray-200 p-2 rounded text-left"
-          >
-            Logout
-          </button>
-        </nav>
+        <NavList testId="sidebar-nav" items={navItems} onLogout={handleLogout} className="mt-4 px-4" />
       </aside>
+
+      {/* Mobile drawer — the only navigation below md. Mounted only while open so useDialog
+          captures the opener and can restore focus to it (F26 convention). */}
+      {navOpen && (
+        <MobileNavDrawer items={navItems} onLogout={handleLogout} onClose={closeNav} />
+      )}
 
       {/* Main */}
       <div className="flex-1 flex flex-col">
-        <header className="bg-white shadow-md p-4 flex justify-between items-center">
-          <h1 className="text-lg font-semibold">Hello, {user?.name || 'Guest'}</h1>
+        <header className="bg-white shadow-md p-4 flex items-center gap-2">
+          <MobileNavButton onClick={() => setNavOpen(true)} />
+          <h1 className="text-lg font-semibold truncate">Hello, {user?.name || 'Guest'}</h1>
         </header>
 
-        <main className="flex-1 p-6 overflow-auto">
+        <main className="flex-1 p-4 md:p-6 overflow-auto">
           {user?.access !== 'technician' && (
             <>
               <div className="bg-white p-6 rounded shadow-md">

--- a/src/utils/nav.js
+++ b/src/utils/nav.js
@@ -1,0 +1,99 @@
+// src/utils/nav.js — F19 increment 2a: the portal's navigation, as data.
+//
+// WHY THIS FILE EXISTS: the dashboard sidebar used to be the one and only navigation in the
+// portal, and it is `hidden md:block` — so on a phone there were no links at all. Increment 2a
+// adds a mobile drawer, which means the same nav is now rendered TWICE. Two hand-maintained
+// copies of a role-gated list is how a feature ends up reachable on a laptop and invisible on
+// a phone (or worse, the reverse), so the list lives here once and both renderers read it.
+//
+// Kept pure and JSX-free so scripts/podium-nav-smoke.mjs can import it in node — the same
+// arrangement as src/utils/compose.js and src/utils/lotLabels.js.
+//
+// ⚠️ These gates decide what to SHOW only. The server is authoritative: /api/podium/inbox,
+// /api/leads, /api/logistics and /api/integrations all re-check the JWT role set via
+// lib/rbac.js. Hiding a link is never the security control.
+
+// Imported with the .js extension on purpose: node (which runs the smoke) resolves ESM
+// specifiers literally and cannot find './auth'. Webpack and jest both accept the extension.
+import { hasAnyRole } from './auth.js';
+
+// Every key this builder can emit, in render order. Exported so a test can assert the builder
+// never invents a key nobody styled or routed.
+export const NAV_KEYS = [
+  'dashboard',
+  'settings',
+  'inbox',
+  'leads',
+  'logistics',
+  'products',
+  'customers',
+  'waitlist',
+  'delivery',
+  'peloton',
+  'integrations',
+  'register',
+  'logout',
+];
+
+/**
+ * The nav items for a given user + role set, in display order.
+ *
+ * Returns `[{ key, label, to?, emphasis?, dot? }]`. `logout` has no `to` — it is an action the
+ * renderer wires to its own handler, because logging out writes an access-log row and clears
+ * storage, which is page behaviour, not navigation.
+ *
+ * Tolerates `user: null` / `roles: null`. dashboard.js gates its whole render on `loading`, so
+ * a null user is COMPUTED but never rendered today — the tolerance is there so a future caller
+ * (or a reordered effect) gets an empty nav rather than a crashed page. A session created
+ * before F0b genuinely has no `roles` array, and that path is live.
+ */
+export function buildNavItems({ user, roles } = {}) {
+  const roleSet = Array.isArray(roles) ? roles : [];
+  // Fall back to the legacy single `access` value so a pre-roles session still resolves its
+  // primary role — same precedence as utils/auth.js getRoles().
+  const effectiveRoles = roleSet.length ? roleSet : (user?.access ? [user.access] : []);
+
+  // F3/F5: the Inbox and lead funnel are sales tools. F7b: the Awaiting-Workorder queue is a
+  // logistics tool. F10: the Integrations log is superadmin-only observability.
+  const canUseInbox = hasAnyRole(effectiveRoles, ['sales', 'superadmin']);
+  const canUseLeads = canUseInbox;
+  const canUseLogistics = hasAnyRole(effectiveRoles, ['logistics', 'superadmin']);
+  const canUseIntegrations = hasAnyRole(effectiveRoles, ['superadmin']);
+  const isSuperadmin = user?.access === 'superadmin';
+  const isTechnician = user?.access === 'technician';
+
+  const items = [
+    { key: 'dashboard', label: 'Dashboard', to: '/dashboard' },
+    { key: 'settings', label: 'Account Settings', to: '/settings' },
+  ];
+
+  if (canUseInbox) items.push({ key: 'inbox', label: 'Inbox', to: '/inbox' });
+  if (canUseLeads) items.push({ key: 'leads', label: 'Lead Funnel', to: '/leads' });
+  if (canUseLogistics) {
+    items.push({ key: 'logistics', label: 'Awaiting Workorder', to: '/logistics/awaiting-workorder' });
+  }
+
+  if (!isTechnician) {
+    items.push({ key: 'products', label: 'Products', to: '/products' });
+    items.push({ key: 'customers', label: 'Customers', to: '/customers' });
+    items.push({ key: 'waitlist', label: 'Waitlist', to: '/waitlist' });
+  }
+
+  // Delivery Operations is visible to everyone; the shared WK workshop account gets the
+  // workshop view instead of the ops view.
+  items.push({
+    key: 'delivery',
+    label: 'Delivery Operations',
+    to: user?.id === 'WK' ? '/workshop' : '/delivery_operations',
+  });
+
+  if (isSuperadmin) items.push({ key: 'peloton', label: 'Peloton', to: '/peloton', dot: true });
+  if (canUseIntegrations) items.push({ key: 'integrations', label: 'Integrations', to: '/integrations' });
+  if (isSuperadmin) {
+    items.push({ key: 'register', label: 'Register New User', to: '/register', emphasis: true });
+  }
+
+  items.push({ key: 'logout', label: 'Logout' });
+
+  return items;
+}


### PR DESCRIPTION
## The problem

The dashboard sidebar is `hidden md:block`, and it is the **only navigation in the portal**. So on a phone, a logged-in user saw a dashboard with **no links to anywhere** — no Inbox, no Lead Funnel, no Delivery Operations, no Logout.

F19 increment 1 (PR #81) made the portal installable, which makes this worse rather than better: an installed PWA runs standalone with **no browser URL bar**, so there is no address bar to type a path into either.

This is increment **2a** of F19's mobile pass. F19 stays `IN_PROGRESS`: incr 2b (the per-page responsive pass, incl. the inbox mobile layout F4/F11 deferred) and incr 3 (optional web push) remain.

## What changed

| File | What |
|---|---|
| `src/utils/nav.js` **(new)** | `buildNavItems({user, roles})` — the nav list **and every role gate in it**, in one place. Pure and JSX-free so the node smoke imports it directly (`src/utils/compose.js` / `lotLabels.js` precedent). |
| `src/components/PortalNav.js` **(new)** | `NavList` (rendered by both the sidebar and the drawer), `MobileNavDrawer`, `MobileNavButton`. |
| `src/pages/dashboard.js` | Renders both from the same list. Logout lifted into one `handleLogout` shared by sidebar and drawer. Header/main mobile padding. **−121 lines of hand-maintained sidebar JSX.** |
| `scripts/podium-nav-smoke.mjs` **(new)** | 48 checks over the role gates (auto-discovered by the F24 runner — no registration step). |
| `src/pages/__tests__/dashboardNav.test.js` **(new)** | 13 RTL tests on the F25 harness. |

**The role gates are transcribed verbatim from the old sidebar — characterization, not a redesign.** That includes its `access`-vs-`roles` asymmetry (Integrations is role-gated; Peloton and Register are `access`-gated). Nothing about who sees what changed in this PR; if any of that is wrong, it was wrong before and should be its own change.

Client role checks still only decide **what to show** — `lib/rbac.js` remains the authority on every one of these endpoints.

## Verification

- **61 component tests** (4 suites), **20/20 smoke suites**, `CI=true npm run build` **clean, no warnings**.
- **Mutation testing: 17 mutants, 0 survivors.** Round 1 was 9/0 — then the code review proved **five more mutants survived it**, all now covered (see below).
- Bundle `main.2bd8366e.js` **166.54 kB**.
- **No migration. Neon untouched — not even a read. No new serverless function. No new dependency.**

## Code review — 5 Important + 5 Minor, and it caught two real bugs

**Fixed (Important):**
1. 🔴 **The install banner covered the drawer and would have stolen the Logout tap.** `PwaPrompts` is `fixed bottom-4 left-4 z-50`, rendered globally from `App.js`, and the drawer was `z-40` — so on a small phone the bottom of the item list (where Logout sits for a superadmin's 13 items) sat **under** the "Install app" bar. It only bites a rep who has **not installed the app yet** — exactly this increment's audience. Drawer is now `z-[60]`, with the reason written next to it.
2. 🔴 **Crossing the md breakpoint with the drawer open killed keyboard navigation page-wide.** Above md the drawer is `display:none` but was still **mounted**, so `useDialog`'s document-level Tab trap kept cycling focus through invisible links — and the hamburger and backdrop are `md:hidden` too, so there was no visible way out. Repro: open the drawer in portrait, rotate to landscape. Now a `matchMedia('(min-width: 768px)')` listener closes it.
3. **Escape was bound to the dialog element**, unlike all four existing modals which bind it to `window`. Not stylistic: a tap on the drawer's heading or padding blurs to `<body>` in a real browser, and a keydown at `<body>` never reaches an element handler — Escape would silently stop working. jsdom cannot reproduce that, so the precedent is the evidence. Moved to `window`.
4. **`to={item.to}` could be hard-coded to `/dashboard`** — every link in the portal pointing at one page — **with all 56 tests and 48 smoke checks green.** The smoke asserted `to` on the *data*, the RTL tests asserted *labels* in the DOM, and nothing joined them. Now every rendered `href` is asserted against `buildNavItems`, in **both** renderings.
5. **The `getRoles()` wiring was deletable with everything green**, because every fixture was entitled via legacy `user.access`. A sales rep (`access:'staff'`, `roles:['staff','sales']`) would have silently lost Inbox and Lead Funnel on both renderings. Now covered by a roles-only fixture.

**Fixed (Minor):** the × button and the backdrop click were both deletable with a green suite; `md:hidden` could be stripped from the hamburger and the drawer (i.e. "no desktop change" was unverified) — all now asserted.

**Rejected, with reason:** `aria-expanded`/`aria-controls` on the hamburger. F26 deliberately split *dialogs* from *disclosures* in this repo — the assign picker got disclosure semantics precisely because it is a popover over a live page, and there is a test asserting it is **not** a dialog. This drawer is a true modal, so it gets dialog semantics; `aria-expanded` on a dialog trigger would contradict that split.

**Corrected, not fixed:** a comment in `nav.js` claimed the null-user path renders. It doesn't — `dashboard.js` gates the whole render on `loading`. The tolerance stays (a throw in the memo would crash the page), the comment now says what is actually true.

## ⚠️ What jsdom cannot prove — worth 60 seconds on a real phone

jsdom has no layout engine and no CSS, so these are reasoned from the DOM/CSS model and **want a human spot-check on the Preview**:
- the drawer actually sits above the install banner (the `z-[60]` fix);
- Escape after tapping the drawer's padding (the blur-to-body case);
- the breakpoint auto-close on a real rotate.

## Test it

1. Open the Preview on a phone (or DevTools device toolbar at 375×667) and log in.
2. **Before this PR there is no nav at all below 768px.** Now: tap ☰ next to "Hello, …".
3. Check the drawer lists exactly what your role sees on desktop; tap a link → you land on that page and **the drawer is closed**.
4. Escape, the ×, and a tap on the dim area all close it. Focus returns to ☰.
5. Rotate to landscape (≥768px) with the drawer open → it closes and the desktop sidebar takes over.
6. Log out from the drawer → you land on the login page and the access-log records it.
7. Desktop (≥768px): the sidebar is unchanged and there is no hamburger.

## Reviewer checklist

- [ ] Every destination your role needs is in the drawer, and nothing extra.
- [ ] A `sales` user sees Inbox + Lead Funnel; a `technician` sees no Products/Customers/Waitlist; the `WK` account's Delivery Operations still goes to `/workshop`.
- [ ] Desktop is visually unchanged.
- [ ] The install banner does not cover the drawer on a real phone.
- [ ] Nothing here changes who is *allowed* to do anything — only what is shown.

Not merged by me. No changes to `main`, Production, or the production database.
