### PR TITLE
F32(b) — bump @testing-library/user-event to v14 (userEvent.setup())

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
         "@testing-library/dom": "^10.4.0",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.3.0",
-        "@testing-library/user-event": "^13.5.0",
+        "@testing-library/user-event": "^14.6.1",
         "@zxing/browser": "^0.2.1",
         "@zxing/library": "^0.23.0",
         "axios": "^1.11.0",
@@ -3514,15 +3514,12 @@
       }
     },
     "node_modules/@testing-library/user-event": {
-      "version": "13.5.0",
-      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-13.5.0.tgz",
-      "integrity": "sha512-5Kwtbo3Y/NowpkbRuSepbyMFkZmHgD+vPzYB/RJ4oxt5Gj/avFFBYjhw27cqSVPVw/3a67NK1PbiIr9k4Gwmdg==",
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
       "license": "MIT",
-      "dependencies": {
-        "@babel/runtime": "^7.12.5"
-      },
       "engines": {
-        "node": ">=10",
+        "node": ">=12",
         "npm": ">=6"
       },
       "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "@testing-library/dom": "^10.4.0",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
-    "@testing-library/user-event": "^13.5.0",
+    "@testing-library/user-event": "^14.6.1",
     "@zxing/browser": "^0.2.1",
     "@zxing/library": "^0.23.0",
     "axios": "^1.11.0",

--- a/src/pages/__tests__/composeModal.test.js
+++ b/src/pages/__tests__/composeModal.test.js
@@ -40,6 +40,12 @@ const recipientBox = () => screen.getByLabelText(/^to$/i);
 const messageBox = () => screen.getByLabelText(/^message$/i);
 const backdrop = () => screen.getByTestId('compose-backdrop');
 
+// user-event v14: one fresh `setup()` per test (real timers throughout this file).
+let user;
+beforeEach(() => {
+  user = userEvent.setup();
+});
+
 describe('ComposeModal — Start button gating', () => {
   test('Start is disabled before anything is typed', () => {
     renderModal();
@@ -48,8 +54,8 @@ describe('ComposeModal — Start button gating', () => {
 
   test('Start stays disabled when the recipient is not a phone or an email', async () => {
     renderModal();
-    await userEvent.type(recipientBox(), 'not-a-contact');
-    await userEvent.type(messageBox(), 'Your rack is ready for pickup.');
+    await user.type(recipientBox(), 'not-a-contact');
+    await user.type(messageBox(), 'Your rack is ready for pickup.');
     // "not-a-contact" has no @-domain and fewer than MIN_PHONE_DIGITS digits, so there is
     // nowhere for this message to go. Sending it would 400 at best.
     expect(startButton()).toBeDisabled();
@@ -57,15 +63,15 @@ describe('ComposeModal — Start button gating', () => {
 
   test('Start stays disabled when the message is only whitespace', async () => {
     renderModal();
-    await userEvent.type(recipientBox(), '0412345678');
-    await userEvent.type(messageBox(), '   ');
+    await user.type(recipientBox(), '0412345678');
+    await user.type(messageBox(), '   ');
     expect(startButton()).toBeDisabled();
   });
 
   test('Start enables once the recipient and the message are both valid', async () => {
     renderModal();
-    await userEvent.type(recipientBox(), '0412345678');
-    await userEvent.type(messageBox(), 'Your rack is ready for pickup.');
+    await user.type(recipientBox(), '0412345678');
+    await user.type(messageBox(), 'Your rack is ready for pickup.');
     expect(startButton()).toBeEnabled();
   });
 });
@@ -73,9 +79,9 @@ describe('ComposeModal — Start button gating', () => {
 describe('ComposeModal — what it submits', () => {
   test('a phone recipient submits channel "phone", trimmed', async () => {
     const { onSubmit } = renderModal();
-    await userEvent.type(recipientBox(), '  0412 345 678  ');
-    await userEvent.type(messageBox(), '  Your rack is ready.  ');
-    await userEvent.click(startButton());
+    await user.type(recipientBox(), '  0412 345 678  ');
+    await user.type(messageBox(), '  Your rack is ready.  ');
+    await user.click(startButton());
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onSubmit).toHaveBeenCalledWith({
@@ -87,9 +93,9 @@ describe('ComposeModal — what it submits', () => {
 
   test('an email recipient submits channel "email"', async () => {
     const { onSubmit } = renderModal();
-    await userEvent.type(recipientBox(), 'nick@graysfitness.com.au');
-    await userEvent.type(messageBox(), 'Quote attached.');
-    await userEvent.click(startButton());
+    await user.type(recipientBox(), 'nick@graysfitness.com.au');
+    await user.type(messageBox(), 'Quote attached.');
+    await user.click(startButton());
 
     expect(onSubmit).toHaveBeenCalledWith(
       expect.objectContaining({ channel: 'email', to: 'nick@graysfitness.com.au' }),
@@ -114,13 +120,13 @@ describe('ComposeModal — while a send is in flight', () => {
   // the Inbox-level test is called out as a backlog row above rather than assumed covered.
   test('the disabled Start button cannot be re-clicked once sending', async () => {
     const { onSubmit, rerender } = renderModal();
-    await userEvent.type(recipientBox(), '0412345678');
-    await userEvent.type(messageBox(), 'Your rack is ready.');
-    await userEvent.click(startButton());
+    await user.type(recipientBox(), '0412345678');
+    await user.type(messageBox(), 'Your rack is ready.');
+    await user.click(startButton());
     expect(onSubmit).toHaveBeenCalledTimes(1);
 
     rerender(<ComposeModal sending onSubmit={onSubmit} onClose={jest.fn()} />);
-    await userEvent.click(startButton());
+    await user.click(startButton());
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 });
@@ -128,13 +134,13 @@ describe('ComposeModal — while a send is in flight', () => {
 describe('ComposeModal — closing without losing a draft', () => {
   test('Escape closes an untouched modal', async () => {
     const { onClose } = renderModal();
-    await userEvent.keyboard('{Escape}');
+    await user.keyboard('{Escape}');
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   test('Escape does not close mid-send, which would drop the draft', async () => {
     const { onClose } = renderModal({ sending: true });
-    await userEvent.keyboard('{Escape}');
+    await user.keyboard('{Escape}');
     expect(onClose).not.toHaveBeenCalled();
   });
 
@@ -143,14 +149,14 @@ describe('ComposeModal — closing without losing a draft', () => {
   // Without it, deleting the whole closeOnBackdrop body left all 11 earlier tests green.
   test('a backdrop click closes an untouched modal', async () => {
     const { onClose } = renderModal();
-    await userEvent.click(backdrop());
+    await user.click(backdrop());
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   test('a backdrop click discards nothing once the rep has typed', async () => {
     const { onClose } = renderModal();
-    await userEvent.type(messageBox(), 'Half a quote');
-    await userEvent.click(backdrop());
+    await user.type(messageBox(), 'Half a quote');
+    await user.click(backdrop());
     expect(onClose).not.toHaveBeenCalled();
   });
 
@@ -159,15 +165,15 @@ describe('ComposeModal — closing without losing a draft', () => {
   // reload. Untested, that guarantee is a comment; tested, it's a constraint.
   test('Cancel closes even when the rep has typed', async () => {
     const { onClose } = renderModal();
-    await userEvent.type(messageBox(), 'Half a quote');
-    await userEvent.click(screen.getByRole('button', { name: /cancel/i }));
+    await user.type(messageBox(), 'Half a quote');
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
   test('the × closes even when the rep has typed', async () => {
     const { onClose } = renderModal();
-    await userEvent.type(messageBox(), 'Half a quote');
-    await userEvent.click(screen.getByRole('button', { name: /close/i }));
+    await user.type(messageBox(), 'Half a quote');
+    await user.click(screen.getByRole('button', { name: /close/i }));
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/pages/__tests__/dashboardNav.test.js
+++ b/src/pages/__tests__/dashboardNav.test.js
@@ -75,7 +75,9 @@ const labelsIn = (el) =>
     .map((n) => n.textContent.trim())
     .filter(Boolean);
 
+let user;
 beforeEach(() => {
+  user = userEvent.setup(); // v14: no fake timers in this file
   global.fetch = mockFetch();
   installMatchMedia(false);
 });
@@ -99,7 +101,7 @@ describe('F19 — mobile navigation drawer', () => {
     expect(sidebarLabels).toContain('Dashboard');
     expect(sidebarLabels).toContain('Logout');
 
-    await userEvent.click(menuButton());
+    await user.click(menuButton());
     const drawerLabels = labelsIn(screen.getByTestId('mobile-nav'));
 
     // Order included: the two renderings read the same list, so drift shows up here first.
@@ -109,7 +111,7 @@ describe('F19 — mobile navigation drawer', () => {
   test('the drawer is a dialog and takes focus (F26 convention)', async () => {
     renderDashboard();
     await waitFor(() => expect(menuButton()).toBeInTheDocument());
-    await userEvent.click(menuButton());
+    await user.click(menuButton());
 
     const dialog = screen.getByRole('dialog');
     expect(dialog).toHaveAttribute('aria-modal', 'true');
@@ -120,10 +122,10 @@ describe('F19 — mobile navigation drawer', () => {
   test('Escape closes the drawer and focus returns to the menu button', async () => {
     renderDashboard();
     await waitFor(() => expect(menuButton()).toBeInTheDocument());
-    await userEvent.click(menuButton());
+    await user.click(menuButton());
     expect(screen.getByRole('dialog')).toBeInTheDocument();
 
-    await userEvent.keyboard('{Escape}');
+    await user.keyboard('{Escape}');
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
     expect(document.activeElement).toBe(menuButton());
   });
@@ -132,10 +134,10 @@ describe('F19 — mobile navigation drawer', () => {
     // Without this the router swaps the page underneath and the menu stays open on top of it.
     renderDashboard();
     await waitFor(() => expect(menuButton()).toBeInTheDocument());
-    await userEvent.click(menuButton());
+    await user.click(menuButton());
 
     const drawer = screen.getByTestId('mobile-nav');
-    await userEvent.click(within(drawer).getByRole('link', { name: 'Products' }));
+    await user.click(within(drawer).getByRole('link', { name: 'Products' }));
 
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
   });
@@ -143,22 +145,22 @@ describe('F19 — mobile navigation drawer', () => {
   test('the backdrop closes the drawer', async () => {
     renderDashboard();
     await waitFor(() => expect(menuButton()).toBeInTheDocument());
-    await userEvent.click(menuButton());
+    await user.click(menuButton());
 
-    await userEvent.click(screen.getByTestId('mobile-nav-backdrop'));
+    await user.click(screen.getByTestId('mobile-nav-backdrop'));
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
   });
 
   test('Logout works from the drawer — in an installed PWA it is the only way out', async () => {
     renderDashboard();
     await waitFor(() => expect(menuButton()).toBeInTheDocument());
-    await userEvent.click(menuButton());
+    await user.click(menuButton());
 
     const drawer = screen.getByTestId('mobile-nav');
     // act-wrapped explicitly: the handler awaits the access-log POST and only then navigates,
     // so the router's state update lands after userEvent's own act scope has closed.
     await act(async () => {
-      await userEvent.click(within(drawer).getByRole('button', { name: 'Logout' }));
+      await user.click(within(drawer).getByRole('button', { name: 'Logout' }));
     });
 
     await waitFor(() => expect(localStorage.getItem('token')).toBeNull());
@@ -170,12 +172,12 @@ describe('F19 — mobile navigation drawer', () => {
   test('every link actually points where the nav data says — in BOTH renderings', async () => {
     // Without this the labels can be right and every href wrong: the code review proved
     // `to={item.to}` could be hard-coded to "/dashboard" with all tests still green.
-    const user = { id: 'NK', name: 'Nick', access: 'superadmin', roles: ['superadmin'] };
-    renderDashboard(user);
+    const nickUser = { id: 'NK', name: 'Nick', access: 'superadmin', roles: ['superadmin'] };
+    renderDashboard(nickUser);
     await waitFor(() => expect(menuButton()).toBeInTheDocument());
-    await userEvent.click(menuButton());
+    await user.click(menuButton());
 
-    const expected = buildNavItems({ user, roles: user.roles }).filter((i) => i.to);
+    const expected = buildNavItems({ user: nickUser, roles: nickUser.roles }).filter((i) => i.to);
     for (const testId of ['sidebar-nav', 'mobile-nav']) {
       const nav = screen.getByTestId(testId);
       for (const item of expected) {
@@ -190,7 +192,7 @@ describe('F19 — mobile navigation drawer', () => {
     // and every other fixture here is entitled via `access`, so nothing else would notice.
     renderDashboard({ id: 'AM', name: 'Amelia', access: 'staff', roles: ['staff', 'sales'] });
     await waitFor(() => expect(menuButton()).toBeInTheDocument());
-    await userEvent.click(menuButton());
+    await user.click(menuButton());
 
     const drawer = screen.getByTestId('mobile-nav');
     expect(within(drawer).getByRole('link', { name: 'Inbox' })).toBeInTheDocument();
@@ -203,9 +205,9 @@ describe('F19 — mobile navigation drawer', () => {
     // the affordance a rep will actually aim for.
     renderDashboard();
     await waitFor(() => expect(menuButton()).toBeInTheDocument());
-    await userEvent.click(menuButton());
+    await user.click(menuButton());
 
-    await userEvent.click(screen.getByRole('button', { name: /close menu/i }));
+    await user.click(screen.getByRole('button', { name: /close menu/i }));
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
   });
 
@@ -215,7 +217,7 @@ describe('F19 — mobile navigation drawer', () => {
     const media = installMatchMedia(false);
     renderDashboard();
     await waitFor(() => expect(menuButton()).toBeInTheDocument());
-    await userEvent.click(menuButton());
+    await user.click(menuButton());
     expect(screen.getByRole('dialog')).toBeInTheDocument();
 
     act(() => media.growPastBreakpoint());
@@ -230,14 +232,14 @@ describe('F19 — mobile navigation drawer', () => {
     expect(menuButton()).toHaveClass('md:hidden');
     expect(screen.getByTestId('sidebar-nav').closest('aside')).toHaveClass('hidden', 'md:block');
 
-    await userEvent.click(menuButton());
+    await user.click(menuButton());
     expect(screen.getByTestId('mobile-nav-backdrop').parentElement).toHaveClass('md:hidden');
   });
 
   test('a technician sees no Products / Customers / Waitlist in the drawer either', async () => {
     renderDashboard({ id: 'TE', name: 'Tech', access: 'technician', roles: ['technician'] });
     await waitFor(() => expect(menuButton()).toBeInTheDocument());
-    await userEvent.click(menuButton());
+    await user.click(menuButton());
 
     const drawer = screen.getByTestId('mobile-nav');
     for (const label of ['Products', 'Customers', 'Waitlist']) {

--- a/src/pages/__tests__/inboxCompose.test.js
+++ b/src/pages/__tests__/inboxCompose.test.js
@@ -127,22 +127,19 @@ const settle = async () => {
 /**
  * Open the modal and fill it in, leaving it one submit away from sending.
  *
- * ⚠️ `fireEvent.change`, NOT `userEvent.type`, and that is load-bearing rather than lazy.
- * user-event **v13** (what this repo pins) leaves an armed `capture: true, once: true` window
- * blur listener behind after typing. The next test's modal autofocuses its input on commit,
- * jsdom synchronously blurs the old one, that listener fires `fireEvent.change` — i.e. a second
- * RTL `act()` re-entered from inside the first one's flush — and React 19 (which pops the act
- * scope BEFORE flushing) reports "A component suspended inside an `act` scope".
+ * `fireEvent.change` rather than `user.type` for the two inputs, and that is a deliberate
+ * choice, not laziness: per-keystroke behaviour (the Start button enabling as you type) is
+ * covered by composeModal.test.js, which is the right place for it; nothing here needs
+ * keystroke fidelity, so the cheaper synchronous set is preferred.
  *
- * The warning itself is cosmetic. What is not cosmetic: React latches
- * `didWarnNoAwaitAct` on the first such warning, and that latch is SHARED with the genuine
- * "you called act(async) without await" warning — so from that point on, the rest of the file
- * loses React's un-awaited-act detection entirely. Verified by planting an un-awaited async act
- * and watching it go silent.
- *
- * Per-keystroke behaviour (the Start button enabling as you type) is covered by
- * composeModal.test.js, which is the right place for it; nothing here needs keystroke fidelity.
- * Delete this note when user-event moves to v14 — `userEvent.setup()` does not do this.
+ * (HISTORICAL — the ORIGINAL reason, now gone: under user-event **v13** typing left an armed
+ * `capture:true, once:true` window blur listener behind. The next test's modal autofocused its
+ * input on commit, jsdom synchronously blurred the old one, that listener re-fired inside the
+ * first flush, and React 19 reported "A component suspended inside an `act` scope" — a cosmetic
+ * warning that nonetheless burned React's shared one-shot `didWarnNoAwaitAct` latch and disabled
+ * un-awaited-act detection for the rest of the file. F32(b) moved the repo to user-event **v14**
+ * with `userEvent.setup()`, which does not install that listener, so the trap no longer exists —
+ * `user.type` here would now be safe. It stays as `fireEvent.change` purely for the reason above.)
  */
 async function openComposeAndFill({ to = '0400 999 888', body = 'Hi, this is Grays Fitness' } = {}) {
   await waitFor(() => expect(screen.getByRole('button', { name: /new conversation/i })).toBeInTheDocument());
@@ -156,7 +153,9 @@ async function openComposeAndFill({ to = '0400 999 888', body = 'Hi, this is Gra
 /** The modal's submit control. Anchored — `/send/i` would also match the reply composer. */
 const startButton = (dialog) => within(dialog).getByRole('button', { name: /start conversation/i });
 
+let user;
 beforeEach(() => {
+  user = userEvent.setup(); // v14: user.* is only used under real timers in this file
   localStorage.setItem('token', 'test-token');
   localStorage.setItem('user', JSON.stringify({ id: 'GS', name: 'Tester', roles: ['sales'] }));
   URL.createObjectURL = jest.fn(() => 'blob:mock-url');
@@ -178,7 +177,7 @@ describe('F28 — Inbox.submitCompose', () => {
     renderInbox();
     const dialog = await openComposeAndFill();
 
-    await userEvent.click(startButton(dialog));
+    await user.click(startButton(dialog));
 
     await waitFor(() => expect(composeCalls()).toHaveLength(1));
     const [, init] = composeCalls()[0];
@@ -190,7 +189,6 @@ describe('F28 — Inbox.submitCompose', () => {
       expect(global.fetch.mock.calls.some(([u]) => String(u).includes('resource=conversation&conversationId=conv-new'))).toBe(true),
     );
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
-
   });
 
   test('the list is refreshed even when the bucket does not change', async () => {
@@ -209,7 +207,7 @@ describe('F28 — Inbox.submitCompose', () => {
     const before = global.fetch.mock.calls.filter(([u]) => String(u).includes('resource=conversations')).length;
 
     const dialog = await openComposeAndFill();
-    await userEvent.click(startButton(dialog));
+    await user.click(startButton(dialog));
 
     await waitFor(() =>
       expect(global.fetch.mock.calls.filter(([u]) => String(u).includes('resource=conversations')).length)
@@ -230,7 +228,7 @@ describe('F28 — Inbox.submitCompose', () => {
     );
 
     const dialog = await openComposeAndFill();
-    await userEvent.click(startButton(dialog));
+    await user.click(startButton(dialog));
 
     await waitFor(() =>
       expect(global.fetch.mock.calls.some(([u]) => String(u).includes('resource=conversations&bucket=all'))).toBe(true),
@@ -247,7 +245,7 @@ describe('F28 — Inbox.submitCompose', () => {
     renderInbox();
     const dialog = await openComposeAndFill();
 
-    await userEvent.click(startButton(dialog));
+    await user.click(startButton(dialog));
 
     await waitFor(() => expect(toast.success).toHaveBeenCalledWith(composeResultMessage(result)));
     expect(toast.success).toHaveBeenCalledWith('Reopened and continued the existing conversation');
@@ -295,12 +293,12 @@ describe('F28 — Inbox.submitCompose', () => {
     global.fetch = mockFetch(() => json({ conversationId: 'conv-new', reused: false }));
     renderInbox();
     const first = await openComposeAndFill();
-    await userEvent.click(startButton(first));
+    await user.click(startButton(first));
     await waitFor(() => expect(composeCalls()).toHaveLength(1));
     await waitFor(() => expect(screen.queryByRole('dialog')).not.toBeInTheDocument());
 
     const second = await openComposeAndFill({ to: '0400 111 222', body: 'Second message' });
-    await userEvent.click(startButton(second));
+    await user.click(startButton(second));
     await waitFor(() => expect(composeCalls()).toHaveLength(2));
   });
 
@@ -312,7 +310,7 @@ describe('F28 — Inbox.submitCompose', () => {
     // act-wrapped: the 401 branch navigates after an await, so the router's state update lands
     // outside userEvent's own act scope.
     await act(async () => {
-      await userEvent.click(startButton(dialog));
+      await user.click(startButton(dialog));
     });
 
     await waitFor(() => expect(screen.getByText('LOGIN PAGE')).toBeInTheDocument());
@@ -336,7 +334,7 @@ describe('F28 — Inbox.submitCompose', () => {
     renderInbox();
     const dialog = await openComposeAndFill();
 
-    await userEvent.click(startButton(dialog));
+    await user.click(startButton(dialog));
 
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Could not start the conversation'));
     expect(screen.getByRole('dialog')).toBeInTheDocument();
@@ -347,7 +345,7 @@ describe('F28 — Inbox.submitCompose', () => {
     renderInbox();
     const dialog = await openComposeAndFill();
 
-    await userEvent.click(startButton(dialog));
+    await user.click(startButton(dialog));
 
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith('Podium rejected the recipient'));
     // The rep must be able to fix the recipient rather than retype the message.
@@ -363,7 +361,7 @@ describe('F28 — Inbox.submitCompose', () => {
     renderInbox();
     const dialog = await openComposeAndFill();
 
-    await userEvent.click(startButton(dialog));
+    await user.click(startButton(dialog));
 
     await waitFor(() => expect(toast.error).toHaveBeenCalled());
     const message = toast.error.mock.calls.at(-1)[0];
@@ -426,7 +424,7 @@ describe('F28 — Inbox.submitCompose', () => {
     renderInbox();
     const dialog = await openComposeAndFill();
 
-    await userEvent.click(startButton(dialog));
+    await user.click(startButton(dialog));
 
     await waitFor(() => expect(toast).toHaveBeenCalled());
     expect(toast.mock.calls.at(-1)[0]).toMatch(/find it under all conversations/i);

--- a/src/pages/__tests__/inboxComposerReset.test.js
+++ b/src/pages/__tests__/inboxComposerReset.test.js
@@ -105,7 +105,9 @@ const conversationButton = (name) => {
 };
 const composer = () => screen.getByPlaceholderText(/type a reply…|write an internal note…/i);
 
+let user;
 beforeEach(() => {
+  user = userEvent.setup(); // v14: real timers here, no advanceTimers needed
   localStorage.setItem('token', 'test-token');
   localStorage.setItem('user', JSON.stringify({ id: 'GS', name: 'Tester', roles: ['sales'] }));
   global.fetch = mockFetch();
@@ -128,13 +130,13 @@ describe('F27 — switching conversations resets the composer', () => {
 
     // Open Alice and start typing a reply we never send.
     await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
-    await userEvent.click(conversationButton('Alice Adams'));
+    await user.click(conversationButton('Alice Adams'));
     await waitFor(() => expect(composer()).toBeInTheDocument());
-    await userEvent.type(composer(), 'Alice, your rack is ready');
+    await user.type(composer(), 'Alice, your rack is ready');
     expect(composer()).toHaveValue('Alice, your rack is ready');
 
     // Switch to Bob by clicking the list — the path this feature fixes.
-    await userEvent.click(conversationButton('Bob Brown'));
+    await user.click(conversationButton('Bob Brown'));
     await waitFor(() => expect(screen.getByText(/Message in conv-bob/i)).toBeInTheDocument());
 
     // The draft addressed to Alice must NOT be sitting in Bob's composer.
@@ -145,14 +147,14 @@ describe('F27 — switching conversations resets the composer', () => {
     renderInbox();
 
     await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
-    await userEvent.click(conversationButton('Alice Adams'));
+    await user.click(conversationButton('Alice Adams'));
     await waitFor(() => expect(composer()).toBeInTheDocument());
 
     // Put the composer into internal-note mode on Alice's thread.
-    await userEvent.click(screen.getByRole('button', { name: /internal note/i }));
+    await user.click(screen.getByRole('button', { name: /internal note/i }));
     expect(screen.getByPlaceholderText(/write an internal note…/i)).toBeInTheDocument();
 
-    await userEvent.click(conversationButton('Bob Brown'));
+    await user.click(conversationButton('Bob Brown'));
     await waitFor(() => expect(screen.getByText(/Message in conv-bob/i)).toBeInTheDocument());
 
     // If note mode survived, the next Send posts a team-only note instead of replying to the
@@ -169,18 +171,18 @@ describe('F27 — switching conversations resets the composer', () => {
     renderInbox();
 
     await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
-    await userEvent.click(conversationButton('Alice Adams'));
+    await user.click(conversationButton('Alice Adams'));
     await waitFor(() => expect(composer()).toBeInTheDocument());
 
     const file = new File(['fake-image-bytes'], 'alice-quote.png', { type: 'image/png' });
     const input = document.querySelector('input[type="file"]');
     expect(input).toBeTruthy();
-    await userEvent.upload(input, file);
+    await user.upload(input, file);
     await waitFor(() =>
       expect(screen.getByRole('button', { name: /remove attachment/i })).toBeInTheDocument(),
     );
 
-    await userEvent.click(conversationButton('Bob Brown'));
+    await user.click(conversationButton('Bob Brown'));
     await waitFor(() => expect(screen.getByText(/Message in conv-bob/i)).toBeInTheDocument());
 
     expect(screen.queryByRole('button', { name: /remove attachment/i })).not.toBeInTheDocument();
@@ -192,14 +194,14 @@ describe('F27 — switching conversations resets the composer', () => {
     renderInbox();
 
     await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
-    await userEvent.click(conversationButton('Alice Adams'));
+    await user.click(conversationButton('Alice Adams'));
     await waitFor(() => expect(composer()).toBeInTheDocument());
-    await userEvent.type(composer(), 'Half a sentence');
+    await user.type(composer(), 'Half a sentence');
 
     // A rep re-clicking the thread they are already in (or a list re-render) must not be
     // treated as a switch — that would discard their work with no undo, which is the same
     // class of harm this feature exists to prevent, just pointed the other way.
-    await userEvent.click(conversationButton('Alice Adams'));
+    await user.click(conversationButton('Alice Adams'));
     await waitFor(() => expect(screen.getByText(/Message in conv-alice/i)).toBeInTheDocument());
 
     expect(composer()).toHaveValue('Half a sentence');

--- a/src/pages/__tests__/inboxFilterDraft.test.js
+++ b/src/pages/__tests__/inboxFilterDraft.test.js
@@ -93,16 +93,18 @@ async function openAliceAnd(type) {
     </MemoryRouter>,
   );
   await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
-  await userEvent.click(conversationButton('Alice Adams'));
+  await user.click(conversationButton('Alice Adams'));
   await waitFor(() => expect(composer()).toBeInTheDocument());
   // Wait for the thread itself, not just the composer: the message list arrives on its own
   // request, and a test that types immediately can outrun it (the typing was the only reason
   // the other tests happened to be safe).
   await waitFor(() => expect(screen.getByText('Is the rack still available?')).toBeInTheDocument());
-  if (type) await userEvent.type(composer(), type);
+  if (type) await user.type(composer(), type);
 }
 
+let user;
 beforeEach(() => {
+  user = userEvent.setup(); // v14: every user.* call here runs under real timers
   localStorage.setItem('token', 'test-token');
   localStorage.setItem('user', JSON.stringify({ id: 'GS', name: 'Tester', roles: ['sales'] }));
   global.fetch = mockFetch();
@@ -119,7 +121,7 @@ describe('F31 — a filter switch must not throw away work', () => {
   test('switching the status filter keeps a half-typed reply', async () => {
     await openAliceAnd('Yes — it is, I can hold it for you');
 
-    await userEvent.click(screen.getByRole('button', { name: 'Closed' }));
+    await user.click(screen.getByRole('button', { name: 'Closed' }));
 
     expect(composer()).toHaveValue('Yes — it is, I can hold it for you');
 
@@ -129,7 +131,7 @@ describe('F31 — a filter switch must not throw away work', () => {
   test('switching the bucket filter keeps a half-typed reply', async () => {
     await openAliceAnd('Yes — it is, I can hold it for you');
 
-    await userEvent.click(screen.getByRole('button', { name: 'All' }));
+    await user.click(screen.getByRole('button', { name: 'All' }));
 
     expect(composer()).toHaveValue('Yes — it is, I can hold it for you');
 
@@ -139,7 +141,7 @@ describe('F31 — a filter switch must not throw away work', () => {
   test('the thread stays open too — a draft with nowhere to send it is no better', async () => {
     await openAliceAnd('Half a sentence');
 
-    await userEvent.click(screen.getByRole('button', { name: 'All' }));
+    await user.click(screen.getByRole('button', { name: 'All' }));
 
     // The reading pane still shows Alice's thread, so Send still goes where the rep expects.
     expect(screen.getByText('Is the rack still available?')).toBeInTheDocument();
@@ -152,7 +154,7 @@ describe('F31 — a filter switch must not throw away work', () => {
     // on the filter.
     await openAliceAnd('Half a sentence');
 
-    await userEvent.click(screen.getByRole('button', { name: 'All' }));
+    await user.click(screen.getByRole('button', { name: 'All' }));
 
     await waitFor(() =>
       expect(global.fetch.mock.calls.some(([u]) => String(u).includes('resource=conversations&bucket=all'))).toBe(true),
@@ -165,7 +167,7 @@ describe('F31 — a filter switch must not throw away work', () => {
     await openAliceAnd(null);
     expect(screen.getByText('Is the rack still available?')).toBeInTheDocument();
 
-    await userEvent.click(screen.getByRole('button', { name: 'All' }));
+    await user.click(screen.getByRole('button', { name: 'All' }));
 
     await waitFor(() => expect(screen.queryByText('Is the rack still available?')).not.toBeInTheDocument());
   });
@@ -173,24 +175,33 @@ describe('F31 — a filter switch must not throw away work', () => {
   test('whitespace is not work — a composer holding only spaces still clears', async () => {
     await openAliceAnd('   ');
 
-    await userEvent.click(screen.getByRole('button', { name: 'All' }));
+    await user.click(screen.getByRole('button', { name: 'All' }));
 
     await waitFor(() => expect(screen.queryByText('Is the rack still available?')).not.toBeInTheDocument());
   });
 
   test('an attached file counts as work even with no text typed', async () => {
-    // A quote PDF or a photo of the machine is the expensive half of a message: the rep found
-    // the file, not just typed a line. Losing it silently is worse than losing the text.
+    // A clip of the machine running is the expensive half of a message: the rep found the file,
+    // not just typed a line. Losing it silently is worse than losing the text.
+    //
+    // A VIDEO, not the original PDF, and BOTH halves of that are load-bearing under user-event v14:
+    //   1. the composer input is `accept="image/*,video/*"`, and v14's `upload` ENFORCES `accept`
+    //      (v13 did not), so a PDF is filtered out and never reaches the change handler — exactly
+    //      as it would be for a real rep. The old `quote-20431.pdf` tested an upload the UI forbids.
+    //      (Whether a quote PDF SHOULD be attachable is a product question, tracked as F35.)
+    //   2. of the accepted kinds, an IMAGE chip shows its name only in `alt` on an <img>, not as
+    //      text, so `getByText(filename)` would miss it; a VIDEO chip renders the filename in a
+    //      <span>, which is what this assertion reads.
     await openAliceAnd(null);
-    const file = new File(['pdf-bytes'], 'quote-20431.pdf', { type: 'application/pdf' });
+    const file = new File(['mp4-bytes'], 'machine-20431.mp4', { type: 'video/mp4' });
     const input = document.querySelector('input[type="file"]');
     expect(input).toBeTruthy();
-    await userEvent.upload(input, file);
-    await waitFor(() => expect(screen.getByText(/quote-20431\.pdf/i)).toBeInTheDocument());
+    await user.upload(input, file);
+    await waitFor(() => expect(screen.getByText(/machine-20431\.mp4/i)).toBeInTheDocument());
 
-    await userEvent.click(screen.getByRole('button', { name: 'All' }));
+    await user.click(screen.getByRole('button', { name: 'All' }));
 
-    expect(screen.getByText(/quote-20431\.pdf/i)).toBeInTheDocument();
+    expect(screen.getByText(/machine-20431\.mp4/i)).toBeInTheDocument();
     expect(screen.getByText('Is the rack still available?')).toBeInTheDocument();
     await settle();
   });
@@ -198,7 +209,7 @@ describe('F31 — a filter switch must not throw away work', () => {
   test('re-clicking the filter you are already on changes nothing', async () => {
     await openAliceAnd('Still typing');
 
-    await userEvent.click(screen.getByRole('button', { name: 'Assigned to You' }));
+    await user.click(screen.getByRole('button', { name: 'Assigned to You' }));
 
     expect(composer()).toHaveValue('Still typing');
     expect(screen.getByText('Is the rack still available?')).toBeInTheDocument();
@@ -212,8 +223,8 @@ describe('F31 — a filter switch must not throw away work', () => {
     // whole suite green before this test.
     await openAliceAnd(null);
 
-    await userEvent.click(screen.getByRole('button', { name: 'Assigned to You' }));
-    await userEvent.click(screen.getByRole('button', { name: 'Open' }));
+    await user.click(screen.getByRole('button', { name: 'Assigned to You' }));
+    await user.click(screen.getByRole('button', { name: 'Open' }));
 
     expect(screen.getByText('Is the rack still available?')).toBeInTheDocument();
     await settle();
@@ -224,7 +235,7 @@ describe('F31 — a filter switch must not throw away work', () => {
     // `switchStatus` could bypass switchScope entirely and never clear anything.
     await openAliceAnd(null);
 
-    await userEvent.click(screen.getByRole('button', { name: 'Closed' }));
+    await user.click(screen.getByRole('button', { name: 'Closed' }));
 
     await waitFor(() => expect(screen.queryByText('Is the rack still available?')).not.toBeInTheDocument());
   });
@@ -236,12 +247,12 @@ describe('F31 — a filter switch must not throw away work', () => {
     // visible effect at all — and Send still targets the thread they are looking at.
     await openAliceAnd('Yes, I can hold it until Friday');
 
-    await userEvent.click(screen.getByRole('button', { name: 'Closed' }));
+    await user.click(screen.getByRole('button', { name: 'Closed' }));
 
     await waitFor(() => expect(screen.getByText(/isn’t in the current view/i)).toBeInTheDocument());
     expect(composer()).toHaveValue('Yes, I can hold it until Friday');
 
-    await userEvent.click(screen.getByRole('button', { name: /^send$/i }));
+    await user.click(screen.getByRole('button', { name: /^send$/i }));
     await waitFor(() => {
       const post = global.fetch.mock.calls.find(
         ([u, init]) => String(u).includes('resource=messages') && init?.method === 'POST',
@@ -260,7 +271,8 @@ describe('F31 — a filter switch must not throw away work', () => {
     // Fake timers from BEFORE the render, and fireEvent throughout: the 8s interval is created
     // during mount, so switching to fake timers afterwards leaves a real timer that
     // advanceTimersByTime can never fire — the first version of this test passed on that
-    // technicality and proved nothing. userEvent v13 needs real timers, hence fireEvent.
+    // technicality and proved nothing. fireEvent (not the v14 `user`) so the interaction itself
+    // doesn't schedule work on the fake clock this test is driving by hand.
     jest.useFakeTimers();
     try {
       render(
@@ -294,7 +306,7 @@ describe('F31 — a filter switch must not throw away work', () => {
     // Otherwise the banner could be permanently on and the test above would prove nothing.
     await openAliceAnd('Half a sentence');
 
-    await userEvent.click(screen.getByRole('button', { name: 'All' }));
+    await user.click(screen.getByRole('button', { name: 'All' }));
 
     expect(screen.queryByText(/isn’t in the current view/i)).not.toBeInTheDocument();
     await settle();

--- a/src/pages/__tests__/modalA11y.test.js
+++ b/src/pages/__tests__/modalA11y.test.js
@@ -43,6 +43,12 @@ function renderWithOpener(renderModal) {
 
 const opener = () => screen.getByRole('button', { name: /open it/i });
 
+// user-event v14: a fresh `setup()` per test. No fake timers in this file, so no advanceTimers.
+let user;
+beforeEach(() => {
+  user = userEvent.setup();
+});
+
 describe('true modals — dialog semantics', () => {
   const cases = [
     {
@@ -74,7 +80,7 @@ describe('true modals — dialog semantics', () => {
 
   test.each(cases)('$name exposes role="dialog" and aria-modal', async ({ render: r }) => {
     renderWithOpener(r);
-    await userEvent.click(opener());
+    await user.click(opener());
 
     const dialog = screen.getByRole('dialog');
     expect(dialog).toHaveAttribute('aria-modal', 'true');
@@ -84,7 +90,7 @@ describe('true modals — dialog semantics', () => {
   // idea which one opened.
   test.each(cases)('$name is named by its own heading', async ({ render: r, heading }) => {
     renderWithOpener(r);
-    await userEvent.click(opener());
+    await user.click(opener());
 
     const dialog = screen.getByRole('dialog');
     expect(within(dialog).getByRole('heading')).toHaveTextContent(heading);
@@ -93,7 +99,7 @@ describe('true modals — dialog semantics', () => {
 
   test.each(cases)('$name moves focus inside itself when it opens', async ({ render: r }) => {
     renderWithOpener(r);
-    await userEvent.click(opener());
+    await user.click(opener());
 
     const dialog = screen.getByRole('dialog');
     expect(dialog).toContainElement(document.activeElement);
@@ -108,7 +114,7 @@ describe('true modals — dialog semantics', () => {
     renderWithOpener((onClose) => (
       <ComposeModal sending={false} onSubmit={jest.fn()} onClose={onClose} />
     ));
-    await userEvent.click(opener());
+    await user.click(opener());
     expect(screen.getByLabelText(/^to$/i)).toHaveFocus();
   });
 
@@ -116,7 +122,7 @@ describe('true modals — dialog semantics', () => {
     renderWithOpener((onClose) => (
       <ProductLookupModal products={[]} loaded search="" setSearch={jest.fn()} onClose={onClose} />
     ));
-    await userEvent.click(opener());
+    await user.click(opener());
     expect(screen.getByLabelText(/search products/i)).toHaveFocus();
   });
 
@@ -125,30 +131,30 @@ describe('true modals — dialog semantics', () => {
     renderWithOpener((onClose) => (
       <WorkorderModal workorderId="WO123" detail={null} loading={false} onClose={onClose} />
     ));
-    await userEvent.click(opener());
+    await user.click(opener());
     expect(screen.getByRole('button', { name: /close/i })).toHaveFocus();
   });
 
   // The actual reported bug: Tab must not walk out into the inbox behind the modal.
   test.each(cases)('$name keeps Tab inside the dialog', async ({ render: r }) => {
     renderWithOpener(r);
-    await userEvent.click(opener());
+    await user.click(opener());
     const dialog = screen.getByRole('dialog');
 
     // Enough tabs to leave any of these dialogs several times over if the trap is absent.
     for (let i = 0; i < 12; i += 1) {
-      await userEvent.tab();
+      await user.tab();
       expect(dialog).toContainElement(document.activeElement);
     }
   });
 
   test.each(cases)('$name keeps Shift+Tab inside the dialog', async ({ render: r }) => {
     renderWithOpener(r);
-    await userEvent.click(opener());
+    await user.click(opener());
     const dialog = screen.getByRole('dialog');
 
     for (let i = 0; i < 12; i += 1) {
-      await userEvent.tab({ shift: true });
+      await user.tab({ shift: true });
       expect(dialog).toContainElement(document.activeElement);
     }
   });
@@ -157,8 +163,8 @@ describe('true modals — dialog semantics', () => {
   // losing their place in a long conversation list.
   test.each(cases)('$name returns focus to the opener when it closes', async ({ render: r }) => {
     renderWithOpener(r);
-    await userEvent.click(opener());
-    await userEvent.keyboard('{Escape}');
+    await user.click(opener());
+    await user.keyboard('{Escape}');
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     expect(opener()).toHaveFocus();
@@ -171,7 +177,7 @@ describe('true modals — Escape', () => {
   test('WorkorderModal closes on Escape', async () => {
     const onClose = jest.fn();
     render(<WorkorderModal workorderId="WO123" detail={null} loading={false} onClose={onClose} />);
-    await userEvent.keyboard('{Escape}');
+    await user.keyboard('{Escape}');
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
@@ -180,7 +186,7 @@ describe('true modals — Escape', () => {
     render(
       <ProductLookupModal products={[]} loaded search="" setSearch={jest.fn()} onClose={onClose} />,
     );
-    await userEvent.keyboard('{Escape}');
+    await user.keyboard('{Escape}');
     expect(onClose).toHaveBeenCalledTimes(1);
   });
 
@@ -189,7 +195,7 @@ describe('true modals — Escape', () => {
   test('ComposeModal still refuses Escape mid-send', async () => {
     const onClose = jest.fn();
     render(<ComposeModal sending onSubmit={jest.fn()} onClose={onClose} />);
-    await userEvent.keyboard('{Escape}');
+    await user.keyboard('{Escape}');
     expect(onClose).not.toHaveBeenCalled();
   });
 });
@@ -226,7 +232,7 @@ describe('assign picker — a popover, NOT a modal', () => {
     renderPicker();
     expect(trigger()).toHaveAttribute('aria-expanded', 'false');
 
-    await userEvent.click(trigger());
+    await user.click(trigger());
     expect(trigger()).toHaveAttribute('aria-expanded', 'true');
     // aria-controls must point at the popup that actually exists.
     const controls = trigger().getAttribute('aria-controls');
@@ -246,7 +252,7 @@ describe('assign picker — a popover, NOT a modal', () => {
 
   test('each rep toggle exposes its assigned state, and the tick is not announced', async () => {
     renderPicker({ assignees: [{ podiumUserId: 'p1', portalId: 'AA', name: 'Alex Rep' }] });
-    await userEvent.click(trigger());
+    await user.click(trigger());
 
     const alex = screen.getByRole('button', { name: /alex rep/i });
     const bo = screen.getByRole('button', { name: /bo rep/i });
@@ -261,10 +267,10 @@ describe('assign picker — a popover, NOT a modal', () => {
 
   test('Escape closes it and puts focus back on the trigger', async () => {
     renderPicker();
-    await userEvent.click(trigger());
+    await user.click(trigger());
     expect(screen.getByText('Alex Rep')).toBeInTheDocument();
 
-    await userEvent.keyboard('{Escape}');
+    await user.keyboard('{Escape}');
     expect(screen.queryByText('Alex Rep')).not.toBeInTheDocument();
     expect(trigger()).toHaveFocus();
   });
@@ -273,7 +279,7 @@ describe('assign picker — a popover, NOT a modal', () => {
   // fails — which is the intent.
   test('it is NOT announced as a modal dialog', async () => {
     renderPicker();
-    await userEvent.click(trigger());
+    await user.click(trigger());
 
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     expect(document.querySelector('[aria-modal="true"]')).toBeNull();


### PR DESCRIPTION
## What this is
The remaining half of **F32** (F32(a) shipped the inbox poll-401 redirect in PR #93). **Test-tooling only — no production `src/` file is changed.**

Bumps `@testing-library/user-event` `^13.5.0` → `^14.6.1` and migrates the 6 component test files that use it from the top-level `userEvent.click/type/keyboard(...)` API to the v14 `userEvent.setup()` instance pattern (module-scoped `let user;` assigned in `beforeEach`, then `user.click(...)`).

**Why it matters:** user-event v13 left an armed `capture:true, once:true` window-blur listener that burned React's shared one-shot `didWarnNoAwaitAct` latch, silently disabling un-awaited-`act` detection for the rest of a test file (documented in F28's `inboxCompose` note). v14's `setup()` does not install that listener, so **detection is restored repo-wide**.

## Two behaviour changes v14 forced (both faithful)
- **`inboxFilterDraft`** — the "an attachment counts as work" test uploaded a **PDF**, which v14's `upload` now filters against the composer input's `accept="image/*,video/*"` (v13 did not enforce `accept`, so the PDF was testing an upload the real UI forbids). Switched to a **`video/mp4`** — an accepted kind whose chip renders the filename as a `<span>` (an image renders it only in `<img alt>`, which `getByText` can't see). Whether a quote PDF *should* be attachable is a product question, tracked as **F35**.
- **`dashboardNav`** — a local `const user = {…}` mock was renamed to `nickUser` so it stops colliding with the new `user` setup() instance.

Stale "v13" notes in `inboxCompose`/`inboxFilterDraft` updated to describe v14.

## Fake-timer safety
`user.*` is only ever called under **real** timers: the two files that use `jest.useFakeTimers()` (`inboxCompose`, `inboxFilterDraft`) drive their single fake-timer test with `fireEvent`, not `userEvent`. So plain `userEvent.setup()` (no `advanceTimers`) is correct in all six files.

## Known / accepted (backlogged as F36 — out of scope for a dep bump)
v14's restored detection surfaces **2 pre-existing fire-and-forget `act` warnings** in `inboxCompose` (`inbox.js:699` navigate-on-401, `:735` `setComposeSending` finally). v13 had masked them; **the tests still pass**. Draining them fully needs a wider async-test refactor — filed as F36 rather than bundled into this dependency bump.

## Verification
- `CI=true npm run test:ci` → **8 suites / 99 tests pass**
- `npm run smoke` → **22/22 suites pass**
- `CI=true npm run build` → **green**
- No migration · no new serverless fn · no production code change.

## Code review
Reviewed via subagent over the diff: no material findings. Confirmed fake-timer safety, no stragglers, the `nickUser` rename is complete, the video-upload reasoning is correct (non-vacuous), comment accuracy, CI-on-Linux safety, and that **no new leak was introduced** (the 2 warnings are pre-existing).

## Reviewer checklist
- [x] Diff is test-only (`package.json`/lock + 6 `src/pages/__tests__/*.test.js`); no `src/pages/inbox.js` etc. touched
- [x] CI green (build + smoke + component tests) on the Preview
- [x] Comfortable accepting the 2 documented `inboxCompose` act-warnings until F36
- [x] Agree the PDF→video upload change reflects the real `accept="image/*,video/*"` constraint

🤖 Generated with [Claude Code](https://claude.com/claude-code)