### PR TITLE
F34 — route every inbox 401 through a shared session-expiry helper

### DIFF
--- a/src/pages/__tests__/inboxAuthExpiry.test.js
+++ b/src/pages/__tests__/inboxAuthExpiry.test.js
@@ -30,7 +30,7 @@
 //     These two live in adjacent lines and are easy to conflate.
 
 import React from 'react';
-import { act, render, screen, waitFor } from '@testing-library/react';
+import { act, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { MemoryRouter, Routes, Route } from 'react-router-dom';
 import toast from 'react-hot-toast';
 import Inbox from '../inbox';
@@ -287,5 +287,59 @@ describe('F32(a) — the inbox sends an expired session back to login', () => {
     expect(await screen.findByText('DASHBOARD')).toBeInTheDocument();
     expect(screen.queryByText('LOGIN PAGE')).not.toBeInTheDocument();
     await waitFor(() => expect(toast.error).toHaveBeenCalledWith('The Inbox is for sales users'));
+  });
+});
+
+describe('F34 — every 401 in the inbox ENDS the session, not just the poll', () => {
+  // F32(a) fixed the timer path and left a comment naming this: the twelve foreground guards (and
+  // the two loaders that swallowed a 401 into an empty list) still did a bare `navigate('/')`,
+  // leaving token/user/sessionExpiry behind. Back then re-mounted /inbox on a dead token, the
+  // client gate let it in, it 401'd, and it looped. F34 routes them all through endExpiredSession.
+
+  test('a foreground 401 CLEARS the stored session, not only redirects', async () => {
+    // Mutate the clear out of endExpiredSession and the token survives this test. (The silence of
+    // this path is already pinned by "the redirect is silent" above — the same first-load 401 now
+    // runs through endExpiredSession, so a toast added there would fail that test.)
+    global.fetch = mockFetch(() => json({ error: 'Unauthorized' }, 401));
+
+    renderInbox();
+    expect(await screen.findByText('LOGIN PAGE')).toBeInTheDocument();
+
+    expect(localStorage.getItem('token')).toBeNull();
+    expect(localStorage.getItem('user')).toBeNull();
+    expect(localStorage.getItem('sessionExpiry')).toBeNull();
+  });
+
+  test('a 401 from a click-triggered loader (assignees) ends the session too', async () => {
+    // The row's second half: loadAssignees / loadLeadHistory used to do `if (!res.ok) { setX([]);
+    // return; }`, so after expiry a rep clicking a conversation got silently-empty assignee chips
+    // on a dead token — no redirect. Both now carry the identical `endExpiredSession` guard; this
+    // drives it through loadAssignees. `assignCalls` proves the guard actually ran (not a vacuous
+    // pass where the click never reached the loader).
+    let assignCalls = 0;
+    global.fetch = jest.fn(async (url) => {
+      const u = String(url);
+      if (u.includes('/api/podium/assign')) { assignCalls += 1; return json({ error: 'Unauthorized' }, 401); }
+      if (u.includes('resource=conversations')) return json({ data: CONVERSATIONS, serverTime: '2026-07-21T10:00:00.000Z' });
+      if (u.includes('resource=messages')) return json({ data: [], serverTime: '2026-07-21T10:00:00.000Z' });
+      if (u.includes('resource=poll')) return json({ data: [], serverTime: '2026-07-21T10:00:00.000Z' });
+      if (u.includes('resource=templates')) return json({ data: [] });
+      if (u.includes('resource=reps')) return json({ reps: [] });
+      if (u.includes('/api/podium/status')) return json({ podiumUserId: 'pod-me' });
+      if (u.includes('/api/podium/contact')) return json({ customer: null, workorders: [] });
+      if (u.includes('/api/products')) return json([]);
+      return json({});
+    });
+
+    renderInbox();
+    // First load succeeds — the rep is on the inbox.
+    await waitFor(() => expect(screen.getByText('Alice Adams')).toBeInTheDocument());
+
+    // Opening the conversation triggers loadAssignees, which 401s.
+    fireEvent.click(screen.getByText('Alice Adams').closest('button'));
+
+    await waitFor(() => expect(screen.getByText('LOGIN PAGE')).toBeInTheDocument());
+    expect(assignCalls).toBeGreaterThanOrEqual(1);
+    expect(localStorage.getItem('token')).toBeNull();
   });
 });

--- a/src/pages/inbox.js
+++ b/src/pages/inbox.js
@@ -50,6 +50,7 @@ import BackButton from '../components/backbutton';
 import HomeButton from '../components/homebutton';
 import { authHeaders, getToken, getRoles, hasAnyRole } from '../utils/auth';
 import { parseMaybeJson } from '../utils/http';
+import { endExpiredSession } from '../utils/session';
 import { classifyComposeTarget, isValidComposeTarget, composeResultMessage } from '../utils/compose';
 
 const INBOX_ROLES = ['sales', 'superadmin'];
@@ -241,7 +242,7 @@ export default function Inbox() {
         `/api/podium/inbox?resource=conversations&bucket=${bucket}&status=${status}${q}&limit=30`,
         { headers: authHeaders() },
       );
-      if (res.status === 401) { navigate('/'); return; }
+      if (res.status === 401) { endExpiredSession(navigate); return; }
       if (res.status === 403) { toast.error('The Inbox is for sales users'); navigate('/dashboard'); return; }
       const data = await parseMaybeJson(res);
       if (!res.ok) {
@@ -268,7 +269,7 @@ export default function Inbox() {
         `/api/podium/inbox?resource=messages&conversationId=${encodeURIComponent(convId)}&limit=50`,
         { headers: authHeaders() },
       );
-      if (res.status === 401) { navigate('/'); return; }
+      if (res.status === 401) { endExpiredSession(navigate); return; }
       const data = await parseMaybeJson(res);
       if (!res.ok) {
         if (!silent) toast.error(data?.error || 'Could not load this conversation');
@@ -294,7 +295,7 @@ export default function Inbox() {
         `/api/podium/contact?conversationId=${encodeURIComponent(convId)}`,
         { headers: authHeaders() },
       );
-      if (res.status === 401) { navigate('/'); return; }
+      if (res.status === 401) { endExpiredSession(navigate); return; }
       const data = await parseMaybeJson(res);
       if (!res.ok) {
         // A missing customer is not an error (customer:null comes back 200); only surface
@@ -319,26 +320,32 @@ export default function Inbox() {
         `/api/podium/assign?conversationId=${encodeURIComponent(convId)}`,
         { headers: authHeaders() },
       );
+      // F34 — a 401 here is an expired session, not "no assignees". The old `!res.ok` swallow left
+      // the rep with silently-empty chips on a dead token; end the session like every other 401.
+      if (res.status === 401) { endExpiredSession(navigate); return; }
       if (!res.ok) { setAssignees([]); return; }
       const data = await parseMaybeJson(res);
       setAssignees(Array.isArray(data?.assignees) ? data.assignees : []);
     } catch {
       setAssignees([]);
     }
-  }, []);
+  }, [navigate]);
 
   // Funnel stage history (timeline) for the panel's lead — when/if there is one.
   const loadLeadHistory = useCallback(async (leadId) => {
     if (!leadId) { setLeadHistory([]); return; }
     try {
       const res = await fetch(`/api/leads/${leadId}/history`, { headers: authHeaders() });
+      // F34 — as loadAssignees: a 401 is an expired session, not "no history". Redirect, don't
+      // quietly show an empty funnel timeline on a dead token.
+      if (res.status === 401) { endExpiredSession(navigate); return; }
       if (!res.ok) { setLeadHistory([]); return; }
       const data = await parseMaybeJson(res);
       setLeadHistory(Array.isArray(data?.history) ? data.history : []);
     } catch {
       setLeadHistory([]);
     }
-  }, []);
+  }, [navigate]);
 
   // Open a conversation by uid even when it isn't in the current bucket/status list —
   // fetches it directly, then opens its thread + panel. Used by the funnel deep-link and
@@ -374,7 +381,7 @@ export default function Inbox() {
         `/api/podium/inbox?resource=conversation&conversationId=${encodeURIComponent(convId)}`,
         { headers: authHeaders() },
       );
-      if (res.status === 401) { navigate('/'); return false; }
+      if (res.status === 401) { endExpiredSession(navigate); return false; }
       const data = await parseMaybeJson(res);
       if (!res.ok || !data?.conversation) return false;
       setSelectedId(convId);
@@ -482,14 +489,12 @@ export default function Inbox() {
       //
       // It also ends the session properly rather than only navigating: leaving the token behind
       // means Back lands on /inbox, the client gate sees a token and lets it mount, it 401s and
-      // redirects again. `replace` keeps that loop out of history. (The other twelve sites still
-      // only navigate — swept up in F34, where a shared helper can also log it.)
+      // redirects again. `replace` keeps that loop out of history. F34 pulled that clear+replace
+      // into endExpiredSession() and gave the twelve foreground sites the same treatment; the
+      // toast stays HERE, because only the timer path is unattended.
       if (res.status === 401) {
-        localStorage.removeItem('token');
-        localStorage.removeItem('user');
-        localStorage.removeItem('sessionExpiry');
         toast.error('Your session expired — please sign in again');
-        navigate('/', { replace: true });
+        endExpiredSession(navigate);
         return;
       }
       if (!res.ok) return;
@@ -536,7 +541,7 @@ export default function Inbox() {
       const res = await fetch(`/api/workorder?id=${encodeURIComponent(workorderId)}`, {
         headers: authHeaders(),
       });
-      if (res.status === 401) { navigate('/'); return; }
+      if (res.status === 401) { endExpiredSession(navigate); return; }
       const data = await parseMaybeJson(res);
       if (!res.ok) {
         toast.error(data?.error || 'Could not load the workorder');
@@ -696,7 +701,7 @@ export default function Inbox() {
         body: JSON.stringify({ to, channel, body }),
         signal: abort.signal,
       });
-      if (res.status === 401) { navigate('/'); return; }
+      if (res.status === 401) { endExpiredSession(navigate); return; }
       const data = await parseMaybeJson(res);
       if (!res.ok) {
         toast.error(data?.error || 'Could not start the conversation');
@@ -750,7 +755,7 @@ export default function Inbox() {
         headers: authHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({ conversationId: selectedId, status: next }),
       });
-      if (res.status === 401) { navigate('/'); return; }
+      if (res.status === 401) { endExpiredSession(navigate); return; }
       const data = await parseMaybeJson(res);
       if (!res.ok) { toast.error(data?.error || 'Could not update the conversation'); return; }
       setSelectedConv((c) => (c ? { ...c, status: next } : c));
@@ -788,7 +793,7 @@ export default function Inbox() {
         headers: authHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify(payload),
       });
-      if (res.status === 401) { navigate('/'); return; }
+      if (res.status === 401) { endExpiredSession(navigate); return; }
       const data = await parseMaybeJson(res);
       if (!res.ok) { toast.error(data?.error || 'Could not add this conversation to the funnel'); return; }
       toast.success('Added to the funnel');
@@ -820,7 +825,7 @@ export default function Inbox() {
         headers: authHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({ conversationId: selectedId, userIds: nextIds }),
       });
-      if (res.status === 401) { navigate('/'); return; }
+      if (res.status === 401) { endExpiredSession(navigate); return; }
       const data = await parseMaybeJson(res);
       if (!res.ok) {
         toast.error(data?.error || 'Could not update the assignees');
@@ -862,7 +867,7 @@ export default function Inbox() {
         headers: authHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify(payload),
       });
-      if (res.status === 401) { navigate('/'); return; }
+      if (res.status === 401) { endExpiredSession(navigate); return; }
       const data = await parseMaybeJson(res);
       if (!res.ok) {
         toast.error(data?.error || 'Could not send the message');
@@ -903,7 +908,7 @@ export default function Inbox() {
         headers: authHeaders({ 'Content-Type': 'application/json' }),
         body: JSON.stringify({ conversationId: selectedId, body }),
       });
-      if (res.status === 401) { navigate('/'); return; }
+      if (res.status === 401) { endExpiredSession(navigate); return; }
       const data = await parseMaybeJson(res);
       if (!res.ok) {
         toast.error(data?.error || 'Could not add the internal note');
@@ -938,7 +943,7 @@ export default function Inbox() {
         body: JSON.stringify(payload),
       });
       const data = await parseMaybeJson(res);
-      if (res.status === 401) { navigate('/'); return; }
+      if (res.status === 401) { endExpiredSession(navigate); return; }
       if (res.status === 422 && data?.code === 'EMAIL_REQUIRED') {
         setNeedEmail(true);
         toast.error('An email is required to create this customer');

--- a/src/utils/session.js
+++ b/src/utils/session.js
@@ -1,0 +1,23 @@
+// F34 — one definition of "end a dead session", shared by every 401 handler in the inbox.
+//
+// Generalises the F32(a) pollNow fix to the twelve other 401 sites (and the two loaders that
+// swallowed a 401 into an empty list). A 401 in this app almost always means the 1h JWT expired
+// mid-shift, and the old handlers just did `navigate('/')`, which:
+//   - left `token`/`user`/`sessionExpiry` in localStorage, so Back re-mounted /inbox, the client
+//     gate saw a token and let it mount, it 401'd, and redirected again — a loop; and
+//   - used a push, keeping the dead route in history.
+//
+// This clears the SAME three keys App.js's own logout clears and navigates with REPLACE. It is
+// deliberately SILENT: F32(a) split the inbox's 401s into click-driven (the rep knows what they
+// did — no toast) and timer-driven (the poll fires unattended, so IT says why). Keeping the toast
+// out of this shared helper preserves that split and, as a bonus, means a mass-expiry (several
+// inbox fetches 401 at once) can't stack one toast per request. The poll keeps its own toast.
+//
+// No access-log POST on the way out: unlike App.js's authenticated logout, the token is already
+// dead here, so that write would itself 401. The redirect is the honest signal.
+export function endExpiredSession(navigate) {
+  localStorage.removeItem('token');
+  localStorage.removeItem('user');
+  localStorage.removeItem('sessionExpiry');
+  navigate('/', { replace: true });
+}


### PR DESCRIPTION
## Outcome (plain English)
When a rep's login expires while the Inbox is open, the page now ends the session **consistently** everywhere — clears the stored login and returns them to the sign-in screen — instead of only doing so on the background refresh. Before, most actions just bounced to login while leaving a dead login behind (so pressing Back looped straight back in), and two spots (assignee chips, funnel timeline) silently showed nothing at all.

## What this is (F34)
F32(a) fixed only the timer `pollNow` path and its own comment named this follow-up. The twelve **foreground** 401 handlers in `src/pages/inbox.js` did a bare `if (res.status === 401) { navigate('/'); return; }` — leaving `token`/`user`/`sessionExpiry` in localStorage (Back re-mounts `/inbox` on a dead token → loop) and using a push; and two loaders (`loadAssignees`, `loadLeadHistory`) swallowed a 401 into an empty list (no redirect).

**Change:** new `src/utils/session.js` `endExpiredSession(navigate)` = clear the same three keys App.js's logout clears + `navigate('/', { replace: true })`. All 12 foreground sites + the two loaders call it; `pollNow`'s inline block is DRY'd to call it too (**keeping its own `toast.error`**).

## Deliberately SILENT (respects F32(a)'s design)
F32(a) split the inbox's 401s: **click/foreground-driven ones are silent** (the rep knows what they did), **only the unattended timer poll toasts**. `endExpiredSession` therefore does **not** toast — that lives only at the `pollNow` call site. Bonus: a mass-expiry (several inbox fetches 401 at once) can't stack one toast per request. **No access-log POST** on the way out — unlike App.js's authenticated logout, the token is already dead, so that write would itself 401; the redirect is the honest signal.

## Tests
Extended `src/pages/__tests__/inboxAuthExpiry.test.js` (+2):
- a **foreground** 401 CLEARS the session (token/user/sessionExpiry all null), not just redirects — the core F34 change;
- a **click-triggered loader** (assignees) 401 ends the session too — `assignCalls >= 1` proves the click actually reached `loadAssignees` (non-vacuous).
- **Mutation-checked:** removing the clear from `endExpiredSession` turns both new tests (and the DRY'd poll test) red.

## Verification
- `CI=true npm run test:ci` → **8 suites / 101 tests pass** (99 + 2 new)
- `npm run smoke` → **22/22 suites**
- `CI=true npm run build` → **compiles clean** (no exhaustive-deps errors despite the new deps)
- No migration · no new serverless fn · off `main`, independent (no stack).

## Code review
Subagent review over the diff: **no material findings.** Confirmed hook deps are correct (the 11 sed'd sites already depended on `navigate`; the 2 loaders correctly gained `[navigate]`; 7 of the foreground handlers are plain async fns with no dep array), the silent-foreground split is preserved, `endExpiredSession` clears exactly App.js's three keys with `replace:true`, and the assignees test is non-vacuous.

## Known gap (named, not a blocker)
`loadLeadHistory` carries the **identical** guard as `loadAssignees` but has no direct test — covered by construction (same helper, same shape). A belt-and-braces lead-history 401 case could be added later; the reviewer did not block on it.

## Reviewer checklist
- [ ] `endExpiredSession` clears the same keys as App.js's logout, `replace:true`, no toast
- [ ] Foreground 401s stay silent; only `pollNow` toasts (F32(a)'s split intact)
- [ ] CI green (build + smoke + component tests) on the Preview
- [ ] Comfortable that the two loaders now redirect on 401 (a genuine auth failure) rather than silently emptying

🤖 Generated with [Claude Code](https://claude.com/claude-code)