### PR TITLE
F31 - a filter switch no longer destroys a draft in progress

### DIFF
--- a/src/pages/__tests__/inboxFilterDraft.test.js
+++ b/src/pages/__tests__/inboxFilterDraft.test.js
@@ -1,0 +1,302 @@
+// F31 — changing the bucket/status filter must not destroy a draft in progress.
+//
+// THE BUG (live on Production): `switchBucket` and `switchStatus` both call `clearSelection()`,
+// which calls `resetComposerState()` UNCONDITIONALLY. So a rep with a half-typed reply who taps
+// "Closed", or moves from "Assigned to You" to "All", loses it — no warning, no undo.
+//
+// Same family as F27, pointed the other way: F27 was about a draft reaching the WRONG customer,
+// this one is about a draft simply being destroyed. F27 deliberately did not bundle it.
+//
+// THE FIX, and why it is conditional: a filter is about the LIST, not about the open thread.
+// Wiping the reading pane was only ever justified because it was cheap — and it is not cheap
+// when it throws away work. So when the composer has unsaved content, switching a filter now
+// re-filters the list and leaves the thread and the draft exactly as they were. When the
+// composer is empty, behaviour is unchanged (the second test pins that, so the fix cannot
+// quietly become "the thread never closes").
+
+import React from 'react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import Inbox from '../inbox';
+
+const CONVERSATIONS = [
+  {
+    uid: 'conv-alice',
+    status: 'open',
+    channel: { type: 'sms', identifier: '0400000001' },
+    identity: { displayName: 'Alice Adams' },
+    lastMessageAt: '2026-07-21T10:00:00.000Z',
+  },
+];
+
+const json = (body) => ({
+  ok: true,
+  status: 200,
+  json: async () => body,
+  text: async () => JSON.stringify(body),
+  headers: { get: () => 'application/json' },
+});
+
+function mockFetch() {
+  return jest.fn(async (url) => {
+    const u = String(url);
+    if (u.includes('resource=conversations')) {
+      // FILTER-AWARE on purpose. A mock that returns the same row for every bucket/status makes
+      // filtering a no-op, and then the exact state this feature creates — a thread open in the
+      // reading pane that is NOT in the visible list — never occurs in any test, so every
+      // "the thread stays open" assertion passes for the wrong reason. Alice is open and
+      // assigned, so she is absent from status=closed and from bucket=unassigned.
+      const inScope = !u.includes('status=closed') && !u.includes('bucket=unassigned');
+      return json({ data: inScope ? CONVERSATIONS : [], serverTime: '2026-07-21T10:00:00.000Z' });
+    }
+    if (u.includes('resource=messages')) {
+      return json({
+        data: [{ uid: 'm1', direction: 'inbound', body: 'Is the rack still available?', createdAt: '2026-07-21T09:00:00.000Z' }],
+        serverTime: '2026-07-21T10:00:00.000Z',
+      });
+    }
+    if (u.includes('resource=templates')) return json({ data: [] });
+    if (u.includes('resource=reps')) return json({ reps: [] });
+    if (u.includes('/api/podium/status')) return json({ podiumUserId: 'pod-me' });
+    if (u.includes('/api/podium/assign')) return json({ assignees: [] });
+    if (u.includes('/api/podium/contact')) return json({ customer: null, workorders: [] });
+    if (u.includes('/api/products')) return json([]);
+    return json({});
+  });
+}
+
+const composer = () => screen.getByPlaceholderText(/type a reply…|write an internal note…/i);
+
+/**
+ * Let the list reload the switch kicked off finish before the test ends. These assertions are
+ * synchronous (the draft is either still there or it isn't), so without this the fetch settles
+ * after RTL has unmounted and React reports the update as un-acted — noise that would be blamed
+ * on whichever test runs next.
+ */
+const settle = async () => {
+  for (let i = 0; i < 3; i += 1) {
+    // eslint-disable-next-line no-await-in-loop
+    await act(async () => { await new Promise((r) => setTimeout(r, 0)); });
+  }
+};
+const conversationButton = (name) => {
+  const row = screen.getByText(name).closest('button');
+  if (!row) throw new Error(`Conversation row for "${name}" is not a <button>`);
+  return row;
+};
+
+async function openAliceAnd(type) {
+  render(
+    <MemoryRouter>
+      <Inbox />
+    </MemoryRouter>,
+  );
+  await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+  await userEvent.click(conversationButton('Alice Adams'));
+  await waitFor(() => expect(composer()).toBeInTheDocument());
+  // Wait for the thread itself, not just the composer: the message list arrives on its own
+  // request, and a test that types immediately can outrun it (the typing was the only reason
+  // the other tests happened to be safe).
+  await waitFor(() => expect(screen.getByText('Is the rack still available?')).toBeInTheDocument());
+  if (type) await userEvent.type(composer(), type);
+}
+
+beforeEach(() => {
+  localStorage.setItem('token', 'test-token');
+  localStorage.setItem('user', JSON.stringify({ id: 'GS', name: 'Tester', roles: ['sales'] }));
+  global.fetch = mockFetch();
+  URL.createObjectURL = jest.fn(() => 'blob:mock-url');
+  URL.revokeObjectURL = jest.fn();
+});
+
+afterEach(() => {
+  localStorage.clear();
+  jest.resetAllMocks();
+});
+
+describe('F31 — a filter switch must not throw away work', () => {
+  test('switching the status filter keeps a half-typed reply', async () => {
+    await openAliceAnd('Yes — it is, I can hold it for you');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Closed' }));
+
+    expect(composer()).toHaveValue('Yes — it is, I can hold it for you');
+
+    await settle();
+  });
+
+  test('switching the bucket filter keeps a half-typed reply', async () => {
+    await openAliceAnd('Yes — it is, I can hold it for you');
+
+    await userEvent.click(screen.getByRole('button', { name: 'All' }));
+
+    expect(composer()).toHaveValue('Yes — it is, I can hold it for you');
+
+    await settle();
+  });
+
+  test('the thread stays open too — a draft with nowhere to send it is no better', async () => {
+    await openAliceAnd('Half a sentence');
+
+    await userEvent.click(screen.getByRole('button', { name: 'All' }));
+
+    // The reading pane still shows Alice's thread, so Send still goes where the rep expects.
+    expect(screen.getByText('Is the rack still available?')).toBeInTheDocument();
+    expect(composer()).toHaveValue('Half a sentence');
+    await settle();
+  });
+
+  test('the list itself still re-filters', async () => {
+    // The point of the switch has to keep working: this is a fix for the composer, not a veto
+    // on the filter.
+    await openAliceAnd('Half a sentence');
+
+    await userEvent.click(screen.getByRole('button', { name: 'All' }));
+
+    await waitFor(() =>
+      expect(global.fetch.mock.calls.some(([u]) => String(u).includes('resource=conversations&bucket=all'))).toBe(true),
+    );
+  });
+
+  test('with an EMPTY composer the switch still clears the thread (unchanged behaviour)', async () => {
+    // Characterization. Without this, the fix could drift into "the thread never closes", which
+    // is a different product decision that nobody asked for.
+    await openAliceAnd(null);
+    expect(screen.getByText('Is the rack still available?')).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole('button', { name: 'All' }));
+
+    await waitFor(() => expect(screen.queryByText('Is the rack still available?')).not.toBeInTheDocument());
+  });
+
+  test('whitespace is not work — a composer holding only spaces still clears', async () => {
+    await openAliceAnd('   ');
+
+    await userEvent.click(screen.getByRole('button', { name: 'All' }));
+
+    await waitFor(() => expect(screen.queryByText('Is the rack still available?')).not.toBeInTheDocument());
+  });
+
+  test('an attached file counts as work even with no text typed', async () => {
+    // A quote PDF or a photo of the machine is the expensive half of a message: the rep found
+    // the file, not just typed a line. Losing it silently is worse than losing the text.
+    await openAliceAnd(null);
+    const file = new File(['pdf-bytes'], 'quote-20431.pdf', { type: 'application/pdf' });
+    const input = document.querySelector('input[type="file"]');
+    expect(input).toBeTruthy();
+    await userEvent.upload(input, file);
+    await waitFor(() => expect(screen.getByText(/quote-20431\.pdf/i)).toBeInTheDocument());
+
+    await userEvent.click(screen.getByRole('button', { name: 'All' }));
+
+    expect(screen.getByText(/quote-20431\.pdf/i)).toBeInTheDocument();
+    expect(screen.getByText('Is the rack still available?')).toBeInTheDocument();
+    await settle();
+  });
+
+  test('re-clicking the filter you are already on changes nothing', async () => {
+    await openAliceAnd('Still typing');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Assigned to You' }));
+
+    expect(composer()).toHaveValue('Still typing');
+    expect(screen.getByText('Is the rack still available?')).toBeInTheDocument();
+    await settle();
+  });
+
+  test('re-clicking the current filter with an EMPTY composer keeps the thread too', async () => {
+    // The no-op guards (`if (next === bucket) return`) are what this pins. With a draft typed
+    // they are unfalsifiable — `keepThread` would be true anyway — so only the empty-composer
+    // case can tell whether they exist. Mutation testing proved deleting both guards left the
+    // whole suite green before this test.
+    await openAliceAnd(null);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Assigned to You' }));
+    await userEvent.click(screen.getByRole('button', { name: 'Open' }));
+
+    expect(screen.getByText('Is the rack still available?')).toBeInTheDocument();
+    await settle();
+  });
+
+  test('with an EMPTY composer the STATUS filter clears the thread as well', async () => {
+    // The bucket half of `switchScope`'s contract was pinned; the status half was not, so
+    // `switchStatus` could bypass switchScope entirely and never clear anything.
+    await openAliceAnd(null);
+
+    await userEvent.click(screen.getByRole('button', { name: 'Closed' }));
+
+    await waitFor(() => expect(screen.queryByText('Is the rack still available?')).not.toBeInTheDocument());
+  });
+
+  test('a kept thread says so when it falls outside the filter, and can still be sent to', async () => {
+    // The filter-aware mock puts Alice genuinely out of scope here (she is open, the filter is
+    // Closed), which is the state the whole feature creates. Two things have to hold: the rep is
+    // TOLD — on a phone the list is hidden behind the thread, so without this the tap has no
+    // visible effect at all — and Send still targets the thread they are looking at.
+    await openAliceAnd('Yes, I can hold it until Friday');
+
+    await userEvent.click(screen.getByRole('button', { name: 'Closed' }));
+
+    await waitFor(() => expect(screen.getByText(/isn’t in the current view/i)).toBeInTheDocument());
+    expect(composer()).toHaveValue('Yes, I can hold it until Friday');
+
+    await userEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await waitFor(() => {
+      const post = global.fetch.mock.calls.find(
+        ([u, init]) => String(u).includes('resource=messages') && init?.method === 'POST',
+      );
+      expect(post).toBeTruthy();
+      expect(JSON.parse(post[1].body).conversationId).toBe('conv-alice');
+    });
+    await settle();
+  });
+
+  test('a kept thread keeps receiving new messages', async () => {
+    // The failure this prevents is silent and nasty: the 8s poll is scoped by bucket/status, so
+    // a thread kept open OUTSIDE that scope can never appear in the poll's payload — the rep
+    // composes a reply while inbound messages quietly stop arriving. No error, no spinner.
+    // Found by the code review; the top-up in pollNow is what this pins.
+    // Fake timers from BEFORE the render, and fireEvent throughout: the 8s interval is created
+    // during mount, so switching to fake timers afterwards leaves a real timer that
+    // advanceTimersByTime can never fire — the first version of this test passed on that
+    // technicality and proved nothing. userEvent v13 needs real timers, hence fireEvent.
+    jest.useFakeTimers();
+    try {
+      render(
+        <MemoryRouter>
+          <Inbox />
+        </MemoryRouter>,
+      );
+      await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+      fireEvent.click(conversationButton('Alice Adams'));
+      await waitFor(() => expect(screen.getByText('Is the rack still available?')).toBeInTheDocument());
+      fireEvent.change(composer(), { target: { value: 'Typing while she replies' } });
+
+      fireEvent.click(screen.getByRole('button', { name: 'Closed' }));
+      await waitFor(() => expect(screen.getByText(/isn’t in the current view/i)).toBeInTheDocument());
+
+      const threadGets = () => global.fetch.mock.calls.filter(
+        ([u, init]) => String(u).includes('resource=messages') && String(u).includes('conv-alice') && (init?.method || 'GET') === 'GET',
+      ).length;
+      const before = threadGets();
+
+      await act(async () => { jest.advanceTimersByTime(8000); });
+      await act(async () => { await Promise.resolve(); });
+
+      expect(threadGets()).toBeGreaterThan(before);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('the notice is not shown while the thread IS in the list', async () => {
+    // Otherwise the banner could be permanently on and the test above would prove nothing.
+    await openAliceAnd('Half a sentence');
+
+    await userEvent.click(screen.getByRole('button', { name: 'All' }));
+
+    expect(screen.queryByText(/isn’t in the current view/i)).not.toBeInTheDocument();
+    await settle();
+  });
+});

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -209,6 +209,7 @@ export default function Inbox() {
   const deepLinkedRef = useRef(false); // one-shot: open ?conversation= from a funnel deep-link
 
   const sinceRef = useRef(null); // last poll cursor timestamp (server echoes serverTime)
+  const conversationsRef = useRef([]); // latest list, for the poll (see F31 note in pollNow)
 
   // ---- Gate (client-side display only; the server re-checks every request) -------
   useEffect(() => {
@@ -389,6 +390,11 @@ export default function Inbox() {
 
   useEffect(() => { selectedIdRef.current = selectedId; }, [selectedId]);
 
+  // F31 — read by the poll, which must not take `conversations` as a dependency: pollNow is the
+  // interval's callback, so a new identity on every list update would tear down and restart the
+  // 8s timer each time and the poll could drift indefinitely.
+  useEffect(() => { conversationsRef.current = conversations; }, [conversations]);
+
   // Fetch the timeline whenever the panel resolves a lead.
   useEffect(() => {
     loadLeadHistory(panel?.lead?.lead_id || null);
@@ -470,6 +476,15 @@ export default function Inbox() {
         if (selectedId && updated.some((c) => c?.uid === selectedId)) {
           loadThread(selectedId, { silent: true });
         }
+      }
+      // F31 — a thread kept open across a filter switch is, by definition, outside the polled
+      // scope, so it can NEVER appear in `updated`. Without this the rep sits in a live
+      // conversation composing a reply while inbound messages silently stop arriving — no
+      // error, no spinner, nothing. Refresh it directly whenever it is not in the current list.
+      // (The deep-link and post-compose paths could already land in this state; they just
+      // couldn't be reached with one click on the most-used control on the page.)
+      if (selectedIdRef.current && !conversationsRef.current.some((c) => c?.uid === selectedIdRef.current)) {
+        loadThread(selectedIdRef.current, { silent: true });
       }
     } catch {
       /* polls are best-effort; ignore transient errors */
@@ -571,18 +586,43 @@ export default function Inbox() {
     resetComposerState();
   };
 
+  // F31 — is there work in the composer that a filter switch would destroy?
+  //
+  // Text and attachments only. Internal-note MODE is a toggle, not work: re-flicking it costs a
+  // click, and treating it as content would leave threads open after every filter change for a
+  // rep who happens to work in note mode.
+  //
+  // Whitespace is not work either — `draft.trim()` matches what the Send button already treats
+  // as empty, so a composer the rep cannot send from is not one worth protecting.
+  const composerHasUnsavedContent = () => draft.trim().length > 0 || attachments.length > 0;
+
+  // F31 — is the open thread absent from the filtered list? Gated on `!loadingConvos` so the
+  // notice below doesn't flash during every list reload, when `conversations` is briefly stale.
+  const selectedOutsideFilter =
+    !!selectedId && !loadingConvos && !conversations.some((c) => c?.uid === selectedId);
+
+  // F31 — a bucket/status filter is about the LIST, not about the open thread. Clearing the
+  // reading pane alongside it was only ever justified because it was cheap; it is not cheap
+  // when it silently destroys a half-typed reply, with no undo and no warning (same family as
+  // F27, pointed the other way: there a draft reached the WRONG customer, here it is simply
+  // thrown away). So when there is work in the composer, the switch re-filters the list and
+  // leaves the thread and the draft alone. When there isn't, behaviour is exactly as before —
+  // deliberately, so this does not quietly become "the thread never closes".
+  const switchScope = (applyFilter) => {
+    const keepThread = composerHasUnsavedContent();
+    applyFilter();
+    if (!keepThread) clearSelection();
+    sinceRef.current = null;
+  };
+
   const switchBucket = (next) => {
     if (next === bucket) return;
-    setBucket(next);
-    clearSelection();
-    sinceRef.current = null;
+    switchScope(() => setBucket(next));
   };
 
   const switchStatus = (next) => {
     if (next === status) return;
-    setStatus(next);
-    clearSelection();
-    sinceRef.current = null;
+    switchScope(() => setStatus(next));
   };
 
   const openConversation = (c) => {
@@ -1109,6 +1149,23 @@ export default function Inbox() {
 
               {selectedId && (
                 <>
+                  {/* F31 — say so when the open thread is not in the filtered list. Two problems
+                      it solves: on a phone the list is hidden while a thread is open, so a
+                      filter tap would otherwise produce NO visible change at all and read as a
+                      broken control; and on any screen the reading pane and the list beside it
+                      now disagree, with nothing to explain why. */}
+                  {selectedOutsideFilter && (
+                    <div className="px-4 py-2 text-xs bg-amber-50 border-b border-amber-200 text-amber-900 flex items-center justify-between gap-3">
+                      <span>Kept open — this conversation isn’t in the current view. Your draft is safe.</span>
+                      <button
+                        type="button"
+                        onClick={clearSelection}
+                        className="shrink-0 font-semibold underline hover:no-underline"
+                      >
+                        Show the list
+                      </button>
+                    </div>
+                  )}
                   <header className="px-4 py-3 border-b border-gray-200 flex items-center gap-3">
                     <button
                       type="button"


### PR DESCRIPTION
## The bug (live on Production)

`switchBucket` and `switchStatus` both called `clearSelection()`, which calls `resetComposerState()` **unconditionally**. So a rep with a half-typed reply who taps **Closed**, or moves from **Assigned to You** to **All**, loses it — no warning, no undo, no way back.

Same family as F27, pointed the other way: F27 was a draft reaching the **wrong customer**; this is a draft simply being **destroyed**. F27 deliberately left it alone.

## The fix

**A filter is about the LIST, not about the open thread.** Clearing the reading pane alongside it was only ever justified because it was cheap — and it is not cheap when it throws away work.

- **`switchScope()`** — when the composer holds work (trimmed text **or attachments**), the switch re-filters the list and leaves the thread and composer untouched. When the composer is empty, behaviour is **exactly as before**; a test pins that, so this cannot quietly become "the thread never closes".
- **The header now says when the open thread is outside the current view** — *"Kept open — this conversation isn't in the current view. Your draft is safe."* — with a **Show the list** action.
- **`pollNow` tops up a thread that is outside the polled scope.**

The last two are not polish; they are the code review's findings, and both were real:

> **Below `md`, an open thread hides the conversation list entirely** (`aside … hidden md:flex`). On a phone, tapping a filter with a dirty composer produced **no visible change whatsoever** — the list re-fetched behind a hidden pane. The rep taps again, and again. Before this change the same tap cleared the selection and revealed the re-filtered list, so the control was self-evidently working.

> **The 8s poll is scoped by `bucket`/`status`**, so a kept thread can never appear in its payload — `loadThread` never fires for it. The rep sits in a live conversation composing a reply while **inbound messages silently stop arriving**. No error, no spinner. (The deep-link and post-compose paths could already reach this state; F31 made it one click away on the most-used control on the page, so it was fixed rather than inherited.)

## Verification

- **61 component tests** (4 suites), **19/19 smoke suites**, `CI=true npm run build` clean. Bundle `main.611aa85d.js` **165.94 kB (+150 B)**.
- **Mutation testing: 13 mutants, 0 survivors** — including the three the review proved survived my first round.

## Code review — the design choice was attacked, not just the code

I asked the reviewer to attack the *choice* ("keep when dirty, clear when clean") as well as the implementation. Their verdict was to keep it, on evidence from the file: the page **already** ships "a thread open that isn't in the list" in three places — `toggleConversationStatus` (which comments *"The thread stays open so it can be reopened"*), the funnel deep-link, and the post-compose path. So this generalises an existing state rather than inventing one. A confirm dialog on the hottest control in the page was the alternative, and it does nothing for the attachment case.

They also verified that **every action from the contradicted state behaves correctly** — `toggleConversationStatus`, `toggleAssignee`, `sendReply`, `sendNote` and `loadPanel` all key off `selectedId`/`selectedConv`, never off the filter — and that **F27 and F31 compose cleanly** (the F27 uid guard means the kept thread reappearing in the list and being re-clicked does *not* wipe the composer).

**Three mutants survived my first round; all now covered:**
- **both no-op guards (`if (next === bucket) return`) were deletable** with the suite green — my "re-clicking the current filter" test typed a draft first, which made the guard unfalsifiable. Now tested with an empty composer.
- **`switchStatus` could bypass `switchScope` entirely** (never clearing) — the empty-composer characterisation only ever clicked a *bucket*.
- **the poll top-up** was unprotected until a fake-timer test was added. That test also had to be rebuilt: the interval is created during mount, so switching to fake timers afterwards leaves a real timer that `advanceTimersByTime` can never fire — the first version passed on that technicality and proved nothing.

**The test mock was the deepest finding:** it returned the same conversation for every bucket/status, so filtering was a no-op and **the very state this feature creates never occurred in any test**. The mock is now filter-aware (Alice is open + assigned, so she is absent from `status=closed`), which is what makes the notice and poll tests meaningful.

**Refuted my own claim:** I had recorded the surviving `sinceRef.current = null` mutant as "unobservable, because `loadConversations` overwrites it". The reviewer showed that line is only reached on **success** — on a 401/403/non-ok/throw it returns first, so on a failed filter-change fetch the stale cursor from the previous scope survives. The line is not dead; it stays, and its failure path is noted as uncovered (no test exercises a failing conversations response).

**Recorded, not fixed (out of scope):** `clearSelection` also clears `woOpenId`/`woDetail` (F17 modal), `showAssign` and `needEmail`; when the thread is kept, those survive too. Defensible, but it is a behaviour change worth naming.

## Test it

1. Open the Preview → **Inbox** → open a conversation → type a few words (don't send).
2. Click **Closed**, or switch bucket to **All**. **Your draft and the thread are still there**, and an amber line explains the thread isn't in the current view.
3. Click **Show the list** → the thread closes and the filtered list is visible.
4. Repeat with an **empty** composer: the thread clears as it always did.
5. Attach a file with no text typed, then switch a filter — the attachment survives.
6. On a phone (or DevTools at 375px), repeat step 2: you now get an explanation instead of an apparently dead button.

## Reviewer checklist

- [ ] Is "keep when dirty, clear when clean" the behaviour you want, or would you rather it always kept the thread?
- [ ] The wording of the amber notice (customer-invisible, internal only).
- [ ] Nothing server-side changed; no new endpoints, no changed request shapes.
- [ ] The 6 `gray-on-color` contrast findings in `inbox.js` are backlog row **F30** and were deliberately **not** touched here.

Not merged by me. No changes to `main`, Production, or the production database.
