### PR TITLE
F30 - inbox text contrast: every pairing now meets WCAG AA

### DIFF
--- a/scripts/podium-contrast-smoke.mjs
+++ b/scripts/podium-contrast-smoke.mjs
@@ -1,32 +1,36 @@
 // scripts/podium-contrast-smoke.mjs — offline smoke for F30 (inbox text contrast).
 //
 // F30 was raised as "6 gray-on-color findings in src/pages/inbox.js" from a design-hook audit.
-// Re-deriving it found the real shape is bigger and simpler than six scattered spots: the inbox
-// uses `text-gray-400` as its de-emphasis token — timestamps, "Unassigned", panel headings,
-// empty states, modal close buttons — and at #9ca3af that token FAILS WCAG AA against every
-// surface it is used on. It is not a matter of taste, and this file exists so it is not argued
-// about by eye: the ratios below are computed from the real palette values with the real WCAG
-// formula, and the thresholds are the published ones.
+// Re-deriving it changed the finding twice over, and both corrections are the reason this file
+// computes ratios instead of describing them:
 //
-// Why it matters here specifically: the row that raised it says reps read this page "on the
-// warehouse floor" — high ambient light on a phone screen is the worst case for washed-out
-// grey, and the affected text includes the timestamps and assignment state they scan for.
+//   - ALL SIX HOOK FINDINGS ARE FALSE POSITIVES. Every one is a mutually-exclusive ternary
+//     (`cond ? 'bg-blue-500 text-white' : 'bg-white text-gray-700'`), so the grey never lands on
+//     the colour — the hook matches both branches of one className string. The same six were
+//     logged and dismissed during F4, so this file asserts the property that MAKES them false
+//     positives rather than dismissing them by eye a third time.
+//   - THE REAL DEFECTS WERE ADJACENT, LARGER, AND UNFLAGGED. `text-gray-400` was the page's
+//     de-emphasis token across 34 sites at 2.54:1 on white — and, found only by measuring after
+//     a code review corrected the surface, the outbound bubble's own white message text sat at
+//     3.68:1 on `bg-blue-500`. That is the actual conversation, failing worse than any grey.
 //
-// The remedy is one token step, `text-gray-400` -> `text-gray-500` (#6b7280), which clears AA on
-// both inbox surfaces while staying clearly de-emphasised against the gray-700/900 body text —
-// so the visual hierarchy the grey was there to express is preserved. Anything genuinely
-// decorative would need a documented exemption rather than a silent one.
+// Everything here is computed from the real Tailwind values with the real WCAG 2.1 formula, so
+// a palette change breaks the file loudly instead of silently invalidating its claims. Thresholds
+// are the published ones. Every affected site is text-[10px]/[11px]/xs/sm — none reaches the
+// large-text carve-out — so AA 4.5:1 applies throughout.
 //
-// WHAT THIS DOES NOT CLAIM: it checks the de-emphasis token against the two surfaces the inbox
-// actually paints (white panels, the gray-50 thread). It is not a full-page contrast audit — it
-// cannot see an element's real background, only the pairs asserted here, and it covers inbox.js
-// alone because that is F30's scope.
+// Why it matters here: the row that raised it says reps read this page "on the warehouse floor".
+// High ambient light on a phone is the worst case for washed-out text.
+//
+// WHAT THIS DOES NOT CLAIM: it reasons over palette values and source tokens. jsdom has no
+// layout or paint, so nothing here observes a rendered pixel. It models the four surfaces the
+// inbox actually paints; an element placed on some fifth surface is outside what it can see.
 //
 //   node scripts/podium-contrast-smoke.mjs
 
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 
 const ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..');
 const INBOX = join(ROOT, 'src', 'pages', 'inbox.js');
@@ -56,198 +60,251 @@ export function contrastRatio(fg, bg) {
   return (hi + 0.05) / (lo + 0.05);
 }
 
+// Tailwind 3.4 defaults (tailwind.config.js extends nothing), for every token this page pairs.
+export const PALETTE = {
+  white: '#ffffff',
+  'gray-50': '#f9fafb',
+  'gray-100': '#f3f4f6',
+  'gray-200': '#e5e7eb',
+  'gray-300': '#d1d5db',
+  'gray-400': '#9ca3af',
+  'gray-500': '#6b7280',
+  'gray-600': '#4b5563',
+  'gray-700': '#374151',
+  'gray-800': '#1f2937',
+  'gray-900': '#111827',
+  'blue-50': '#eff6ff',
+  'blue-100': '#dbeafe',
+  'blue-500': '#3b82f6',
+  'blue-600': '#2563eb',
+  'blue-700': '#1d4ed8',
+  'amber-50': '#fffbeb',
+  'amber-500': '#f59e0b',
+  'amber-600': '#d97706',
+  'amber-700': '#b45309',
+  'amber-900': '#78350f',
+  'green-700': '#15803d',
+  'green-800': '#166534',
+};
+
+const AA_NORMAL = 4.5; // WCAG 2.1 SC 1.4.3, normal-size text
+const round = (n) => Math.round(n * 100) / 100;
+const ratioOf = (fg, bg) => contrastRatio(PALETTE[fg], PALETTE[bg]);
+
+// The four surfaces the inbox actually paints text onto. The first version of this file listed
+// only the first two, and code review found two changed sites sitting below AA on the others —
+// so the list being COMPLETE is load-bearing, not decorative.
+const SURFACES = ['white', 'gray-50', 'gray-100', 'blue-50'];
+
 // ---------------------------------------------------------------------------
-// The source scanners (pure, so the fixtures below can falsify them)
+// The source scanner (pure, so the fixtures below can falsify it)
 // ---------------------------------------------------------------------------
 
-/** Strip comments, so prose about a token is never mistaken for a use of it. */
+/** Strip comments, preserving line count so reported line numbers stay true. */
 export function stripAside(src) {
-  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+  const blank = (m) => '\n'.repeat((m.match(/\n/g) || []).length);
+  return src.replace(/\/\*[\s\S]*?\*\//g, blank).replace(/^\s*\/\/.*$/gm, '');
 }
 
-/** Every use of a grey text token that fails AA on this page's surfaces. */
+/**
+ * Every string literal in the source, with the offset it started at.
+ *
+ * This is the unit that matters: in JSX, each branch of a ternary is its own literal, so tokens
+ * that share a literal are tokens that actually render together. Code review showed why the
+ * previous "nearest preceding bg- class" approach could not work — it was order-dependent
+ * (`text-gray-400 bg-blue-500` scored differently from the reverse) and blind to the multi-line
+ * template classNames that dominate this file, which is how it missed the outbound bubble.
+ */
+export function styleChunks(src) {
+  const chunks = [];
+  const re = /'([^'\n]*)'|"([^"\n]*)"|`([^`]*)`/g;
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    const body = m[1] ?? m[2] ?? m[3] ?? '';
+    // Inside a template literal, each ${…} is its own scope — its contents are separate
+    // literals which this same pass picks up, so blank them out here.
+    chunks.push({ text: body.replace(/\$\{[\s\S]*?\}/g, ' '), index: m.index });
+  }
+  return chunks;
+}
+
+/**
+ * Text/background pairs that share a literal and fail AA.
+ * Resolving both tokens through the palette — rather than allowlisting "light-looking" colour
+ * names — is what lets this see any hue, and stops it flagging pairings that actually pass
+ * (`bg-amber-50 text-gray-500` is 4.66:1 and is not a defect).
+ */
+export function failingPairs(src, { allow = [] } = {}) {
+  const stripped = stripAside(src);
+  const offenders = [];
+  for (const chunk of styleChunks(stripped)) {
+    const bg = (chunk.text.match(/\bbg-([a-z]+-\d00|white)\b/) || [])[1];
+    if (!bg || !PALETTE[bg]) continue;
+    for (const m of chunk.text.matchAll(/\btext-([a-z]+-\d00|white)\b/g)) {
+      const fg = m[1];
+      if (!PALETTE[fg]) continue;
+      const ratio = contrastRatio(PALETTE[fg], PALETTE[bg]);
+      if (ratio >= AA_NORMAL) continue;
+      const pair = `text-${fg} on bg-${bg}`;
+      if (allow.includes(pair)) continue;
+      offenders.push(`line ${stripped.slice(0, chunk.index).split('\n').length}: ${pair} (${round(ratio)}:1)`);
+    }
+  }
+  return offenders;
+}
+
+/** Uses of a grey text token that fails AA on every surface this page paints. */
 export function failingGreysIn(src) {
   const stripped = stripAside(src);
   const found = [];
-  const re = /text-gray-(400|300)\b/g;
-  let m;
-  while ((m = re.exec(stripped)) !== null) {
+  for (const m of stripped.matchAll(/\btext-(?:gray|slate|zinc|neutral)-(\d00)\b/g)) {
+    const token = m[0].replace('text-', '');
+    const hex = PALETTE[token];
+    // Unknown token, or one that clears AA somewhere it could legitimately sit: not a finding.
+    if (hex && SURFACES.some((s) => contrastRatio(hex, PALETTE[s]) >= AA_NORMAL)) continue;
     found.push(`${m[0]} at line ${stripped.slice(0, m.index).split('\n').length}`);
   }
   return found;
 }
 
 /**
- * Grey text whose nearest preceding background class — i.e. the one in its own ternary branch —
- * is a COLOURED one. This is the property that makes the design hook's six "gray-on-color"
- * findings false positives, expressed as something checkable rather than a judgement call.
+ * Pairs left failing ON PURPOSE would go here, each with the row that will fix it — listed
+ * rather than silently skipped, so an exemption cannot grow without an edit to this line.
+ *
+ * It is deliberately EMPTY. The palette-resolving scanner found two more real failures that the
+ * earlier name-matching one structurally could not see — every primary button (`bg-blue-500` +
+ * white = 3.68:1) and the internal-note controls (`bg-amber-500` + white = **2.15:1**, the worst
+ * pairing on the page) — and an exemption list holding the page's own buttons would have made
+ * the guard's headline claim meaningless. They were darkened instead: blue-600 (5.17) and
+ * amber-700 (5.02), hovers one step further.
  */
-export function greyOnColourIn(src) {
-  const stripped = stripAside(src);
-  const offenders = [];
-  const re = /text-gray-\d00\b/g;
-  let m;
-  while ((m = re.exec(stripped)) !== null) {
-    const before = stripped.slice(0, m.index);
-    const bgs = before.match(/bg-[a-z]+(-\d00)?(\/\d+)?/g);
-    if (!bgs) continue;
-    const nearest = bgs[bgs.length - 1];
-    // Only a background in the same className string can be the grey's own background.
-    if (/\n/.test(before.slice(before.lastIndexOf(nearest)))) continue;
-    if (!/^bg-(white|gray|slate|neutral)/.test(nearest)) {
-      offenders.push(`line ${before.split('\n').length}: ${nearest} + ${m[0]}`);
-    }
-  }
-  return offenders;
-}
+const KNOWN_FAILING = [];
 
-// Tailwind's default palette, for the tokens this page uses.
-const PALETTE = {
-  white: '#ffffff',
-  'gray-50': '#f9fafb',
-  'gray-300': '#d1d5db',
-  'gray-400': '#9ca3af',
-  'gray-500': '#6b7280',
-  'gray-700': '#374151',
-  'gray-900': '#111827',
-  'blue-50': '#eff6ff',
-  'blue-100': '#dbeafe',
-  'blue-600': '#2563eb',
-};
+function main() {
+  console.log('F30 inbox contrast smoke — pure, no DOM, no network\n');
 
-const AA_NORMAL = 4.5; // WCAG 2.1 1.4.3, normal-size text
-const round = (n) => Math.round(n * 100) / 100;
-
-// The two surfaces the inbox paints de-emphasised text onto.
-const SURFACES = ['white', 'gray-50'];
-
-console.log('F30 inbox contrast smoke — pure, no DOM, no network\n');
-
-console.log('the contrast formula itself (known values):');
-{
-  check('black on white is 21:1', round(contrastRatio('#000000', '#ffffff')) === 21);
-  check('white on white is 1:1', round(contrastRatio('#ffffff', '#ffffff')) === 1);
-  check('it is symmetric', round(contrastRatio('#9ca3af', '#ffffff')) === round(contrastRatio('#ffffff', '#9ca3af')));
-  // A published reference point: #767676 is the canonical "smallest grey that passes AA on white".
-  check('#767676 on white clears AA (the canonical boundary grey)', contrastRatio('#767676', '#ffffff') >= AA_NORMAL);
-  // The sRGB curve has a LINEAR segment below 0.03928 that none of the palette colours reach,
-  // so breaking it was invisible to every other check here (a surviving mutant). #050505 sits
-  // inside that segment: 5/255 = 0.0196 -> /12.92 = 0.001517, and the channel weights sum to 1.
-  check(
-    'the linear segment of the sRGB curve is implemented, not just the power one',
-    Math.abs(relativeLuminance('#050505') - (5 / 255 / 12.92)) < 1e-9,
-  );
-  check('#777777 … and one step lighter does not', contrastRatio('#797979', '#ffffff') < AA_NORMAL);
-}
-
-console.log('\nwhy the old token had to change — measured, not asserted:');
-{
-  for (const surface of SURFACES) {
-    const ratio = contrastRatio(PALETTE['gray-400'], PALETTE[surface]);
+  console.log('the contrast formula itself (known values):');
+  {
+    check('black on white is 21:1', round(contrastRatio('#000000', '#ffffff')) === 21);
+    check('white on white is 1:1', round(contrastRatio('#ffffff', '#ffffff')) === 1);
+    check('it is symmetric', round(contrastRatio('#9ca3af', '#ffffff')) === round(contrastRatio('#ffffff', '#9ca3af')));
+    check('#767676 on white clears AA (the canonical boundary grey)', contrastRatio('#767676', '#ffffff') >= AA_NORMAL);
+    check('#797979 — one step lighter — does not', contrastRatio('#797979', '#ffffff') < AA_NORMAL);
+    // The sRGB curve has a LINEAR segment below 0.03928 that no palette colour reaches, so
+    // breaking it was invisible to every other check here (a surviving mutant). #050505 is
+    // inside it: 5/255 = 0.0196 -> /12.92, and the channel weights sum to 1.
     check(
-      `text-gray-400 on ${surface} FAILS AA (${round(ratio)}:1 < ${AA_NORMAL})`,
-      ratio < AA_NORMAL,
-      'if this ever passes, the palette moved and this whole file needs re-deriving',
+      'the linear segment of the sRGB curve is implemented, not just the power one',
+      Math.abs(relativeLuminance('#050505') - (5 / 255 / 12.92)) < 1e-9,
     );
   }
-  check('text-gray-300 would be worse still', contrastRatio(PALETTE['gray-300'], PALETTE.white) < contrastRatio(PALETTE['gray-400'], PALETTE.white));
-}
 
-console.log('\nthe replacement token clears AA on every surface the inbox paints:');
-{
-  for (const surface of SURFACES) {
-    const ratio = contrastRatio(PALETTE['gray-500'], PALETTE[surface]);
-    check(`text-gray-500 on ${surface} passes AA (${round(ratio)}:1)`, ratio >= AA_NORMAL);
+  console.log('\nwhy the old tokens had to change — measured, not asserted:');
+  {
+    for (const surface of ['white', 'gray-50']) {
+      check(`text-gray-400 on ${surface} FAILS AA (${round(ratioOf('gray-400', surface))}:1)`, ratioOf('gray-400', surface) < AA_NORMAL);
+    }
+    // Found only after code review corrected the surface: the bubble is bg-blue-500, not -600.
+    check(`the old bubble put its own white message text at ${round(ratioOf('white', 'blue-500'))}:1`, ratioOf('white', 'blue-500') < AA_NORMAL);
+    check(`text-blue-100 on the old bubble was ${round(ratioOf('blue-100', 'blue-500'))}:1`, ratioOf('blue-100', 'blue-500') < AA_NORMAL);
   }
-  check(
-    'and it is still clearly de-emphasised against body text',
-    contrastRatio(PALETTE['gray-500'], PALETTE.white) < contrastRatio(PALETTE['gray-700'], PALETTE.white),
-    'the grey exists to express hierarchy — a fix that flattens it is not a fix',
-  );
+
+  console.log('\nthe replacement tokens clear AA on the surfaces they are used on:');
+  {
+    for (const surface of ['white', 'gray-50']) {
+      check(`text-gray-500 on ${surface} passes (${round(ratioOf('gray-500', surface))}:1)`, ratioOf('gray-500', surface) >= AA_NORMAL);
+    }
+    // gray-500 does NOT clear the other two surfaces — which is exactly why the sites sitting on
+    // them use gray-600. Asserting the failure keeps that decision from looking arbitrary.
+    for (const surface of ['gray-100', 'blue-50']) {
+      check(`text-gray-500 would FAIL on ${surface} (${round(ratioOf('gray-500', surface))}:1) — hence gray-600 there`, ratioOf('gray-500', surface) < AA_NORMAL);
+      check(`text-gray-600 on ${surface} passes (${round(ratioOf('gray-600', surface))}:1)`, ratioOf('gray-600', surface) >= AA_NORMAL);
+    }
+    check('the darkened bubble carries its white text at 5.17:1', ratioOf('white', 'blue-600') >= AA_NORMAL);
+    check(`text-blue-50 on the darkened bubble passes (${round(ratioOf('blue-50', 'blue-600'))}:1)`, ratioOf('blue-50', 'blue-600') >= AA_NORMAL);
+    check('… and stays de-emphasised against the bubble’s own body text', ratioOf('blue-50', 'blue-600') < ratioOf('white', 'blue-600'));
+    check(`the attachment chip’s white label passes on bg-blue-700 (${round(ratioOf('white', 'blue-700'))}:1)`, ratioOf('white', 'blue-700') >= AA_NORMAL);
+    check('de-emphasis is still de-emphasis, not body text', ratioOf('gray-500', 'white') < ratioOf('gray-700', 'white'));
+  }
+
+  console.log('\nthe conversation row reads on BOTH of its surfaces (white, and blue-50 when selected):');
+  {
+    // The first fix made "Unassigned" the faintest text on the row — the one state a rep hunts
+    // for — and collided it with the timestamp. Colour now carries the meaning instead of weight.
+    for (const surface of ['white', 'blue-50']) {
+      check(`Unassigned (amber-700) passes on ${surface} (${round(ratioOf('amber-700', surface))}:1)`, ratioOf('amber-700', surface) >= AA_NORMAL);
+      check(`You (green-700) passes on ${surface} (${round(ratioOf('green-700', surface))}:1)`, ratioOf('green-700', surface) >= AA_NORMAL);
+      check(`Assigned (gray-600) passes on ${surface} (${round(ratioOf('gray-600', surface))}:1)`, ratioOf('gray-600', surface) >= AA_NORMAL);
+    }
+    check('Unassigned is not the same colour as the timestamp beside it', PALETTE['amber-700'] !== PALETTE['gray-600']);
+  }
+
+  console.log('\nthe scanners find what they are supposed to find (fixtures):');
+  {
+    // Mutation testing showed why these exist: with the repo already fixed every scan runs over
+    // clean input, so deleting a RECORDER left the whole file green.
+    check('the pair scanner reports a real failing pairing', failingPairs("className={'bg-blue-500 text-white'}").length === 1);
+    check('… regardless of token order', failingPairs("className={'text-white bg-blue-500'}").length === 1);
+    check('… across a multi-line className', failingPairs('className={`bg-blue-500 rounded\n  text-white px-2`}').length === 1);
+    check('… and accepts the ternary shape that made F30 a false alarm',
+      failingPairs("className={on ? 'bg-blue-600 text-white' : 'bg-white text-gray-700'}").length === 0,
+      'the grey lives in the other branch from the colour and never renders on it');
+    check('… while still judging each branch on its own merits',
+      failingPairs("className={on ? 'bg-blue-600 text-white' : 'bg-white text-gray-400'}").length === 1,
+      'a failing branch must not be excused by a passing sibling');
+    check('… does not flag a pairing that actually passes (bg-amber-50 + gray-500 = 4.66:1)',
+      failingPairs("className={'bg-amber-50 text-gray-500'}").length === 0);
+    // The allowlist mechanism is kept (and tested) even though nothing uses it today, so a
+    // future deliberate exemption is a one-line, reviewable edit rather than a new mechanism.
+    check('… and honours an allowlist when one is given',
+      failingPairs("className={'bg-blue-500 text-white'}", { allow: ['text-white on bg-blue-500'] }).length === 0);
+
+    check('the failing-grey scan reports a gray-400', failingGreysIn('<div className="text-gray-400" />').length === 1);
+    check('… and its slate/zinc/neutral cousins', failingGreysIn('text-slate-400 text-zinc-400 text-neutral-400').length === 3);
+    check('… and is silent on the replacement token', failingGreysIn('<div className="text-gray-500" />').length === 0);
+    check('… ignores a mention inside a line comment', failingGreysIn('// was text-gray-400 before\n').length === 0);
+    check('… and inside a block comment', failingGreysIn('/* was text-gray-400 */').length === 0);
+    check('the hover form is caught too', failingGreysIn('hover:text-gray-400').length === 1);
+    check(
+      'stripping comments does not shift reported line numbers',
+      failingGreysIn('/* a\nb\nc */\ntext-gray-400')[0].endsWith('line 4'),
+      'a diagnostic that points at the wrong line sends someone hunting',
+    );
+  }
+
+  console.log('\nthe inbox itself:');
+  {
+    const src = readFileSync(INBOX, 'utf8');
+
+    const greys = failingGreysIn(src);
+    check('no sub-AA grey text token remains', greys.length === 0, `\n    ${greys.join('\n    ')}`);
+    check('no sub-AA blue text token remains', !/text-blue-100\b/.test(stripAside(src)));
+
+    const pairs = failingPairs(src, { allow: KNOWN_FAILING });
+    check('NO text/background pairing in the inbox fails AA', pairs.length === 0, `\n    ${pairs.join('\n    ')}`);
+    check('… and that claim is unconditional — nothing is exempted', KNOWN_FAILING.length === 0);
+    check('the old CTA surfaces are gone', !/\bbg-(blue|amber)-500\b/.test(stripAside(src)));
+
+    // Guard the guard: had the de-emphasis styling been deleted rather than darkened, every
+    // check above would also pass. Code review pointed out the earlier floor was unfalsifiable,
+    // and that the real property is a conservation law rather than a threshold — the tokens are
+    // accounted for exactly, so any change to the count has to be a deliberate edit here.
+    const stripped = stripAside(src);
+    const g500 = (stripped.match(/text-gray-500\b/g) || []).length;
+    const g600 = (stripped.match(/text-gray-600\b/g) || []).length;
+    check(
+      `the de-emphasis tokens are all accounted for (${g500} × gray-500 + ${g600} × gray-600 = ${g500 + g600})`,
+      g500 + g600 === 60,
+      'main had 34 gray-400 + 20 gray-500 + 8 gray-600 = 62 de-emphasised sites. Two were ' +
+        'deliberately PROMOTED out of the de-emphasis band and are pinned by their own checks ' +
+        'above — the funnel note to gray-700, and Unassigned to amber-700 — leaving 60. An exact ' +
+        'count rather than a floor, because a floor is unfalsifiable: code review showed >= 40 ' +
+        'survived being mutated to >= 0. Any change here should be a deliberate edit with a diff.',
+    );
+  }
+
+  console.log(`\n✅ contrast smoke: ${passed} checks passed`);
 }
 
-console.log('\nthe outbound bubble — the one the old audit called a false positive, and it was not:');
-{
-  // The timestamp inside a sent message is `outbound ? text-blue-100 : text-gray-400`. The two
-  // branches are mutually exclusive, so the GREY never lands on the blue — that part of the old
-  // "gray-on-color" reading really was a false positive. But measuring the branch that does
-  // render showed the pairing fails anyway, on its own terms and for a different reason.
-  const before = contrastRatio(PALETTE['blue-100'], PALETTE['blue-600']);
-  check(
-    `text-blue-100 on bg-blue-600 FAILS AA too (${round(before)}:1)`,
-    before < AA_NORMAL,
-    'assumed to be fine when this file was written; the formula disagreed',
-  );
-
-  const after = contrastRatio(PALETTE['blue-50'], PALETTE['blue-600']);
-  check(`text-blue-50 on bg-blue-600 passes (${round(after)}:1)`, after >= AA_NORMAL);
-  check(
-    'and stays de-emphasised against the bubble’s own white body text',
-    after < contrastRatio(PALETTE.white, PALETTE['blue-600']),
-  );
-
-  check('no sub-AA blue text token remains in inbox.js', !/text-blue-100\b/.test(readFileSync(INBOX, 'utf8')));
-}
-
-console.log('\nthe scanners find what they are supposed to find (fixtures):');
-{
-  // Mutation testing showed why these fixtures exist: with the repo already fixed, every scan
-  // below runs over clean input, so deleting its RECORDER left the whole file green. A scanner
-  // is only falsifiable against input that contains the thing it looks for.
-  check('the failing-token scan reports a gray-400', failingGreysIn('<div className="text-gray-400" />').length === 1);
-  check('… and a gray-300', failingGreysIn('<div className="text-gray-300" />').length === 1);
-  check('… reports each occurrence', failingGreysIn('text-gray-400 text-gray-400 text-gray-300').length === 3);
-  check('… and is silent on the replacement token', failingGreysIn('<div className="text-gray-500" />').length === 0);
-  check('… and ignores a mention inside a comment', failingGreysIn('// was text-gray-400 before\n').length === 0);
-  check('the hover form is caught too', failingGreysIn('hover:text-gray-400').length === 1);
-
-  check('the grey-on-colour scan reports a real pairing', greyOnColourIn("className={'bg-blue-500 text-gray-700'}").length === 1);
-  check('… and accepts the ternary shape that made F30 a false alarm',
-    greyOnColourIn("className={on ? 'bg-blue-500 text-white' : 'bg-white text-gray-700'}").length === 0);
-  check('… and accepts a light-grey background', greyOnColourIn("className={'bg-gray-100 text-gray-700'}").length === 0);
-}
-
-console.log('\nthe inbox no longer ships the failing token:');
-{
-  const src = readFileSync(INBOX, 'utf8');
-  const failing = failingGreysIn(src);
-  check('no sub-AA grey text token remains in inbox.js', failing.length === 0, `\n    ${failing.join('\n    ')}`);
-
-  // Guard the guard: if the de-emphasis styling vanished altogether the check above would also
-  // pass, and the page would have lost its hierarchy instead of gaining contrast. This is a
-  // smoke alarm for wholesale deletion, not a precise contract — the floor is deliberately well
-  // below the 51 sites present when it was written.
-  const replacements = (stripAside(src).match(/text-gray-500\b/g) || []).length;
-  check(`the de-emphasis token is still in use (${replacements} occurrences)`, replacements >= 40, 'did the greys get deleted rather than darkened?');
-}
-
-console.log('\nthe two places where the hierarchy had to be restored downward, not upward:');
-{
-  const src = readFileSync(INBOX, 'utf8');
-  // Raising the failing grey one step would have collided with text that renders BESIDE it.
-  // These two are the only such pairs in the file, and both are pinned so a later bulk
-  // find-and-replace cannot quietly flatten them again.
-  check(
-    'the conversation list still distinguishes Unassigned from Assigned',
-    /'Unassigned', cls: 'text-gray-500'/.test(src) && /'Assigned', cls: 'text-gray-700'/.test(src),
-    'these labels sit side by side down the list — identical greys remove the scanning cue',
-  );
-  check(
-    'funnel history still distinguishes the note from its timestamp',
-    /text-\[11px\] text-gray-700 break-words/.test(src),
-    'note and timestamp render on the same row',
-  );
-}
-
-console.log('\nthe design hook’s "gray-on-color" findings are ternaries — checked, not assumed:');
-{
-  // F30 was raised from a design-hook audit reporting 6 gray-on-color findings. Every one is a
-  // MUTUALLY-EXCLUSIVE ternary — `cond ? 'bg-blue-500 text-white' : 'bg-white text-gray-700'` —
-  // so the grey never lands on the colour; the hook matches both branches of one string. The
-  // same finding was logged and dismissed during F4, so rather than dismiss it a third time by
-  // eye, this asserts the property that makes it a false positive.
-  const offenders = greyOnColourIn(readFileSync(INBOX, 'utf8'));
-  check('no grey text sits on a coloured background', offenders.length === 0, `\n    ${offenders.join('\n    ')}`);
-}
-
-console.log(`\n✅ contrast smoke: ${passed} checks passed`);
+// Only run the suite when executed directly, so the pure helpers above can be imported.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) main();

--- a/scripts/podium-contrast-smoke.mjs
+++ b/scripts/podium-contrast-smoke.mjs
@@ -56,6 +56,51 @@ export function contrastRatio(fg, bg) {
   return (hi + 0.05) / (lo + 0.05);
 }
 
+// ---------------------------------------------------------------------------
+// The source scanners (pure, so the fixtures below can falsify them)
+// ---------------------------------------------------------------------------
+
+/** Strip comments, so prose about a token is never mistaken for a use of it. */
+export function stripAside(src) {
+  return src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+}
+
+/** Every use of a grey text token that fails AA on this page's surfaces. */
+export function failingGreysIn(src) {
+  const stripped = stripAside(src);
+  const found = [];
+  const re = /text-gray-(400|300)\b/g;
+  let m;
+  while ((m = re.exec(stripped)) !== null) {
+    found.push(`${m[0]} at line ${stripped.slice(0, m.index).split('\n').length}`);
+  }
+  return found;
+}
+
+/**
+ * Grey text whose nearest preceding background class — i.e. the one in its own ternary branch —
+ * is a COLOURED one. This is the property that makes the design hook's six "gray-on-color"
+ * findings false positives, expressed as something checkable rather than a judgement call.
+ */
+export function greyOnColourIn(src) {
+  const stripped = stripAside(src);
+  const offenders = [];
+  const re = /text-gray-\d00\b/g;
+  let m;
+  while ((m = re.exec(stripped)) !== null) {
+    const before = stripped.slice(0, m.index);
+    const bgs = before.match(/bg-[a-z]+(-\d00)?(\/\d+)?/g);
+    if (!bgs) continue;
+    const nearest = bgs[bgs.length - 1];
+    // Only a background in the same className string can be the grey's own background.
+    if (/\n/.test(before.slice(before.lastIndexOf(nearest)))) continue;
+    if (!/^bg-(white|gray|slate|neutral)/.test(nearest)) {
+      offenders.push(`line ${before.split('\n').length}: ${nearest} + ${m[0]}`);
+    }
+  }
+  return offenders;
+}
+
 // Tailwind's default palette, for the tokens this page uses.
 const PALETTE = {
   white: '#ffffff',
@@ -85,6 +130,13 @@ console.log('the contrast formula itself (known values):');
   check('it is symmetric', round(contrastRatio('#9ca3af', '#ffffff')) === round(contrastRatio('#ffffff', '#9ca3af')));
   // A published reference point: #767676 is the canonical "smallest grey that passes AA on white".
   check('#767676 on white clears AA (the canonical boundary grey)', contrastRatio('#767676', '#ffffff') >= AA_NORMAL);
+  // The sRGB curve has a LINEAR segment below 0.03928 that none of the palette colours reach,
+  // so breaking it was invisible to every other check here (a surviving mutant). #050505 sits
+  // inside that segment: 5/255 = 0.0196 -> /12.92 = 0.001517, and the channel weights sum to 1.
+  check(
+    'the linear segment of the sRGB curve is implemented, not just the power one',
+    Math.abs(relativeLuminance('#050505') - (5 / 255 / 12.92)) < 1e-9,
+  );
   check('#777777 … and one step lighter does not', contrastRatio('#797979', '#ffffff') < AA_NORMAL);
 }
 
@@ -137,28 +189,36 @@ console.log('\nthe outbound bubble — the one the old audit called a false posi
   check('no sub-AA blue text token remains in inbox.js', !/text-blue-100\b/.test(readFileSync(INBOX, 'utf8')));
 }
 
+console.log('\nthe scanners find what they are supposed to find (fixtures):');
+{
+  // Mutation testing showed why these fixtures exist: with the repo already fixed, every scan
+  // below runs over clean input, so deleting its RECORDER left the whole file green. A scanner
+  // is only falsifiable against input that contains the thing it looks for.
+  check('the failing-token scan reports a gray-400', failingGreysIn('<div className="text-gray-400" />').length === 1);
+  check('… and a gray-300', failingGreysIn('<div className="text-gray-300" />').length === 1);
+  check('… reports each occurrence', failingGreysIn('text-gray-400 text-gray-400 text-gray-300').length === 3);
+  check('… and is silent on the replacement token', failingGreysIn('<div className="text-gray-500" />').length === 0);
+  check('… and ignores a mention inside a comment', failingGreysIn('// was text-gray-400 before\n').length === 0);
+  check('the hover form is caught too', failingGreysIn('hover:text-gray-400').length === 1);
+
+  check('the grey-on-colour scan reports a real pairing', greyOnColourIn("className={'bg-blue-500 text-gray-700'}").length === 1);
+  check('… and accepts the ternary shape that made F30 a false alarm',
+    greyOnColourIn("className={on ? 'bg-blue-500 text-white' : 'bg-white text-gray-700'}").length === 0);
+  check('… and accepts a light-grey background', greyOnColourIn("className={'bg-gray-100 text-gray-700'}").length === 0);
+}
+
 console.log('\nthe inbox no longer ships the failing token:');
 {
   const src = readFileSync(INBOX, 'utf8');
-  const stripped = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
-
-  const failing = [];
-  for (const token of ['gray-400', 'gray-300']) {
-    const re = new RegExp(`text-${token}\\b`, 'g');
-    let m;
-    while ((m = re.exec(stripped)) !== null) {
-      failing.push(`text-${token} at line ${stripped.slice(0, m.index).split('\n').length}`);
-    }
-  }
+  const failing = failingGreysIn(src);
   check('no sub-AA grey text token remains in inbox.js', failing.length === 0, `\n    ${failing.join('\n    ')}`);
 
   // Guard the guard: if the de-emphasis styling vanished altogether the check above would also
-  // pass, and the page would have lost its hierarchy instead of gaining contrast.
-  const replacements = (stripped.match(/text-gray-500\b/g) || []).length;
-  check(`the de-emphasis token is still in use (${replacements} occurrences)`, replacements >= 25, 'did the greys get deleted rather than darkened?');
-
-  // hover:text-gray-400 would reintroduce it on interaction.
-  check('no hover state drops back to the failing token', !/hover:text-gray-[34]00\b/.test(stripped));
+  // pass, and the page would have lost its hierarchy instead of gaining contrast. This is a
+  // smoke alarm for wholesale deletion, not a precise contract — the floor is deliberately well
+  // below the 51 sites present when it was written.
+  const replacements = (stripAside(src).match(/text-gray-500\b/g) || []).length;
+  check(`the de-emphasis token is still in use (${replacements} occurrences)`, replacements >= 40, 'did the greys get deleted rather than darkened?');
 }
 
 console.log('\nthe two places where the hierarchy had to be restored downward, not upward:');
@@ -185,23 +245,8 @@ console.log('\nthe design hook’s "gray-on-color" findings are ternaries — ch
   // MUTUALLY-EXCLUSIVE ternary — `cond ? 'bg-blue-500 text-white' : 'bg-white text-gray-700'` —
   // so the grey never lands on the colour; the hook matches both branches of one string. The
   // same finding was logged and dismissed during F4, so rather than dismiss it a third time by
-  // eye, this asserts the property that makes it a false positive: the nearest background class
-  // preceding each grey token is a LIGHT one. A genuine gray-on-colour would fail here.
-  const src = readFileSync(INBOX, 'utf8');
-  const offenders = [];
-  const re = /text-gray-\d00\b/g;
-  let m;
-  while ((m = re.exec(src)) !== null) {
-    const before = src.slice(0, m.index);
-    const bg = before.match(/bg-[a-z]+(-\d00)?(\/\d+)?(?![\s\S]*bg-)/);
-    if (!bg) continue;
-    // Only consider a background in the same className string.
-    const sameString = !/[\n]/.test(before.slice(bg.index));
-    if (!sameString) continue;
-    if (!/^bg-(white|gray|slate|neutral)/.test(bg[0])) {
-      offenders.push(`line ${before.split('\n').length}: ${bg[0]} + ${m[0]}`);
-    }
-  }
+  // eye, this asserts the property that makes it a false positive.
+  const offenders = greyOnColourIn(readFileSync(INBOX, 'utf8'));
   check('no grey text sits on a coloured background', offenders.length === 0, `\n    ${offenders.join('\n    ')}`);
 }
 

--- a/scripts/podium-contrast-smoke.mjs
+++ b/scripts/podium-contrast-smoke.mjs
@@ -1,0 +1,208 @@
+// scripts/podium-contrast-smoke.mjs — offline smoke for F30 (inbox text contrast).
+//
+// F30 was raised as "6 gray-on-color findings in src/pages/inbox.js" from a design-hook audit.
+// Re-deriving it found the real shape is bigger and simpler than six scattered spots: the inbox
+// uses `text-gray-400` as its de-emphasis token — timestamps, "Unassigned", panel headings,
+// empty states, modal close buttons — and at #9ca3af that token FAILS WCAG AA against every
+// surface it is used on. It is not a matter of taste, and this file exists so it is not argued
+// about by eye: the ratios below are computed from the real palette values with the real WCAG
+// formula, and the thresholds are the published ones.
+//
+// Why it matters here specifically: the row that raised it says reps read this page "on the
+// warehouse floor" — high ambient light on a phone screen is the worst case for washed-out
+// grey, and the affected text includes the timestamps and assignment state they scan for.
+//
+// The remedy is one token step, `text-gray-400` -> `text-gray-500` (#6b7280), which clears AA on
+// both inbox surfaces while staying clearly de-emphasised against the gray-700/900 body text —
+// so the visual hierarchy the grey was there to express is preserved. Anything genuinely
+// decorative would need a documented exemption rather than a silent one.
+//
+// WHAT THIS DOES NOT CLAIM: it checks the de-emphasis token against the two surfaces the inbox
+// actually paints (white panels, the gray-50 thread). It is not a full-page contrast audit — it
+// cannot see an element's real background, only the pairs asserted here, and it covers inbox.js
+// alone because that is F30's scope.
+//
+//   node scripts/podium-contrast-smoke.mjs
+
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = join(fileURLToPath(new URL('.', import.meta.url)), '..');
+const INBOX = join(ROOT, 'src', 'pages', 'inbox.js');
+
+let passed = 0;
+function check(name, cond, detail) {
+  if (!cond) throw new Error(`FAIL: ${name}${detail ? ` — ${detail}` : ''}`);
+  passed += 1;
+  console.log(`  ✓ ${name}`);
+}
+
+// ---------------------------------------------------------------------------
+// WCAG 2.1 contrast (pure)
+// ---------------------------------------------------------------------------
+
+export function relativeLuminance(hex) {
+  const h = hex.replace('#', '');
+  const channels = [0, 2, 4].map((i) => parseInt(h.slice(i, i + 2), 16) / 255);
+  const [r, g, b] = channels.map((c) => (c <= 0.03928 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4));
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+export function contrastRatio(fg, bg) {
+  const a = relativeLuminance(fg);
+  const b = relativeLuminance(bg);
+  const [hi, lo] = a > b ? [a, b] : [b, a];
+  return (hi + 0.05) / (lo + 0.05);
+}
+
+// Tailwind's default palette, for the tokens this page uses.
+const PALETTE = {
+  white: '#ffffff',
+  'gray-50': '#f9fafb',
+  'gray-300': '#d1d5db',
+  'gray-400': '#9ca3af',
+  'gray-500': '#6b7280',
+  'gray-700': '#374151',
+  'gray-900': '#111827',
+  'blue-50': '#eff6ff',
+  'blue-100': '#dbeafe',
+  'blue-600': '#2563eb',
+};
+
+const AA_NORMAL = 4.5; // WCAG 2.1 1.4.3, normal-size text
+const round = (n) => Math.round(n * 100) / 100;
+
+// The two surfaces the inbox paints de-emphasised text onto.
+const SURFACES = ['white', 'gray-50'];
+
+console.log('F30 inbox contrast smoke — pure, no DOM, no network\n');
+
+console.log('the contrast formula itself (known values):');
+{
+  check('black on white is 21:1', round(contrastRatio('#000000', '#ffffff')) === 21);
+  check('white on white is 1:1', round(contrastRatio('#ffffff', '#ffffff')) === 1);
+  check('it is symmetric', round(contrastRatio('#9ca3af', '#ffffff')) === round(contrastRatio('#ffffff', '#9ca3af')));
+  // A published reference point: #767676 is the canonical "smallest grey that passes AA on white".
+  check('#767676 on white clears AA (the canonical boundary grey)', contrastRatio('#767676', '#ffffff') >= AA_NORMAL);
+  check('#777777 … and one step lighter does not', contrastRatio('#797979', '#ffffff') < AA_NORMAL);
+}
+
+console.log('\nwhy the old token had to change — measured, not asserted:');
+{
+  for (const surface of SURFACES) {
+    const ratio = contrastRatio(PALETTE['gray-400'], PALETTE[surface]);
+    check(
+      `text-gray-400 on ${surface} FAILS AA (${round(ratio)}:1 < ${AA_NORMAL})`,
+      ratio < AA_NORMAL,
+      'if this ever passes, the palette moved and this whole file needs re-deriving',
+    );
+  }
+  check('text-gray-300 would be worse still', contrastRatio(PALETTE['gray-300'], PALETTE.white) < contrastRatio(PALETTE['gray-400'], PALETTE.white));
+}
+
+console.log('\nthe replacement token clears AA on every surface the inbox paints:');
+{
+  for (const surface of SURFACES) {
+    const ratio = contrastRatio(PALETTE['gray-500'], PALETTE[surface]);
+    check(`text-gray-500 on ${surface} passes AA (${round(ratio)}:1)`, ratio >= AA_NORMAL);
+  }
+  check(
+    'and it is still clearly de-emphasised against body text',
+    contrastRatio(PALETTE['gray-500'], PALETTE.white) < contrastRatio(PALETTE['gray-700'], PALETTE.white),
+    'the grey exists to express hierarchy — a fix that flattens it is not a fix',
+  );
+}
+
+console.log('\nthe outbound bubble — the one the old audit called a false positive, and it was not:');
+{
+  // The timestamp inside a sent message is `outbound ? text-blue-100 : text-gray-400`. The two
+  // branches are mutually exclusive, so the GREY never lands on the blue — that part of the old
+  // "gray-on-color" reading really was a false positive. But measuring the branch that does
+  // render showed the pairing fails anyway, on its own terms and for a different reason.
+  const before = contrastRatio(PALETTE['blue-100'], PALETTE['blue-600']);
+  check(
+    `text-blue-100 on bg-blue-600 FAILS AA too (${round(before)}:1)`,
+    before < AA_NORMAL,
+    'assumed to be fine when this file was written; the formula disagreed',
+  );
+
+  const after = contrastRatio(PALETTE['blue-50'], PALETTE['blue-600']);
+  check(`text-blue-50 on bg-blue-600 passes (${round(after)}:1)`, after >= AA_NORMAL);
+  check(
+    'and stays de-emphasised against the bubble’s own white body text',
+    after < contrastRatio(PALETTE.white, PALETTE['blue-600']),
+  );
+
+  check('no sub-AA blue text token remains in inbox.js', !/text-blue-100\b/.test(readFileSync(INBOX, 'utf8')));
+}
+
+console.log('\nthe inbox no longer ships the failing token:');
+{
+  const src = readFileSync(INBOX, 'utf8');
+  const stripped = src.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^\s*\/\/.*$/gm, '');
+
+  const failing = [];
+  for (const token of ['gray-400', 'gray-300']) {
+    const re = new RegExp(`text-${token}\\b`, 'g');
+    let m;
+    while ((m = re.exec(stripped)) !== null) {
+      failing.push(`text-${token} at line ${stripped.slice(0, m.index).split('\n').length}`);
+    }
+  }
+  check('no sub-AA grey text token remains in inbox.js', failing.length === 0, `\n    ${failing.join('\n    ')}`);
+
+  // Guard the guard: if the de-emphasis styling vanished altogether the check above would also
+  // pass, and the page would have lost its hierarchy instead of gaining contrast.
+  const replacements = (stripped.match(/text-gray-500\b/g) || []).length;
+  check(`the de-emphasis token is still in use (${replacements} occurrences)`, replacements >= 25, 'did the greys get deleted rather than darkened?');
+
+  // hover:text-gray-400 would reintroduce it on interaction.
+  check('no hover state drops back to the failing token', !/hover:text-gray-[34]00\b/.test(stripped));
+}
+
+console.log('\nthe two places where the hierarchy had to be restored downward, not upward:');
+{
+  const src = readFileSync(INBOX, 'utf8');
+  // Raising the failing grey one step would have collided with text that renders BESIDE it.
+  // These two are the only such pairs in the file, and both are pinned so a later bulk
+  // find-and-replace cannot quietly flatten them again.
+  check(
+    'the conversation list still distinguishes Unassigned from Assigned',
+    /'Unassigned', cls: 'text-gray-500'/.test(src) && /'Assigned', cls: 'text-gray-700'/.test(src),
+    'these labels sit side by side down the list — identical greys remove the scanning cue',
+  );
+  check(
+    'funnel history still distinguishes the note from its timestamp',
+    /text-\[11px\] text-gray-700 break-words/.test(src),
+    'note and timestamp render on the same row',
+  );
+}
+
+console.log('\nthe design hook’s "gray-on-color" findings are ternaries — checked, not assumed:');
+{
+  // F30 was raised from a design-hook audit reporting 6 gray-on-color findings. Every one is a
+  // MUTUALLY-EXCLUSIVE ternary — `cond ? 'bg-blue-500 text-white' : 'bg-white text-gray-700'` —
+  // so the grey never lands on the colour; the hook matches both branches of one string. The
+  // same finding was logged and dismissed during F4, so rather than dismiss it a third time by
+  // eye, this asserts the property that makes it a false positive: the nearest background class
+  // preceding each grey token is a LIGHT one. A genuine gray-on-colour would fail here.
+  const src = readFileSync(INBOX, 'utf8');
+  const offenders = [];
+  const re = /text-gray-\d00\b/g;
+  let m;
+  while ((m = re.exec(src)) !== null) {
+    const before = src.slice(0, m.index);
+    const bg = before.match(/bg-[a-z]+(-\d00)?(\/\d+)?(?![\s\S]*bg-)/);
+    if (!bg) continue;
+    // Only consider a background in the same className string.
+    const sameString = !/[\n]/.test(before.slice(bg.index));
+    if (!sameString) continue;
+    if (!/^bg-(white|gray|slate|neutral)/.test(bg[0])) {
+      offenders.push(`line ${before.split('\n').length}: ${bg[0]} + ${m[0]}`);
+    }
+  }
+  check('no grey text sits on a coloured background', offenders.length === 0, `\n    ${offenders.join('\n    ')}`);
+}
+
+console.log(`\n✅ contrast smoke: ${passed} checks passed`);

--- a/scripts/podium-contrast-smoke.mjs
+++ b/scripts/podium-contrast-smoke.mjs
@@ -133,13 +133,28 @@ export function stripAside(src) {
  */
 export function styleChunks(src) {
   const chunks = [];
-  const re = /'([^'\n]*)'|"([^"\n]*)"|`([^`]*)`/g;
+  const re = /'([^'\n]*)'|"([^"\n]*)"|`([\s\S]*?)`/g;
   let m;
   while ((m = re.exec(src)) !== null) {
-    const body = m[1] ?? m[2] ?? m[3] ?? '';
-    // Inside a template literal, each ${…} is its own scope — its contents are separate
-    // literals which this same pass picks up, so blank them out here.
-    chunks.push({ text: body.replace(/\$\{[\s\S]*?\}/g, ' '), index: m.index });
+    if (m[3] === undefined) {
+      chunks.push({ text: m[1] ?? m[2], index: m.index });
+      continue;
+    }
+    // A template literal is TWO kinds of thing: its own static class text, and one or more
+    // ${…} expressions that usually hold the ternary branches. An earlier version blanked the
+    // expressions — which silently discarded the branches, the single most common place a
+    // pairing hides in this file. Mutation testing caught it: reverting the attachment chip to
+    // a light blue went unnoticed because its classes live inside a ${…}. Recurse instead.
+    const tpl = m[3];
+    const base = m.index + 1;
+    let statics = tpl;
+    for (const expr of tpl.matchAll(/\$\{([\s\S]*?)\}/g)) {
+      for (const inner of styleChunks(expr[1])) {
+        chunks.push({ text: inner.text, index: base + expr.index + 2 + inner.index });
+      }
+      statics = statics.split(expr[0]).join(' '.repeat(expr[0].length));
+    }
+    chunks.push({ text: statics, index: base });
   }
   return chunks;
 }
@@ -262,6 +277,11 @@ function main() {
     check('the pair scanner reports a real failing pairing', failingPairs("className={'bg-blue-500 text-white'}").length === 1);
     check('… regardless of token order', failingPairs("className={'text-white bg-blue-500'}").length === 1);
     check('… across a multi-line className', failingPairs('className={`bg-blue-500 rounded\n  text-white px-2`}').length === 1);
+    check('… inside a ${…} branch of a template literal — where this file hides most of them',
+      failingPairs("className={`rounded ${on ? 'bg-blue-500 text-white' : 'bg-white text-gray-700'}`}").length === 1,
+      'blanking these instead of recursing is how the attachment-chip regression stayed green');
+    check('… and the template’s own static classes are still read',
+      failingPairs("className={`bg-blue-500 text-white ${extra}`}").length === 1);
     check('… and accepts the ternary shape that made F30 a false alarm',
       failingPairs("className={on ? 'bg-blue-600 text-white' : 'bg-white text-gray-700'}").length === 0,
       'the grey lives in the other branch from the colour and never renders on it');

--- a/scripts/podium-contrast-smoke.mjs
+++ b/scripts/podium-contrast-smoke.mjs
@@ -78,13 +78,29 @@ export const PALETTE = {
   'blue-500': '#3b82f6',
   'blue-600': '#2563eb',
   'blue-700': '#1d4ed8',
+  'blue-400': '#60a5fa',
+  'blue-800': '#1e40af',
   'amber-50': '#fffbeb',
+  'amber-100': '#fef3c7',
   'amber-500': '#f59e0b',
   'amber-600': '#d97706',
   'amber-700': '#b45309',
+  'amber-800': '#92400e',
   'amber-900': '#78350f',
+  'green-100': '#dcfce7',
   'green-700': '#15803d',
   'green-800': '#166534',
+  'emerald-100': '#d1fae5',
+  'emerald-800': '#065f46',
+  'red-100': '#fee2e2',
+  'red-600': '#dc2626',
+  'red-700': '#b91c1c',
+  'pink-100': '#fce7f3',
+  'pink-800': '#9d174d',
+  'purple-100': '#f3e8ff',
+  'purple-800': '#6b21a8',
+  'yellow-100': '#fef9c3',
+  'yellow-800': '#854d0e',
 };
 
 const AA_NORMAL = 4.5; // WCAG 2.1 SC 1.4.3, normal-size text
@@ -284,6 +300,28 @@ function main() {
     check('NO text/background pairing in the inbox fails AA', pairs.length === 0, `\n    ${pairs.join('\n    ')}`);
     check('… and that claim is unconditional — nothing is exempted', KNOWN_FAILING.length === 0);
     check('the old CTA surfaces are gone', !/\bbg-(blue|amber)-500\b/.test(stripAside(src)));
+
+    // An unknown token is skipped by failingPairs, so a pairing built from one is invisible to
+    // it — mutation testing proved the point by swapping the attachment chip to bg-blue-400,
+    // which was absent from PALETTE and therefore sailed through. The palette must cover
+    // everything the page uses, or the scan quietly checks less than it appears to.
+    const unknown = [...new Set(
+      [...stripAside(src).matchAll(/\b(?:bg|text)-((?:[a-z]+-\d00)|white)\b/g)].map((m) => m[1]),
+    )].filter((t) => !PALETTE[t]);
+    check('every colour token the inbox uses is in the palette', unknown.length === 0, `unresolved: ${unknown.join(', ')}`);
+
+    check('SURFACES still lists all four painted surfaces', SURFACES.length === 4
+      && ['white', 'gray-50', 'gray-100', 'blue-50'].every((s) => SURFACES.includes(s)),
+      'shrinking this list silently narrows every check that iterates it');
+
+    // The two sites that sit on the DARKER surfaces. failingPairs cannot reach them — their
+    // className carries no background, because the surface comes from an ancestor — so they are
+    // pinned by source. Both were found by code review sitting at 4.39 / 4.44 after the first
+    // pass "fixed" them, and mutation testing showed nothing else catches a regression here.
+    check('the footer paragraph on the gray-100 shell uses gray-600',
+      /<p className="text-xs text-gray-600 mt-3">/.test(src));
+    check('the conversation-row timestamp uses gray-600 (a selected row is bg-blue-50)',
+      /text-xs text-gray-600">\{formatTime\(c\?\.lastMessageAt\)\}/.test(src));
 
     // Guard the guard: had the de-emphasis styling been deleted rather than darkened, every
     // check above would also pass. Code review pointed out the earlier floor was unfalsifiable,

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -947,14 +947,19 @@ export default function Inbox() {
 
   const assigneeLabel = (c) => {
     const uids = conversationAssigneeUids(c);
-    if (uids.length === 0) return { text: 'Unassigned', cls: 'text-gray-400' };
+    // Unassigned stays the lighter of the two, because these labels sit side by side DOWN the
+    // conversation list and the weight difference is how a rep spots an unclaimed thread at a
+    // glance. Raising the failing grey to gray-500 would have made "Unassigned" and "Assigned"
+    // identical, so the assigned states step DOWN to gray-700 instead of the unassigned one
+    // stepping up — both now clear AA and the scanning cue survives.
+    if (uids.length === 0) return { text: 'Unassigned', cls: 'text-gray-500' };
     const mine = myPodiumUid && uids.includes(myPodiumUid);
     if (uids.length === 1) {
-      return mine ? { text: 'You', cls: 'text-green-700' } : { text: 'Assigned', cls: 'text-gray-500' };
+      return mine ? { text: 'You', cls: 'text-green-700' } : { text: 'Assigned', cls: 'text-gray-700' };
     }
     return mine
       ? { text: `You +${uids.length - 1}`, cls: 'text-green-700' }
-      : { text: `${uids.length} assignees`, cls: 'text-gray-500' };
+      : { text: `${uids.length} assignees`, cls: 'text-gray-700' };
   };
 
   // Prefer the resolved customer/contact name in the thread header once the panel loads.
@@ -1070,7 +1075,7 @@ export default function Inbox() {
                       type="button"
                       onClick={() => setSearchInput('')}
                       aria-label="Clear search"
-                      className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                      className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-600"
                     >
                       ×
                     </button>
@@ -1131,7 +1136,7 @@ export default function Inbox() {
                       </div>
                       <div className="flex items-center justify-between gap-2 mt-1">
                         <span className={`text-xs ${a.cls}`}>{a.text}</span>
-                        <span className="text-xs text-gray-400">{formatTime(c?.lastMessageAt)}</span>
+                        <span className="text-xs text-gray-500">{formatTime(c?.lastMessageAt)}</span>
                       </div>
                     </button>
                   );
@@ -1142,7 +1147,7 @@ export default function Inbox() {
             {/* Thread + composer */}
             <section className={`flex-1 min-w-0 flex flex-col ${selectedId ? 'flex' : 'hidden md:flex'}`}>
               {!selectedId && (
-                <div className="flex-1 flex items-center justify-center text-sm text-gray-400">
+                <div className="flex-1 flex items-center justify-center text-sm text-gray-500">
                   Select a conversation to view the chat.
                 </div>
               )}
@@ -1209,7 +1214,7 @@ export default function Inbox() {
                   <div className="flex-1 overflow-y-auto p-4 space-y-3 bg-gray-50">
                     {loadingThread && <div className="text-sm text-gray-500">Loading messages…</div>}
                     {!loadingThread && messages.length === 0 && (
-                      <div className="text-sm text-gray-400">No messages in this conversation.</div>
+                      <div className="text-sm text-gray-500">No messages in this conversation.</div>
                     )}
                     {!loadingThread && messages.map((m) => {
                       // F12 — internal notes render distinctly (team-only, not sent to the customer).
@@ -1238,11 +1243,11 @@ export default function Inbox() {
                             } ${m.optimistic ? 'opacity-80' : ''}`}
                           >
                             {showSenders && outbound && senderDisplay(m) && (
-                              <div className="text-[11px] font-semibold text-blue-100 mb-0.5">{senderDisplay(m)}</div>
+                              <div className="text-[11px] font-semibold text-blue-50 mb-0.5">{senderDisplay(m)}</div>
                             )}
                             {m.body && <div className="whitespace-pre-wrap break-words">{m.body}</div>}
                             <MessageAttachments attachments={m.attachments} outbound={outbound} />
-                            <div className={`text-[10px] mt-1 ${outbound ? 'text-blue-100' : 'text-gray-400'}`}>
+                            <div className={`text-[10px] mt-1 ${outbound ? 'text-blue-50' : 'text-gray-500'}`}>
                               {formatTime(m.createdAt)}{m.optimistic ? ' · sending…' : ''}
                             </div>
                           </div>
@@ -1406,7 +1411,7 @@ export default function Inbox() {
             )}
           </div>
 
-          <p className="text-xs text-gray-400 mt-3">
+          <p className="text-xs text-gray-500 mt-3">
             Chats are read live from Podium and are never stored in the portal. The customer
             panel shows the matched customer, their open orders/deliveries and funnel stage.
           </p>
@@ -1464,21 +1469,21 @@ function CustomerPanel({
     <div className="flex-1 overflow-y-auto p-4 space-y-4 text-sm">
       {/* F16 slot — Podium's auto AI summary + "Jerry" land here (not built this run). */}
       <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50 p-3">
-        <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-400">AI summary</div>
-        <div className="text-xs text-gray-400 mt-1">Auto conversation summary arrives with Jerry (F16).</div>
+        <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">AI summary</div>
+        <div className="text-xs text-gray-500 mt-1">Auto conversation summary arrives with Jerry (F16).</div>
       </div>
 
       {loading && <div className="text-gray-500">Loading customer details…</div>}
 
       {!loading && !panel && (
-        <div className="text-gray-400">Customer details unavailable.</div>
+        <div className="text-gray-500">Customer details unavailable.</div>
       )}
 
       {!loading && panel && (
         <>
           {/* Customer identity (or contact + create action when unmatched) */}
           <section>
-            <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">Customer</div>
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 mb-1">Customer</div>
             {customer ? (
               <div className="space-y-1">
                 <div className="font-semibold text-gray-900">{customer.name || 'Unnamed customer'}</div>
@@ -1486,7 +1491,7 @@ function CustomerPanel({
                 {customer.phone && <Field label="Phone" value={customer.phone} />}
                 {customer.address && <Field label="Address" value={customer.address} />}
                 {panel.matchedBy && panel.matchedBy !== 'none' && (
-                  <div className="text-[11px] text-gray-400 pt-1">
+                  <div className="text-[11px] text-gray-500 pt-1">
                     Matched by {panel.matchedBy === 'podium_contact_id' ? 'linked Podium contact' : panel.matchedBy}
                   </div>
                 )}
@@ -1502,7 +1507,7 @@ function CustomerPanel({
                     {contact.email && <Field label="Email" value={contact.email} />}
                     {contact.phone && <Field label="Phone" value={contact.phone} />}
                     {!contact.name && !contact.email && !contact.phone && (
-                      <div className="text-xs text-gray-400">No contact details available from Podium.</div>
+                      <div className="text-xs text-gray-500">No contact details available from Podium.</div>
                     )}
                   </div>
                 )}
@@ -1534,7 +1539,7 @@ function CustomerPanel({
 
           {/* Funnel stage + history timeline */}
           <section>
-            <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">Funnel stage</div>
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 mb-1">Funnel stage</div>
             {lead ? (
               <div className="space-y-1">
                 <span className={`inline-block text-xs font-semibold px-2 py-0.5 rounded-full ${STAGE_CLS[lead.stage] || 'bg-gray-100 text-gray-700'}`}>
@@ -1547,7 +1552,7 @@ function CustomerPanel({
               </div>
             ) : (
               <div className="space-y-2">
-                <div className="text-gray-400">Not in the funnel yet.</div>
+                <div className="text-gray-500">Not in the funnel yet.</div>
                 {customer && onAddToFunnel && (
                   <button
                     type="button"
@@ -1568,11 +1573,11 @@ function CustomerPanel({
 
           {/* Open workorders — check order progress without leaving the inbox */}
           <section>
-            <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 mb-1">
               Open workorders{workorders.length ? ` (${workorders.length})` : ''}
             </div>
             {workorders.length === 0 ? (
-              <div className="text-gray-400">None open.</div>
+              <div className="text-gray-500">None open.</div>
             ) : (
               <ul className="space-y-2">
                 {workorders.map((w) => {
@@ -1610,11 +1615,11 @@ function CustomerPanel({
 
           {/* Active deliveries */}
           <section>
-            <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">
+            <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 mb-1">
               Active deliveries{deliveries.length ? ` (${deliveries.length})` : ''}
             </div>
             {deliveries.length === 0 ? (
-              <div className="text-gray-400">None active.</div>
+              <div className="text-gray-500">None active.</div>
             ) : (
               <ul className="space-y-2">
                 {deliveries.map((d) => (
@@ -1664,8 +1669,8 @@ export function AssigneeBar({ assignees, reps, myPodiumUid, show, setShow, onTog
   }, [show, setShow]);
   return (
     <div className="mt-1 flex items-center gap-1.5 flex-wrap">
-      <span className="text-[11px] text-gray-400">Assigned:</span>
-      {assignees.length === 0 && <span className="text-xs text-gray-400">Unassigned</span>}
+      <span className="text-[11px] text-gray-500">Assigned:</span>
+      {assignees.length === 0 && <span className="text-xs text-gray-500">Unassigned</span>}
       {assignees.map((a) => {
         const you = myPodiumUid && a.podiumUserId === myPodiumUid;
         return (
@@ -1719,7 +1724,7 @@ export function AssigneeBar({ assignees, reps, myPodiumUid, show, setShow, onTog
                   <span aria-hidden="true" className={`w-4 h-4 shrink-0 rounded border flex items-center justify-center text-[10px] ${checked ? 'bg-blue-500 border-blue-500 text-white' : 'border-gray-300 text-transparent'}`}>✓</span>
                   <span className="min-w-0 flex-1">
                     <span className="block text-xs text-gray-800 truncate">{r.name}</span>
-                    {!r.linked && <span className="block text-[10px] text-gray-400">Not linked to Podium</span>}
+                    {!r.linked && <span className="block text-[10px] text-gray-500">Not linked to Podium</span>}
                   </span>
                 </button>
               );
@@ -1735,7 +1740,7 @@ export function AssigneeBar({ assignees, reps, myPodiumUid, show, setShow, onTog
 function Field({ label, value }) {
   return (
     <div className="flex gap-2 text-xs">
-      <span className="text-gray-400 w-20 shrink-0">{label}</span>
+      <span className="text-gray-500 w-20 shrink-0">{label}</span>
       <span className="text-gray-700 break-words min-w-0">{value}</span>
     </div>
   );
@@ -1774,16 +1779,19 @@ function FunnelTimeline({ history }) {
   if (rows.length === 0) return null;
   return (
     <div className="pt-2">
-      <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">Funnel history</div>
+      <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 mb-1">Funnel history</div>
       <ol className="space-y-1.5 border-l border-gray-200 pl-3">
         {rows.map((h) => (
           <li key={h.id} className="relative">
             <span className="absolute -left-[0.95rem] top-1.5 w-1.5 h-1.5 rounded-full bg-blue-400" />
             <div className="text-xs font-medium text-gray-800">{h.to_stage}</div>
-            <div className="text-[11px] text-gray-400">
+            <div className="text-[11px] text-gray-500">
               {formatTime(h.created_at)}{h.user_name ? ` · ${h.user_name}` : ''}
             </div>
-            {h.notes_log && <div className="text-[11px] text-gray-500 break-words">{h.notes_log}</div>}
+            {/* The note is content and the timestamp is metadata; they render together on the
+                same row, so the note steps DOWN to gray-700 rather than both landing on the
+                same grey once the failing token was raised. */}
+            {h.notes_log && <div className="text-[11px] text-gray-700 break-words">{h.notes_log}</div>}
           </li>
         ))}
       </ol>
@@ -1843,13 +1851,13 @@ export function WorkorderModal({ workorderId, detail, loading, onClose }) {
               <span className="text-xs font-semibold px-2 py-0.5 rounded-full bg-gray-100 text-gray-700">{detail.status}</span>
             )}
           </div>
-          <button type="button" onClick={onClose} className="text-gray-400 hover:text-gray-700 text-xl leading-none" aria-label="Close">×</button>
+          <button type="button" onClick={onClose} className="text-gray-500 hover:text-gray-700 text-xl leading-none" aria-label="Close">×</button>
         </header>
 
         <div className="flex-1 overflow-y-auto p-5 space-y-4 text-sm">
           {loading && <div className="text-gray-500">Loading workorder…</div>}
 
-          {!loading && !detail && <div className="text-gray-400">Workorder details unavailable.</div>}
+          {!loading && !detail && <div className="text-gray-500">Workorder details unavailable.</div>}
 
           {!loading && detail && (
             <>
@@ -1868,11 +1876,11 @@ export function WorkorderModal({ workorderId, detail, loading, onClose }) {
 
               {/* Items + per-item status */}
               <section>
-                <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 mb-1">
                   Items{items.length ? ` (${items.length})` : ''}
                 </div>
                 {items.length === 0 ? (
-                  <div className="text-gray-400">No items.</div>
+                  <div className="text-gray-500">No items.</div>
                 ) : (
                   <ul className="divide-y divide-gray-100 border border-gray-200 rounded-lg">
                     {items.map((it) => (
@@ -1896,7 +1904,7 @@ export function WorkorderModal({ workorderId, detail, loading, onClose }) {
 
               {/* Full activity log (read-only, scrollable, oldest → newest) */}
               <section>
-                <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-400 mb-1">Activity log</div>
+                <div className="text-[11px] font-semibold uppercase tracking-wide text-gray-500 mb-1">Activity log</div>
                 <textarea
                   readOnly
                   value={logText || 'No activity recorded.'}
@@ -1981,7 +1989,7 @@ export function ComposeModal({ sending, onSubmit, onClose }) {
             type="button"
             onClick={onClose}
             disabled={sending}
-            className="text-gray-400 hover:text-gray-700 text-xl leading-none disabled:opacity-40"
+            className="text-gray-500 hover:text-gray-700 text-xl leading-none disabled:opacity-40"
             aria-label="Close"
           >
             ×
@@ -2104,7 +2112,7 @@ export function ProductLookupModal({ products, loaded, search, setSearch, onClos
       >
         <header className="flex items-center justify-between px-5 py-3 border-b border-gray-200">
           <h2 id={titleId} className="text-lg font-bold">Product price &amp; stock</h2>
-          <button type="button" onClick={onClose} className="text-gray-400 hover:text-gray-700 text-xl leading-none" aria-label="Close">×</button>
+          <button type="button" onClick={onClose} className="text-gray-500 hover:text-gray-700 text-xl leading-none" aria-label="Close">×</button>
         </header>
 
         <div className="px-5 pt-4">
@@ -2123,7 +2131,7 @@ export function ProductLookupModal({ products, loaded, search, setSearch, onClos
           {!loaded && <div className="text-sm text-gray-500">Loading products…</div>}
 
           {loaded && all.length === 0 && (
-            <div className="text-sm text-gray-400">Product list unavailable.</div>
+            <div className="text-sm text-gray-500">Product list unavailable.</div>
           )}
 
           {loaded && all.length > 0 && matches.length === 0 && (
@@ -2165,7 +2173,7 @@ export function ProductLookupModal({ products, loaded, search, setSearch, onClos
           )}
         </div>
 
-        <footer className="px-5 py-2 border-t border-gray-200 text-[11px] text-gray-400">
+        <footer className="px-5 py-2 border-t border-gray-200 text-[11px] text-gray-500">
           Retail price and current stock. Loaded once when the Inbox opened.
         </footer>
       </div>

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -947,19 +947,21 @@ export default function Inbox() {
 
   const assigneeLabel = (c) => {
     const uids = conversationAssigneeUids(c);
-    // Unassigned stays the lighter of the two, because these labels sit side by side DOWN the
-    // conversation list and the weight difference is how a rep spots an unclaimed thread at a
-    // glance. Raising the failing grey to gray-500 would have made "Unassigned" and "Assigned"
-    // identical, so the assigned states step DOWN to gray-700 instead of the unassigned one
-    // stepping up — both now clear AA and the scanning cue survives.
-    if (uids.length === 0) return { text: 'Unassigned', cls: 'text-gray-500' };
+    // These labels sit side by side DOWN the list, so they need to stay distinguishable — but
+    // the FIRST attempt got the polarity backwards (caught in review): it left "Unassigned" as
+    // the faintest text on the row when an unclaimed thread is the one state a rep is hunting
+    // for, and it collided with the equally-grey timestamp beside it. Unassigned is now amber —
+    // a needs-attention colour rather than a weight — and the assigned states are the muted
+    // ones. All three clear AA on both surfaces a row can have (white, and blue-50 when
+    // selected); the colours, not the greys, carry the meaning.
+    if (uids.length === 0) return { text: 'Unassigned', cls: 'text-amber-700' };
     const mine = myPodiumUid && uids.includes(myPodiumUid);
     if (uids.length === 1) {
-      return mine ? { text: 'You', cls: 'text-green-700' } : { text: 'Assigned', cls: 'text-gray-700' };
+      return mine ? { text: 'You', cls: 'text-green-700' } : { text: 'Assigned', cls: 'text-gray-600' };
     }
     return mine
       ? { text: `You +${uids.length - 1}`, cls: 'text-green-700' }
-      : { text: `${uids.length} assignees`, cls: 'text-gray-700' };
+      : { text: `${uids.length} assignees`, cls: 'text-gray-600' };
   };
 
   // Prefer the resolved customer/contact name in the thread header once the panel loads.
@@ -1014,7 +1016,7 @@ export default function Inbox() {
                     key={b.key}
                     type="button"
                     onClick={() => switchBucket(b.key)}
-                    className={bucket === b.key ? 'px-3 py-1.5 bg-blue-500 text-white' : 'px-3 py-1.5 bg-white text-gray-700 hover:bg-gray-50'}
+                    className={bucket === b.key ? 'px-3 py-1.5 bg-blue-600 text-white' : 'px-3 py-1.5 bg-white text-gray-700 hover:bg-gray-50'}
                   >
                     {b.label}
                   </button>
@@ -1039,7 +1041,7 @@ export default function Inbox() {
               <button
                 type="button"
                 onClick={() => setShowCompose(true)}
-                className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-blue-500 bg-blue-500 text-sm text-white hover:bg-blue-600"
+                className="inline-flex items-center gap-1 px-3 py-1.5 rounded-lg border border-blue-600 bg-blue-600 text-sm text-white hover:bg-blue-700"
                 title="Start a new conversation with a phone number or email"
               >
                 <span aria-hidden="true">✉️</span> New conversation
@@ -1098,7 +1100,7 @@ export default function Inbox() {
                     <button
                       type="button"
                       onClick={() => navigate('/settings')}
-                      className="w-full bg-blue-500 text-white py-2 rounded hover:bg-blue-600"
+                      className="w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700"
                     >
                       Connect my Podium account
                     </button>
@@ -1136,7 +1138,8 @@ export default function Inbox() {
                       </div>
                       <div className="flex items-center justify-between gap-2 mt-1">
                         <span className={`text-xs ${a.cls}`}>{a.text}</span>
-                        <span className="text-xs text-gray-500">{formatTime(c?.lastMessageAt)}</span>
+                        {/* gray-600: a selected row is bg-blue-50, where gray-500 is 4.44:1. */}
+                        <span className="text-xs text-gray-600">{formatTime(c?.lastMessageAt)}</span>
                       </div>
                     </button>
                   );
@@ -1239,7 +1242,11 @@ export default function Inbox() {
                         <div key={m.uid} className={`flex ${outbound ? 'justify-end' : 'justify-start'}`}>
                           <div
                             className={`max-w-[75%] rounded-2xl px-4 py-2 text-sm shadow-sm ${
-                              outbound ? 'bg-blue-500 text-white rounded-br-sm' : 'bg-white text-gray-800 border border-gray-200 rounded-bl-sm'
+                              // bg-blue-600, not -500: on blue-500 the bubble's OWN white message
+                              // text measures 3.68:1 — the actual conversation, failing AA worse
+                              // than any grey this change started with. blue-600 puts it at 5.17
+                              // and the timestamp below at 4.75.
+                              outbound ? 'bg-blue-600 text-white rounded-br-sm' : 'bg-white text-gray-800 border border-gray-200 rounded-bl-sm'
                             } ${m.optimistic ? 'opacity-80' : ''}`}
                           >
                             {showSenders && outbound && senderDisplay(m) && (
@@ -1289,14 +1296,14 @@ export default function Inbox() {
                         <button
                           type="button"
                           onClick={() => setComposerMode('reply')}
-                          className={composerMode === 'reply' ? 'px-2.5 py-1 bg-blue-500 text-white' : 'px-2.5 py-1 bg-white text-gray-600 hover:bg-gray-50'}
+                          className={composerMode === 'reply' ? 'px-2.5 py-1 bg-blue-600 text-white' : 'px-2.5 py-1 bg-white text-gray-600 hover:bg-gray-50'}
                         >
                           Reply
                         </button>
                         <button
                           type="button"
                           onClick={() => { setComposerMode('note'); setShowTemplates(false); }}
-                          className={composerMode === 'note' ? 'px-2.5 py-1 bg-amber-500 text-white' : 'px-2.5 py-1 bg-white text-gray-600 hover:bg-gray-50'}
+                          className={composerMode === 'note' ? 'px-2.5 py-1 bg-amber-700 text-white' : 'px-2.5 py-1 bg-white text-gray-600 hover:bg-gray-50'}
                         >
                           Internal note
                         </button>
@@ -1377,7 +1384,7 @@ export default function Inbox() {
                         type="submit"
                         disabled={sending || (composerMode === 'note' ? !draft.trim() : (!draft.trim() && attachments.length === 0))}
                         className={`px-4 py-2 rounded-lg text-sm text-white disabled:opacity-50 ${
-                          composerMode === 'note' ? 'bg-amber-500 hover:bg-amber-600' : 'bg-blue-500 hover:bg-blue-600'
+                          composerMode === 'note' ? 'bg-amber-700 hover:bg-amber-800' : 'bg-blue-600 hover:bg-blue-700'
                         }`}
                       >
                         {sending
@@ -1411,7 +1418,9 @@ export default function Inbox() {
             )}
           </div>
 
-          <p className="text-xs text-gray-500 mt-3">
+          {/* gray-600, not -500: this paragraph sits on the page shell (bg-gray-100), where
+              gray-500 is 4.39:1 — under AA. Everything else de-emphasised sits on a white card. */}
+          <p className="text-xs text-gray-600 mt-3">
             Chats are read live from Podium and are never stored in the portal. The customer
             panel shows the matched customer, their open orders/deliveries and funnel stage.
           </p>
@@ -1524,7 +1533,7 @@ function CustomerPanel({
                   type="button"
                   onClick={onCreate}
                   disabled={creating}
-                  className="w-full bg-blue-500 text-white py-2 rounded text-sm hover:bg-blue-600 disabled:opacity-50"
+                  className="w-full bg-blue-600 text-white py-2 rounded text-sm hover:bg-blue-700 disabled:opacity-50"
                 >
                   {creating ? 'Creating…' : 'Create customer from contact'}
                 </button>
@@ -1558,7 +1567,7 @@ function CustomerPanel({
                     type="button"
                     onClick={onAddToFunnel}
                     disabled={addingLead}
-                    className="w-full bg-blue-500 text-white py-2 rounded text-sm hover:bg-blue-600 disabled:opacity-50"
+                    className="w-full bg-blue-600 text-white py-2 rounded text-sm hover:bg-blue-700 disabled:opacity-50"
                   >
                     {addingLead
                       ? 'Adding…'
@@ -1721,7 +1730,7 @@ export function AssigneeBar({ assignees, reps, myPodiumUid, show, setShow, onTog
                       tree (only display:none / visibility:hidden / aria-hidden remove it), so
                       a screen reader announced a "✓" beside EVERY rep — assigned or not. The
                       real state is carried by aria-pressed on the button. */}
-                  <span aria-hidden="true" className={`w-4 h-4 shrink-0 rounded border flex items-center justify-center text-[10px] ${checked ? 'bg-blue-500 border-blue-500 text-white' : 'border-gray-300 text-transparent'}`}>✓</span>
+                  <span aria-hidden="true" className={`w-4 h-4 shrink-0 rounded border flex items-center justify-center text-[10px] ${checked ? 'bg-blue-600 border-blue-600 text-white' : 'border-gray-300 text-transparent'}`}>✓</span>
                   <span className="min-w-0 flex-1">
                     <span className="block text-xs text-gray-800 truncate">{r.name}</span>
                     {!r.linked && <span className="block text-[10px] text-gray-500">Not linked to Podium</span>}
@@ -1762,7 +1771,9 @@ function MessageAttachments({ attachments, outbound }) {
         return (
           <span
             key={key}
-            className={`inline-flex items-center gap-1 text-xs px-2 py-1 rounded-lg ${outbound ? 'bg-blue-400/60 text-white' : 'bg-gray-100 text-gray-700'}`}
+            // bg-blue-700 rather than the old translucent bg-blue-400/60, which composited to
+            // roughly #5197f8 and put this white label at 2.94:1 — the worst pairing on the page.
+            className={`inline-flex items-center gap-1 text-xs px-2 py-1 rounded-lg ${outbound ? 'bg-blue-700 text-white' : 'bg-gray-100 text-gray-700'}`}
           >
             {a.kind === 'video' ? '🎬' : '📎'} {a.filename || a.kind}
           </span>
@@ -2058,7 +2069,7 @@ export function ComposeModal({ sending, onSubmit, onClose }) {
           <button
             type="submit"
             disabled={!canSend}
-            className="px-3 py-1.5 rounded-lg bg-blue-500 text-white text-sm hover:bg-blue-600 disabled:opacity-40 disabled:hover:bg-blue-500"
+            className="px-3 py-1.5 rounded-lg bg-blue-600 text-white text-sm hover:bg-blue-700 disabled:opacity-40 disabled:hover:bg-blue-600"
           >
             {sending ? 'Starting…' : 'Start conversation'}
           </button>


### PR DESCRIPTION
## The row said six findings. All six were false positives — and the real defects were bigger.

F30 was raised as *"6 gray-on-color contrast findings in `src/pages/inbox.js`"* from a design-hook audit, with the instruction to classify each **fix-or-false-positive** rather than bulk-change. That instruction turned out to matter more than the list.

**All six are false positives.** Every one is a mutually-exclusive ternary — `cond ? 'bg-blue-500 text-white' : 'bg-white text-gray-700'` — so the grey never lands on the colour; the hook matches both branches of one className string. The same six were logged and dismissed during F4. Rather than dismiss them by eye a third time, the smoke now asserts the property that *makes* them false positives, so the question is settled mechanically.

**The real defects were adjacent, larger, and flagged by nothing** (all measured, not eyeballed):

| Pairing | Where | Ratio | AA |
|---|---|---|---|
| `text-gray-400` on white | the de-emphasis token, **34 sites** | **2.54** | ✗ |
| `text-gray-400` on `bg-gray-50` | the message thread | **2.43** | ✗ |
| **`text-white` on `bg-amber-500`** | internal-note controls | **2.15** | ✗ |
| **`text-white` on `bg-blue-500`** | **the outbound bubble — the actual conversation** | **3.68** | ✗ |
| `text-white` on `bg-blue-400/60` | attachment chips | ~2.94 | ✗ |
| `text-blue-100` on the bubble | sent-message timestamps | 3.02 | ✗ |
| `text-gray-500` on `bg-gray-100` / `bg-blue-50` | page shell, selected row | 4.39 / 4.44 | ✗ |

Every affected element is `text-[10px]`/`[11px]`/`xs`/`sm` — none reaches the large-text carve-out, so 4.5:1 applies throughout. The row notes reps read this page **on the warehouse floor**; high ambient light on a phone is the worst case for washed-out text.

## The fix

- de-emphasis `gray-400` → `gray-500` (4.83 / 4.63), and `gray-600` for the sites on the darker surfaces (6.87 / 6.51)
- outbound bubble `blue-500` → `blue-600` (white body text **3.68 → 5.17**), its timestamp → `blue-50` (4.75), attachment chip → solid `blue-700` (6.70)
- internal-note controls `amber-500` → `amber-700` (**2.15 → 5.02**); primary buttons `blue-500` → `blue-600`; hovers one step further

**Two places needed the hierarchy restored *downward*.** The file used both `gray-400` and `gray-500`, so raising the failing token flattened two pairs that render *together* (the rest are mutually-exclusive loading/empty states, verified independently by the reviewer):

- **conversation list — "Unassigned" vs "Assigned".** My first attempt got the polarity backwards, and review caught it: it left *Unassigned* — the one state a rep is hunting for — as the faintest text on the row, colliding with the timestamp beside it. Unassigned is now **amber-700**, a needs-attention colour rather than a weight; the assigned states are the muted ones. Colour carries the meaning.
- **funnel history — note vs timestamp**, same row: the note is content, so it steps down to `gray-700`.

## New guard: `scripts/podium-contrast-smoke.mjs` (54 checks)

A real WCAG 2.1 implementation validated against known values (black/white = 21:1, the canonical `#767676` AA boundary, and the sRGB curve's *linear* segment), plus source scanners that **resolve every token through the palette and compute the real ratio**. Ratios are computed, not asserted, so a palette change breaks the file loudly instead of silently invalidating its claims.

Its headline check is unconditional: **no text/background pairing in the inbox fails AA**, with nothing exempted.

## What code review changed — the important part

The reviewer found **the guard was measuring a surface the page never paints**:

1. 🔴 **The bubble is `bg-blue-500`, not `bg-blue-600`** — every `bg-blue-600` in the file was a *hover* state. So `text-blue-50` was actually 3.38:1, the smoke's "no sub-AA blue token remains" was **false as written**, and the bubble's own white message text was at 3.68:1 — a worse defect than any grey this row began with.
2. 🔴 **`SURFACES` omitted the `bg-gray-100` shell and the `bg-blue-50` selected row**, where three sites this diff had *just changed* landed at 4.39 / 4.44.
3. **The scanner was order-dependent, blind to multi-line classNames, and used a colour-*name* allowlist** — which is precisely why it couldn't see the bubble. Rewritten around string literals (in JSX each ternary branch is its own literal) and around the palette.

**The rewritten scanner then immediately found two more** that the name-matching one structurally could not see: the primary buttons (3.68) and the internal-note controls (**2.15**, the worst on the page). I first parked the buttons on a known-failing allowlist as out-of-scope, then removed it — a guard claiming "no pairing fails AA" while exempting the page's own buttons isn't worth having. The allowlist mechanism stays, tested and empty, so a future exemption is one reviewable line.

## Verification

- `npm run smoke` **21/21 suites**; component tests **86 passed**; `CI=true npm run build` exit 0
- **Mutation testing across four rounds.** The final round runs 18 mutants: all 7 production mutants caught (each defect re-introduced), all guard mutants caught. **One knowingly alive:** mutating the exact-count assertion itself (`=== 60` → `>= 0`) — a self-referential assertion can't be defended by a fixture, and the comment says so rather than pretending otherwise.
- Earlier rounds found four survivors that are now closed, including two the *review had already caught once* (site-specific decisions the scanner can't see, because the surface comes from an ancestor) and a hole where `bg-blue-400` sailed through **because it was absent from the palette** — palette coverage is now asserted too.

## Known gaps

- **No browser check was performed.** jsdom has no layout or paint, so every claim here is computed from palette values and source tokens. The CTAs are now visibly a shade darker — **that is the thing to eyeball on the Preview.**
- **Styling-only, so no component test.** An RTL assertion could only restate the className the scanner already reads.
- `text-gray-400` still lives in **10 other pages** — the portal now has two de-emphasis greys and the inbox is the odd one out. Deliberate: F30's scope is `inbox.js`, and the app-wide roll-out (ideally a named semantic token, not a palette override) belongs in its own row. Raised as **F33**.

## Scope

Frontend-only, one page plus one smoke script. **No migration, no new serverless function, Neon untouched.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
