### PR TITLE
F37: drain handleLogout navigate inside act (test-only, dashboardNav 0 act-warnings)

### DIFF
--- a/src/pages/__tests__/dashboardNav.test.js
+++ b/src/pages/__tests__/dashboardNav.test.js
@@ -15,7 +15,7 @@
 //  - the technician restriction survives the refactor (characterization, not new behaviour).
 
 import React from 'react';
-import { act, render, screen, within, waitFor } from '@testing-library/react';
+import { act, render, screen, within, waitFor, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { MemoryRouter } from 'react-router-dom';
 import Dashboard from '../dashboard';
@@ -157,10 +157,20 @@ describe('F19 — mobile navigation drawer', () => {
     await user.click(menuButton());
 
     const drawer = screen.getByTestId('mobile-nav');
-    // act-wrapped explicitly: the handler awaits the access-log POST and only then navigates,
-    // so the router's state update lands after userEvent's own act scope has closed.
+    // handleLogout awaits the access-log POST and only THEN calls navigate('/') (dashboard.js:116),
+    // fire-and-forget from onClick — so that react-router state update (scheduled via
+    // startTransition) lands after the click's own act scope has closed and warns. Drive it with
+    // fireEvent.click inside one act and drain the tail so the navigate is wrapped. NOT
+    // user.click-in-act: user-event v14's own async act saves/restores IS_REACT_ACT_ENVIRONMENT
+    // and flips it false mid-drain, re-arming the very warning (F36 saw a naive version go 2->156).
+    // fireEvent has no such machinery. Same fix as F36's submitAndSettle.
+    const logoutBtn = within(drawer).getByRole('button', { name: 'Logout' });
     await act(async () => {
-      await user.click(within(drawer).getByRole('button', { name: 'Logout' }));
+      fireEvent.click(logoutBtn);
+      for (let i = 0; i < 4; i += 1) {
+        // eslint-disable-next-line no-await-in-loop
+        await new Promise((r) => setTimeout(r, 0));
+      }
     });
 
     await waitFor(() => expect(localStorage.getItem('token')).toBeNull());


### PR DESCRIPTION
## F37 — drain `handleLogout`'s post-`await` navigate inside `act` (test-only)

**Test-only.** One file: `src/pages/__tests__/dashboardNav.test.js` (+14/−4). No product/app code touched → built bundle byte-identical to `main`.

### The problem
`dashboardNav.test.js`'s Logout test already wrapped the click in `act`, but `handleLogout` (`dashboard.js:101`) **awaits** the `/api/access-log` POST and only *then* calls `navigate('/')` (`dashboard.js:116`), fire-and-forget from the button's `onClick`. That react-router state update (scheduled via `startTransition`) lands *after* the click's act scope closes, so React 19's un-awaited-`act` detector — the one **F32(b) restored repo-wide** — warned once. The 13 tests passed; it was 1 console warning.

This is the same class F36 fixed in `inboxCompose.test.js`; found while running F36's full suite. F36 stayed in scope (Golden Rule 7) and backlogged this as its own row.

### The fix
Drive the Logout click with **`fireEvent.click`** inside one `act(async …)` scope, then drain the tail (`await setTimeout(0)` ×4) so `handleLogout`'s `fetch → navigate` is wrapped. `fireEvent` has no act machinery of its own, so the outer `act` stays in force.

**Why not `user.click`:** `user.click`-inside-act-plus-drain re-arms the warning — user-event v14's `setup()` runs its own async act that flips `IS_REACT_ACT_ENVIRONMENT` false mid-drain (F36 reproduced a naive version going **2→156**). Only the one warning-emitting test changed; the other 12 tests still use `user.click` and are untouched.

### Verification (evidence)
- `dashboardNav.test.js`: **13/13 pass, 0 act-warnings** (was 1).
- Full component suite: **9 suites / 110 tests pass**. The 2 warnings that remain on this branch both trace to `inbox.js:704/740` — i.e. inboxCompose, **fixed on the parallel F36 branch #99**. **Zero remaining warnings come from `dashboard`.** Once #99 + this merge, the whole suite is 0 warnings.
- `npm run smoke`: **22/22**. `CI=true npm run build`: **Compiled successfully.**
- **Mutation-checked:** dropping `removeItem('token')` from `handleLogout` still **fails** the Logout test → the `fireEvent.click` trigger drives `handleLogout` identically; detection intact.
- Diff = one test file; bundle unchanged.

### Relationship to #99 (F36)
Independent branches, both off `main`, **not stacked** (different files, no overlap). Merge order doesn't matter. Together they take the whole `test:ci` run to **0 act-warnings**.

### Reviewer checklist
- [ ] `fireEvent.click(logoutBtn)` invokes `handleLogout` the same way `user.click` did
- [ ] Logout assertions (token/user cleared, access-log POST) still non-vacuous
- [ ] Only the Logout test changed; other tests' `user.click` untouched; `user`/`userEvent` still used
- [ ] Test-only; nothing outside `dashboardNav.test.js` changed

Code review (subagent, pre-PR): **Ready to merge: Yes** — no Critical/Important; one informational Minor (the navigate is exercised, not asserted — pre-existing, unchanged by this fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
