### PR TITLE
Workshop scan-in: centred result modal (replaces bottom-right toasts)

### DIFF
--- a/src/components/ScanResultModal.js
+++ b/src/components/ScanResultModal.js
@@ -1,0 +1,114 @@
+import React, { useEffect, useRef, useState } from 'react';
+
+// Centred result modal for the G5 workshop scan-in (workorder detail page). Replaces the
+// bottom-right toasts that reported a scan's outcome: on a keyboard-wedge kiosk the tech is
+// looking at the machine and the scanner, not the corner of the screen, so the result now lands
+// dead-centre. It closes three ways — the Close button, the backdrop, or Escape — and otherwise
+// auto-closes on a visible countdown (default 5s), so an unattended scan station clears itself.
+//
+// Self-contained on purpose: it owns the countdown so the parent just toggles `result` on/off,
+// and so the timer/close behaviour is unit-testable without rendering the whole (fetch-heavy)
+// workorder page.
+//
+//   result: null  → renders nothing
+//   result: { kind: 'success' | 'warn' | 'error', title, detail? }
+
+const KIND = {
+  success: {
+    band: 'border-green-600',
+    badge: 'bg-green-100 text-green-800',
+    icon: '✓', // ✓
+  },
+  warn: {
+    band: 'border-amber-500',
+    badge: 'bg-amber-100 text-amber-900',
+    icon: '!', // !
+  },
+  error: {
+    band: 'border-red-600',
+    badge: 'bg-red-100 text-red-800',
+    icon: '✕', // ✕
+  },
+};
+
+export default function ScanResultModal({ result, onClose, autoCloseSeconds = 5 }) {
+  const [secondsLeft, setSecondsLeft] = useState(autoCloseSeconds);
+  // Keep the latest onClose without making it a timer dependency — a new function identity each
+  // render must not restart the countdown (that would keep an unattended modal open forever).
+  const onCloseRef = useRef(onClose);
+  onCloseRef.current = onClose;
+
+  // Restart + run the countdown whenever a NEW result is shown. Keyed on the result object so a
+  // second scan while the first modal is still up resets the clock rather than inheriting it.
+  useEffect(() => {
+    if (!result) return undefined;
+    setSecondsLeft(autoCloseSeconds);
+    const timer = setInterval(() => {
+      setSecondsLeft((s) => {
+        if (s <= 1) {
+          clearInterval(timer);
+          onCloseRef.current?.();
+          return 0;
+        }
+        return s - 1;
+      });
+    }, 1000);
+    return () => clearInterval(timer);
+  }, [result, autoCloseSeconds]);
+
+  // Escape closes it, like the portal's other dialogs. Bound on window (not the element) so it
+  // still fires after a click has blurred focus to <body> — the same convention the inbox modals use.
+  useEffect(() => {
+    if (!result) return undefined;
+    const onKey = (e) => { if (e.key === 'Escape') onCloseRef.current?.(); };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [result]);
+
+  if (!result) return null;
+  const style = KIND[result.kind] || KIND.error;
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="scan-result-title"
+      data-testid="scan-result-backdrop"
+      onClick={onClose}
+    >
+      <div
+        className={`w-full max-w-md rounded-2xl border-2 ${style.band} bg-white p-6 text-center shadow-2xl`}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div
+          className={`mx-auto mb-4 flex h-16 w-16 items-center justify-center rounded-full text-4xl font-bold leading-none ${style.badge}`}
+          aria-hidden="true"
+        >
+          {style.icon}
+        </div>
+        <h2 id="scan-result-title" className="text-xl font-bold text-gray-900 break-words">
+          {result.title}
+        </h2>
+        {result.detail ? (
+          <p className="mt-2 text-sm text-gray-600 break-words">{result.detail}</p>
+        ) : null}
+        {/* Deliberately NOT autoFocus'd. This is a keyboard-wedge kiosk: the scan <input> keeps
+            focus while the modal is up, so the tech can scan the next lot straight away (its result
+            simply replaces this one, resetting the countdown) instead of a scan landing on this
+            button and its trailing Enter closing the modal and losing that scan. Escape / backdrop /
+            the button / the countdown all still dismiss it. */}
+        <button
+          type="button"
+          onClick={onClose}
+          className="mt-6 w-full rounded-lg bg-gray-900 px-4 py-2.5 text-sm font-semibold text-white hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-400"
+        >
+          Close ({secondsLeft})
+        </button>
+        <p className="mt-2 text-xs text-gray-500">
+          Closes automatically in {secondsLeft}s
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/components/__tests__/scanResultModal.test.js
+++ b/src/components/__tests__/scanResultModal.test.js
@@ -1,0 +1,131 @@
+// Tests for the G5 workshop scan-in result modal (replaces the old bottom-right toasts).
+// The countdown is the interesting part: it must auto-close exactly once, and a re-render with a
+// fresh onClose must NOT restart it — an unattended kiosk station has to clear itself.
+
+import React from 'react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import ScanResultModal from '../ScanResultModal';
+
+const SUCCESS = { kind: 'success', title: 'L00007 → In Workshop', detail: 'TEC-RK3512' };
+
+describe('ScanResultModal', () => {
+  test('renders nothing when there is no result', () => {
+    const { container } = render(<ScanResultModal result={null} onClose={jest.fn()} />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  test('shows the title and detail centred, with a countdown', () => {
+    render(<ScanResultModal result={SUCCESS} onClose={jest.fn()} />);
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true');
+    expect(screen.getByText('L00007 → In Workshop')).toBeInTheDocument();
+    expect(screen.getByText('TEC-RK3512')).toBeInTheDocument();
+    // Both the button and the helper line carry the seconds, starting at the default 5.
+    expect(screen.getByRole('button', { name: /close \(5\)/i })).toBeInTheDocument();
+    expect(screen.getByText(/closes automatically in 5s/i)).toBeInTheDocument();
+  });
+
+  test('the Close button closes it', () => {
+    const onClose = jest.fn();
+    render(<ScanResultModal result={SUCCESS} onClose={onClose} />);
+    fireEvent.click(screen.getByRole('button', { name: /close/i }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('a backdrop click closes it, a click on the card does not', () => {
+    const onClose = jest.fn();
+    render(<ScanResultModal result={SUCCESS} onClose={onClose} />);
+    // Clicking the card (its heading) must not bubble to the backdrop handler.
+    fireEvent.click(screen.getByText('L00007 → In Workshop'));
+    expect(onClose).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByTestId('scan-result-backdrop'));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('Escape closes it', () => {
+    const onClose = jest.fn();
+    render(<ScanResultModal result={SUCCESS} onClose={onClose} />);
+    fireEvent.keyDown(window, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  test('it auto-closes exactly once after the countdown, ticking down on the way', () => {
+    jest.useFakeTimers();
+    try {
+      const onClose = jest.fn();
+      render(<ScanResultModal result={SUCCESS} onClose={onClose} autoCloseSeconds={3} />);
+      expect(screen.getByRole('button', { name: /close \(3\)/i })).toBeInTheDocument();
+
+      act(() => { jest.advanceTimersByTime(1000); });
+      expect(screen.getByRole('button', { name: /close \(2\)/i })).toBeInTheDocument();
+      expect(onClose).not.toHaveBeenCalled();
+
+      act(() => { jest.advanceTimersByTime(2000); });
+      expect(onClose).toHaveBeenCalledTimes(1);
+
+      // The interval must have been cleared — no second close as time keeps passing.
+      act(() => { jest.advanceTimersByTime(5000); });
+      expect(onClose).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('a re-render with a new onClose does NOT restart the countdown', () => {
+    jest.useFakeTimers();
+    try {
+      const first = jest.fn();
+      const second = jest.fn();
+      const { rerender } = render(
+        <ScanResultModal result={SUCCESS} onClose={first} autoCloseSeconds={3} />,
+      );
+      act(() => { jest.advanceTimersByTime(2000); }); // 2s elapsed on the ORIGINAL clock
+
+      // Same result object, different onClose (the parent re-rendered for an unrelated reason).
+      rerender(<ScanResultModal result={SUCCESS} onClose={second} autoCloseSeconds={3} />);
+
+      act(() => { jest.advanceTimersByTime(1000); }); // reaches 3s total — must fire, not reset
+      expect(second).toHaveBeenCalledTimes(1);
+      expect(first).not.toHaveBeenCalled();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('a NEW result restarts the countdown (the next scan replaces the modal)', () => {
+    // The kiosk flow that removing autoFocus enables: a tech scans again while the modal is up, so
+    // a fresh result object arrives and the 5s clock must start over rather than inherit the old one.
+    jest.useFakeTimers();
+    try {
+      const onClose = jest.fn();
+      const { rerender } = render(
+        <ScanResultModal result={{ kind: 'success', title: 'First' }} onClose={onClose} autoCloseSeconds={3} />,
+      );
+      act(() => { jest.advanceTimersByTime(2000); }); // 2s into the FIRST result
+
+      // A different result object (the next scan).
+      rerender(
+        <ScanResultModal result={{ kind: 'error', title: 'Second' }} onClose={onClose} autoCloseSeconds={3} />,
+      );
+      expect(screen.getByText('Second')).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /close \(3\)/i })).toBeInTheDocument(); // reset to 3
+
+      act(() => { jest.advanceTimersByTime(2000); }); // would have closed the FIRST (2+2>3); must not yet
+      expect(onClose).not.toHaveBeenCalled();
+      act(() => { jest.advanceTimersByTime(1000); }); // 3s into the SECOND
+      expect(onClose).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('renders the error and warn variants', () => {
+    const { rerender } = render(
+      <ScanResultModal result={{ kind: 'error', title: 'WRONG ITEM' }} onClose={jest.fn()} />,
+    );
+    expect(screen.getByText('WRONG ITEM')).toBeInTheDocument();
+    rerender(
+      <ScanResultModal result={{ kind: 'warn', title: 'Already on this workorder' }} onClose={jest.fn()} />,
+    );
+    expect(screen.getByText('Already on this workorder')).toBeInTheDocument();
+  });
+});

--- a/src/pages/delivery_operations/workorder/[id].js
+++ b/src/pages/delivery_operations/workorder/[id].js
@@ -3,6 +3,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { createPortal } from 'react-dom';
 import toast from 'react-hot-toast';
 import CreateCustomerModal from '../../../components/CreateCustomerModal';
+import ScanResultModal from '../../../components/ScanResultModal';
 
 /**
  * G3: per-unit lot slots for a workorder item.
@@ -328,6 +329,14 @@ export default function WorkorderDetailPage() {
   const [scanning, setScanning] = useState(false);
   const [scanValue, setScanValue] = useState('');
   const scanInputRef = useRef(null);
+  // G5: the scan result now lands in a centred modal (was a bottom-right toast). Success/warn/error.
+  const [scanResult, setScanResult] = useState(null); // { kind, title, detail }
+  const showScanResult = useCallback((kind, title, detail) => setScanResult({ kind, title, detail }), []);
+  const closeScanResult = useCallback(() => {
+    setScanResult(null);
+    // Hand focus back to the scan box so the next lot can be scanned without a click.
+    setTimeout(() => scanInputRef.current?.focus(), 0);
+  }, []);
 
   // user object
   const [user, setUser] = useState(null);
@@ -362,8 +371,8 @@ export default function WorkorderDetailPage() {
     if (!lotNum) return;
     try {
       const lr = await fetch(`/api/lots?lot_number=${encodeURIComponent(lotNum)}`);
-      if (lr.status === 404) { toast.error(`Lot ${lotNum} not found`); return; }
-      if (!lr.ok) { toast.error('Lookup failed'); return; }
+      if (lr.status === 404) { showScanResult('error', 'Lot not found', `No lot ${lotNum} in the system. Check the sticker and rescan.`); return; }
+      if (!lr.ok) { showScanResult('error', 'Lookup failed', 'Could not reach the lot service — try the scan again.'); return; }
       const lot = await lr.json();
 
       const matches = items.filter((it) =>
@@ -372,9 +381,10 @@ export default function WorkorderDetailPage() {
         String(it.product_id).toUpperCase() === String(lot.product_sku).toUpperCase());
 
       if (!matches.length) {
-        toast.error(
-          `WRONG ITEM — ${lot.lot_number} is ${lot.product_name || lot.product_sku} (${lot.product_sku}). This workorder has no line for that model.`,
-          { duration: 7000 }
+        showScanResult(
+          'error',
+          'WRONG ITEM',
+          `${lot.lot_number} is ${lot.product_name || lot.product_sku} (${lot.product_sku}). This workorder has no line for that model.`,
         );
         return;
       }
@@ -384,11 +394,11 @@ export default function WorkorderDetailPage() {
       for (const it of matches) {
         const sr = await fetch(`/api/lots?sku=${encodeURIComponent(it.product_id)}&workorder_items_id=${it.workorder_items_id}`);
         const sl = sr.ok ? await sr.json() : [];
-        if (lot.workorder_items_id === it.workorder_items_id) { toast(`${lot.lot_number} is already on this workorder.`); return; }
+        if (lot.workorder_items_id === it.workorder_items_id) { showScanResult('warn', 'Already scanned in', `${lot.lot_number} is already on this workorder.`); return; }
         const assignedCount = sl.filter((l) => l.workorder_items_id === it.workorder_items_id && (l.status === 'Assigned' || l.status === 'Sold')).length;
         if (assignedCount < Number(it.quantity || 0)) { target = it; break; }
       }
-      if (!target) { toast.error(`All ${lot.product_sku} units on this workorder already have a lot assigned.`); return; }
+      if (!target) { showScanResult('warn', 'No free slot', `All ${lot.product_sku} units on this workorder already have a lot assigned.`); return; }
 
       const ar = await fetch('/api/lots?action=assign', {
         method: 'POST',
@@ -396,7 +406,7 @@ export default function WorkorderDetailPage() {
         body: JSON.stringify({ lot_id: lot.lot_id, workorder_items_id: target.workorder_items_id }),
       });
       const ad = await ar.json().catch(() => ({}));
-      if (!ar.ok) { toast.error(ad?.error === 'WRONG_MODEL' ? 'Wrong model — lot does not match the item.' : (ad?.error || 'Assign failed')); return; }
+      if (!ar.ok) { showScanResult('error', 'Assign failed', ad?.error === 'WRONG_MODEL' ? 'Wrong model — lot does not match the item.' : (ad?.error || 'The lot could not be assigned.')); return; }
 
       // set the item In Workshop
       await fetch(`/api/workorder?id=${encodeURIComponent(id)}`, {
@@ -405,26 +415,33 @@ export default function WorkorderDetailPage() {
         body: JSON.stringify({ items: [{ workorder_items_id: target.workorder_items_id, status: 'In Workshop' }] }),
       });
 
-      toast.success(`${lot.lot_number} → In Workshop (${lot.product_sku})`, { duration: 5000 });
-
-      // capture the machine's serial (console/screen serial for cardio)
+      // Capture the machine's serial BEFORE the confirmation modal: window.prompt is blocking, so a
+      // modal shown first would only paint once the prompt is dismissed. The success modal is the
+      // final confirmation that the whole scan (assign → In Workshop → serial) is done.
       const sn = window.prompt(`Serial number for ${lot.lot_number} (console/screen serial for cardio — optional):`, lot.serial_number || '');
       if (sn !== null && sn.trim()) {
-        await fetch('/api/lots?action=serial', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', 'x-user-id': userId || '' },
-          body: JSON.stringify({ lot_id: lot.lot_id, serial_number: sn.trim() }),
-        });
+        // The serial is optional AND the lot is already assigned + In Workshop at this point, so a
+        // failure here must NOT turn a successful scan into a red "Scan failed". Swallow it; the
+        // serial can be re-entered from the lot slot below.
+        try {
+          await fetch('/api/lots?action=serial', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json', 'x-user-id': userId || '' },
+            body: JSON.stringify({ lot_id: lot.lot_id, serial_number: sn.trim() }),
+          });
+        } catch { /* serial is optional; the scan itself already succeeded */ }
       }
 
       await reloadWO();
+      showScanResult('success', `${lot.lot_number} → In Workshop`, `${lot.product_name || lot.product_sku} (${lot.product_sku})`);
     } catch {
-      toast.error('Scan failed');
+      showScanResult('error', 'Scan failed', 'Something went wrong during the scan — please try again.');
     } finally {
       setScanValue('');
-      scanInputRef.current?.focus();
+      // Focus returns to the scan box when the result modal closes (see closeScanResult), so the
+      // tech reads the outcome before the next scan can land.
     }
-  }, [items, id, userId, reloadWO]);
+  }, [items, id, userId, reloadWO, showScanResult]);
 
   useEffect(() => {
     try {
@@ -1324,6 +1341,9 @@ export default function WorkorderDetailPage() {
             }}
           />
         )}
+
+        {/* G5: centred scan-in result (success / warn / error), manual close or 5s auto-close. */}
+        <ScanResultModal result={scanResult} onClose={closeScanResult} />
       </main>
     </div>
   );


### PR DESCRIPTION
## What you asked for
On the **workshop scan-in** (lot allocation on the workorder detail page), the success/failed scan result now shows a **centred modal** instead of a bottom-right toast. It closes **manually** (Close button, click outside, or Escape) or **auto-closes on a 5-second countdown**.

## How it behaves
- **Success** (green ✓): "L##### → In Workshop" + the model/SKU.
- **Wrong item / lookup fail / assign fail / unexpected error** (red ✕): the WRONG-ITEM alarm and other failures.
- **Already scanned in / no free slot** (amber !): mild "nothing to do" cases.
- Big centred card, colour-coded, with the message and a `Close (5)` button ticking down; auto-dismisses at 0.

## Notes on the flow (unchanged except the result display)
- The assign → In Workshop → serial-prompt → reload logic is untouched. The success modal now appears **after** the serial prompt (a native `window.prompt` blocks the screen, so showing the modal first would only paint once you answered the prompt) — so the modal is the final "all done" confirmation.
- The optional serial step is now wrapped so that if *only* the serial save fails, you still get the green success (the lot was already assigned + set In Workshop) instead of a misleading red "Scan failed".
- **Kiosk detail:** the Close button is deliberately not auto-focused, so the scan box keeps focus — you can scan the next lot straight away and its result just replaces the modal (no lost scans). Escape / clicking outside / the button / the countdown all still dismiss it.

## Scope
- Only the **workshop lot-allocation scan-in** (workorder detail page). The public `/scan` price lookup and the page's other toasts (Save, etc.) are untouched.

## Files
- New `src/components/ScanResultModal.js` (self-contained, owns its countdown)
- `src/pages/delivery_operations/workorder/[id].js` (the 8 scan-result toasts → the modal)
- New `src/components/__tests__/scanResultModal.test.js` (9 tests)

## Verification
- `CI=true npm run test:ci` → **9 suites / 110 tests pass** (incl. the 5s auto-close firing exactly once, and consecutive-scan countdown reset)
- `npm run smoke` → **22/22** · `CI=true npm run build` → **compiles clean**
- Code review (subagent): no blocking findings; the 3 items it raised (autoFocus/lost-scan, serial-failure masking success, a noisy countdown live-region) are all fixed in this PR. All modal colours meet WCAG AA.
- No migration, no new serverless function.

## One thing to eyeball
Whether the **5s auto-close** feels right for the workshop, or you'd prefer it stay open until dismissed / a different duration — easy to change (`autoCloseSeconds`). Also happy to tune the wording or colours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)